### PR TITLE
Add feature for Icon sizes and spinners using classes

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -4,7 +4,37 @@ export default Ember.Component.extend({
   tagName: 'md-icon',
   classNames: ['paper-icon'],
   classNameBindings: ['iconClass'],
+
+  spin: false,
+  reverseSpin: false,
+
   iconClass: function(){
-    return 'ic-'+this.get('icon');
+    var iconClasses = 'ic-'+this.get('icon');
+
+    if(this.get('spin')){
+      iconClasses +=' md-spin';
+    } else if (this.get('reverseSpin')){
+      iconClasses +=' md-spin-reverse';
+    }
+
+    switch(this.get('size')){
+      case 'lg':
+        iconClasses += ' md-lg';
+        break;
+      case 2:
+        iconClasses += ' md-2x';
+        break;
+      case 3:
+        iconClasses += ' md-3x';
+        break;
+      case 4:
+        iconClasses += ' md-4x';
+        break;
+      case 5:
+        iconClasses += ' md-5x';
+        break;
+    }
+
+    return iconClasses;
   }.property('icon')
 });

--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -3,38 +3,35 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'md-icon',
   classNames: ['paper-icon'],
-  classNameBindings: ['iconClass'],
+  classNameBindings: ['iconClass', 'sizeClass', 'spinClass'],
 
   spin: false,
   reverseSpin: false,
 
   iconClass: function(){
-    var iconClasses = 'ic-'+this.get('icon');
+    return 'ic-'+this.get('icon');
+  }.property('icon'),
 
+  spinClass: function(){
     if(this.get('spin')){
-      iconClasses +=' md-spin';
+      return ' md-spin';
     } else if (this.get('reverseSpin')){
-      iconClasses +=' md-spin-reverse';
+      return ' md-spin-reverse';
     }
+  }.property('spin','reverseSpin'),
 
+  sizeClass : function(){
     switch(this.get('size')){
       case 'lg':
-        iconClasses += ' md-lg';
-        break;
+        return ' md-lg';
       case 2:
-        iconClasses += ' md-2x';
-        break;
+        return ' md-2x';
       case 3:
-        iconClasses += ' md-3x';
-        break;
+        return ' md-3x';
       case 4:
-        iconClasses += ' md-4x';
-        break;
+        return ' md-4x';
       case 5:
-        iconClasses += ' md-5x';
-        break;
+        return ' md-5x';
     }
-
-    return iconClasses;
-  }.property('icon')
+  }.property('size')
 });

--- a/addon/styles/scss/paper-icon.scss
+++ b/addon/styles/scss/paper-icon.scss
@@ -8,3 +8,71 @@ md-icon {
   width: 3 * $baseline-grid;
   line-height: 3 * $baseline-grid;
 }
+
+// Icon sizes
+.md-lg {
+  font-size: 1.5em;
+  line-height: .5em;
+  vertical-align: -35%;
+}
+.md-2x { font-size: 2em; }
+.md-3x { font-size: 3em; }
+.md-4x { font-size: 4em; }
+.md-5x { font-size: 5em; }
+
+// Icon spinners
+.md-spin {
+  -webkit-animation: md-spin 1.5s infinite linear;
+  animation: md-spin 1.5s infinite linear;
+}
+
+.md-spin-reverse {
+  -webkit-animation: md-spin-reverse 1.5s infinite linear;
+  animation: md-spin-reverse 1.5s infinite linear;
+}
+
+// Spin
+@-webkit-keyframes md-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+@keyframes md-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+// Spin Reverse
+@-webkit-keyframes md-spin-reverse {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(-359deg);
+    transform: rotate(-359deg);
+  }
+}
+
+@keyframes md-spin-reverse {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(-359deg);
+    transform: rotate(-359deg);
+  }
+}

--- a/tests/dummy/app/templates/icons.hbs
+++ b/tests/dummy/app/templates/icons.hbs
@@ -16,17 +16,18 @@
   </pre>
   <h4>Larger Icons</h4>
     <pre>
-      \{{paper-icon icon="check" class="md-lg"}}
-      \{{paper-icon icon="check" class="md-2x"}}
-      \{{paper-icon icon="check" class="md-3x"}}
-      \{{paper-icon icon="check" class="md-4x"}}
-      \{{paper-icon icon="check" class="md-5x"}}
+      \{{paper-icon icon="check" size="lg"}
+      \{{paper-icon icon="check" size=2}}
+      \{{paper-icon icon="check" size=3}}
+      \{{paper-icon icon="check" size=4}}
+      \{{paper-icon icon="check" size=5}}
     </pre>
   <h4>Spinners</h4>
     <pre>
-      \{{paper-icon icon="rotate-right" class="md-spin"}}
-      \{{paper-icon icon="rotate-left" class="md-spin-reverse"}}
+      \{{paper-icon icon="rotate-right" spin=true}}
+      \{{paper-icon icon="rotate-left" reverseSpin=true}}
     </pre>
+    {{paper-icon icon="rotate-right" spin=true size="lg"}}
   <div>
     {{#each icon in icons}}
       <div class="icon-tile">

--- a/tests/dummy/app/templates/icons.hbs
+++ b/tests/dummy/app/templates/icons.hbs
@@ -27,7 +27,6 @@
       \{{paper-icon icon="rotate-right" spin=true}}
       \{{paper-icon icon="rotate-left" reverseSpin=true}}
     </pre>
-    {{paper-icon icon="rotate-right" spin=true size="lg"}}
   <div>
     {{#each icon in icons}}
       <div class="icon-tile">

--- a/tests/dummy/app/templates/icons.hbs
+++ b/tests/dummy/app/templates/icons.hbs
@@ -16,7 +16,7 @@
   </pre>
   <h4>Larger Icons</h4>
     <pre>
-      \{{paper-icon icon="check" size="lg"}
+      \{{paper-icon icon="check" size="lg"}}
       \{{paper-icon icon="check" size=2}}
       \{{paper-icon icon="check" size=3}}
       \{{paper-icon icon="check" size=4}}

--- a/tests/dummy/app/templates/icons.hbs
+++ b/tests/dummy/app/templates/icons.hbs
@@ -10,10 +10,23 @@
 {{#paper-content classNames="md-padding icon-demo"}}
 
   <h3>Template</h3>
+  <h4>Basic Icons</h4>
   <pre>
     \{{paper-icon icon="check"}}
   </pre>
-
+  <h4>Larger Icons</h4>
+    <pre>
+      \{{paper-icon icon="check" class="md-lg"}}
+      \{{paper-icon icon="check" class="md-2x"}}
+      \{{paper-icon icon="check" class="md-3x"}}
+      \{{paper-icon icon="check" class="md-4x"}}
+      \{{paper-icon icon="check" class="md-5x"}}
+    </pre>
+  <h4>Spinners</h4>
+    <pre>
+      \{{paper-icon icon="rotate-right" class="md-spin"}}
+      \{{paper-icon icon="rotate-left" class="md-spin-reverse"}}
+    </pre>
   <div>
     {{#each icon in icons}}
       <div class="icon-tile">


### PR DESCRIPTION
using classes to create multiple sizes of `paper-icon` and css animation for spinners.

the added classes are:
`.md-lg`  for large icon (1.5em)
`.md-2x` 2x default icon
`.md-3x` 3x default icon
`.md-4x` 4x default icon
`.md-5x` 5x default icon

`.md-spin` clockwise spinner
`.md-spin-reverse` anti-clockwise spinner