### PR TITLE
Add note about generator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Install the ember-cli addon in your ember-cli project:
 
 ```
 $ npm install --save-dev ember-paper
+$ ember g ember-paper
 ```
 
 All the components and styles are ready to use in your application templates.


### PR DESCRIPTION
It's a small change, but I didn't immediately realize that you also have to run `ember g ember-paper` after installing the add-on in order to add the proper dependencies to the `bower.json` file.  I just added a note to the Readme so others don't get tripped up on this as well.
