### PR TITLE
Add app.scss to Blueprint

### DIFF
--- a/blueprints/ember-paper/files/app/styles/app.scss
+++ b/blueprints/ember-paper/files/app/styles/app.scss
@@ -1,0 +1,1 @@
+ @import 'ember-paper';


### PR DESCRIPTION
`ember g ember-paper` will attempt to install `app.scss`.  If it's already there, the developer will at least see that they should add `@import 'ember-paper';`