### PR TITLE
Autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/miguelcobain/ember-paper/issues"
   },
   "devDependencies": {
+    "autoprefixer": "^5.1.0"
     "body-parser": "^1.2.0",
     "broccoli-asset-rev": "0.3.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/miguelcobain/ember-paper/issues"
   },
   "devDependencies": {
-    "autoprefixer": "^5.1.0"
+    "autoprefixer": "^5.1.0",
     "body-parser": "^1.2.0",
     "broccoli-asset-rev": "0.3.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -11,3 +11,6 @@ npm install node-sass
 
 echo "compiling CSS to /vendor with node-sass"
 ./node_modules/.bin/node-sass ./addon/styles/scss/main.scss ./vendor/ember-paper.css
+
+echo "autoprefixing"
+./node_modules/autoprefixer/autoprefixer -b "last 2 versions" ./vendor/ember-paper.css

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -12,5 +12,8 @@ npm install node-sass
 echo "compiling CSS to /vendor with node-sass"
 ./node_modules/.bin/node-sass ./addon/styles/scss/main.scss ./vendor/ember-paper.css
 
+echo "install autoprefixer"
+npm install autoprefixer
+
 echo "autoprefixing"
 ./node_modules/autoprefixer/autoprefixer -b "last 2 versions" ./vendor/ember-paper.css


### PR DESCRIPTION
Most if not all issues on Safari are because vendor prefixes. Autoprefixer takes care of that in the best way possible