### PR TITLE
Fix dismissing sidenav on iOS

### DIFF
--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -4,8 +4,14 @@ export default Ember.Component.extend({
   tagName: 'md-backdrop',
   classNames: ['paper-backdrop', 'md-opaque', 'md-default-theme'],
 
-  click: function(evt) {
-    Ember.$(evt.target).trigger('collapseSidenav');
+  subscribeToTouchEvents: function() {
+    var hammer = new Hammer(this.get('element'));
+    hammer.on('tap', Ember.run.bind(this, this._collapseSidenav));
+  }.on('didInsertElement'),
+
+  _collapseSidenav: function(event) {
+    Ember.$(event.target).trigger('collapseSidenav');
     return false;
   }
+
 });

--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -4,14 +4,24 @@ export default Ember.Component.extend({
   tagName: 'md-backdrop',
   classNames: ['paper-backdrop', 'md-opaque', 'md-default-theme'],
 
+  // Hammer event handler for tapping backdrop
+  tapHammer: null,
+
   subscribeToTouchEvents: function() {
     var hammer = new Hammer(this.get('element'));
     hammer.on('tap', Ember.run.bind(this, this._collapseSidenav));
+    this.set('tapHammer', hammer);
   }.on('didInsertElement'),
 
   _collapseSidenav: function(event) {
     Ember.$(event.target).trigger('collapseSidenav');
     return false;
-  }
+  },
+
+  onWillDestroyElement: function() {
+    if (Ember.isPresent(this.get('tapHammer'))) {
+      this.get('tapHammer').destroy();
+    }
+  }.on('willDestroyElement')
 
 });


### PR DESCRIPTION
For some reason the default `click` event wasn't working on iOS.  I swapped it
out with a Hammer event and it seems to work much better now.

Closes #57 