### PR TITLE
paper-text should pass the 'required' attribute

### DIFF
--- a/app/templates/components/paper-text.hbs
+++ b/app/templates/components/paper-text.hbs
@@ -1,2 +1,2 @@
 <label {{bind-attr for=inputElementId}}>{{label}}</label>
-{{input id=inputElementId type=type value=value focus-in="focusIn" focus-out="focusOut" disabled=disabled}}
+{{input id=inputElementId type=type value=value focus-in="focusIn" focus-out="focusOut" disabled=disabled required=required}}


### PR DESCRIPTION
paper-text does not currently pass the `required` attribute to the underlying `input`. This PR resolves that by simply passing that attribute to the `input`.