### PR TITLE
Add animations for showing and hiding backdrop

### DIFF
--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -2,9 +2,18 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'md-backdrop',
-  classNames:['paper-backdrop','md-opaque','md-default-theme'],
+  classNames: ['paper-backdrop','md-opaque','md-default-theme'],
 
-  click: function(evt){
+  willDestroyElement: function() {
+    var clone  = this.$().clone();
+    this.$().parent().append(clone);
+    clone.addClass('ng-leave');
+    Ember.run.later((function() {
+      clone.remove();
+    }), 200);
+  },
+
+  click: function(evt) {
     Ember.$(evt.target).trigger('collapseSidenav');
     return false;
   }

--- a/app/styles/paper-backdrop.scss
+++ b/app/styles/paper-backdrop.scss
@@ -1,8 +1,18 @@
+@mixin animateFadeIn() {
+  -webkit-animation: $swift-ease-out-timing-function mdBackdropFadeIn 0.5s both;
+  animation: $swift-ease-out-timing-function mdBackdropFadeIn 0.5s both;
+}
+
+@mixin animateFadeOut() {
+  -webkit-animation: $swift-ease-in-timing-function mdBackdropFadeOut 0.2s both;
+  animation: $swift-ease-in-timing-function mdBackdropFadeOut 0.2s both;
+}
+
 md-nav-container {
 
   &.sidenav-expanded {
     md-backdrop {
-      animation: $swift-ease-out-timing-function mdBackdropFadeIn 0.5s both;
+      @include animateFadeIn();
     }
   }
 }
@@ -29,11 +39,14 @@ md-backdrop {
   right: 0;
   bottom: 0;
 
+  @include animateFadeIn();
+
   &.ng-enter {
-    animation: $swift-ease-out-timing-function mdBackdropFadeIn 0.5s both;
+    @include animateFadeIn();
   }
+
   &.ng-leave {
-    animation: $swift-ease-in-timing-function mdBackdropFadeOut 0.2s both;
+    @include animateFadeOut();
   }
 }
 
@@ -41,7 +54,16 @@ md-backdrop {
   from { opacity: 0; }
   to { opacity: 1; }
 }
+@-webkit-keyframes mdBackdropFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @keyframes mdBackdropFadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@-webkit-keyframes mdBackdropFadeOut {
   from { opacity: 1; }
   to { opacity: 0; }
 }


### PR DESCRIPTION
Adds the fade-in and fade-out animations to the `paper-backdrop` component.  From what I can tell, it matches the way that it works on the Material Angular website.

Closes #53.