### PR TITLE
Adding missing classname that makes the navigation work

### DIFF
--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,6 +5,7 @@
       <nav class="sidenav-nav">
         <ul>
         <li>{{#link-to "index"}}Introduction{{/link-to}}</li>
+          <li>{{#link-to "navigation"}}Navigation{{/link-to}}</li>
           <li>{{#link-to "typography"}}Typography{{/link-to}}</li>
           <li>{{#link-to "lists"}}Lists{{/link-to}}</li>
           <li>{{#link-to "button"}}Button{{/link-to}}</li>
@@ -12,7 +13,6 @@
           <li>{{#link-to "toggle"}}Toggle{{/link-to}}</li>
           <li>{{#link-to "radio"}}Radio{{/link-to}}</li>
           <li>{{#link-to "textfield"}}Text Field{{/link-to}}</li>
-          <li>{{#link-to "navigation"}}Navigation{{/link-to}}</li>
         </ul>
       </nav>
     {{/paper-content}}

--- a/tests/dummy/app/templates/navigation.hbs
+++ b/tests/dummy/app/templates/navigation.hbs
@@ -18,7 +18,7 @@
       &lt;/nav&gt;
 
     \{{/paper-drawer}}
-    \{{#paper-content}}
+    \{{#paper-content  classNames="sidenav-static-content"}}
 
       \{{outlet}}
 


### PR DESCRIPTION
When I tried this out the main content was ending up behind the sidebar navigation, I looked at your dummy app and it was using this classname so i added it to the documentation 