### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-sass": "^0.4.0",
     "broccoli-static-compiler": "^0.1.4",
-    "ember-cli": "0.2.0-beta.1",
+    "ember-cli": "^0.2.0",
     "ember-cli-app-version": "0.3.1",
     "ember-cli-babel": "^4.0.0",
     "ember-cli-dependency-checker": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -22,21 +22,21 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-autoprefixer": "^2.1.0",
-    "broccoli-merge-trees": "^0.1.4",
+    "broccoli-merge-trees": "~0.2.1",
     "broccoli-sass": "^0.4.0",
-    "broccoli-static-compiler": "^0.1.4",
+    "broccoli-static-compiler": "~0.2.1",
     "ember-cli": "^0.2.0",
-    "ember-cli-app-version": "0.3.1",
+    "ember-cli-app-version": "~0.3.2",
     "ember-cli-babel": "^4.0.0",
-    "ember-cli-dependency-checker": "0.0.7",
+    "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.8",
+    "ember-cli-qunit": "~0.3.9",
     "ember-cli-uglify": "1.0.1",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "~5.0.1"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Updated a bunch of the dependencies, including the Ember CLI.  I checked what was needed to update for addons in version `0.2.0`, and nothing used in Ember Paper requires a changed.