### PR TITLE
Applying autoprefixer. Fixes miguelcobain/ember-paper#31.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/miguelcobain/ember-paper/issues"
   },
   "devDependencies": {
+    "autoprefixer": "^5.1.0",
     "body-parser": "^1.2.0",
     "broccoli-asset-rev": "0.3.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -7,7 +7,10 @@ npm install bower
 ./node_modules/.bin/bower install
 
 echo "installing node-sass"
-npm install node-sass
+npm install node-sass autoprefixer
 
 echo "compiling CSS to /vendor with node-sass"
 ./node_modules/.bin/node-sass ./addon/styles/scss/main.scss ./vendor/ember-paper.css
+
+echo "applying autoprefixer to /vendor/ember-paper.css"
+./node_modules/.bin/autoprefixer -b 'last 2 versions' ./vendor/ember-paper.css


### PR DESCRIPTION
One of the main issues causing safari to not function properly was the lack of using the `-webkit` vendor prefix for flexbox layouts. Adding autoprefixer and setting it to use the last 2 browsers should ensure that `ember-paper` works properly in Safari as well as IE 10.

See miguelcobain/ember-paper#31 for additional details / discussion.