### PR TITLE
Use ember-cli install command for addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ This project aims to bring Google's new [Material Design](https://www.google.com
 Install the ember-cli addon in your ember-cli project:
 
 ```
-$ npm install --save-dev ember-paper
-$ ember g ember-paper
+$ ember install:addon ember-paper
 ```
 
 All the components and styles are ready to use in your application templates.


### PR DESCRIPTION
This will `npm install --save-dev` the addon, and then also run the generator with the same name. Crazy!

This was [introduced in ember-cli 0.1.5](https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#015)