### PR TITLE
Expose changed action on paper-radio

### DIFF
--- a/addon/components/paper-radio.js
+++ b/addon/components/paper-radio.js
@@ -19,6 +19,7 @@ export default BaseFocusable.extend(RippleMixin, {
   checkedDidChange: Ember.observer('checked', function() {
     if (this.get('checked')) {
       this.set('selected', this.get('value'));
+      this.sendAction('changed', this.get('value'));
     }
   }),
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -13,6 +13,9 @@ export default Ember.Route.extend({
     },
     willTransition: function() {
       this.controller.set('drawerOpen',false);
+    },
+    alertValue: function(value) {
+      alert('You clicked Radio button: ' + value);
     }
   }
 });

--- a/tests/dummy/app/templates/radio.hbs
+++ b/tests/dummy/app/templates/radio.hbs
@@ -18,11 +18,12 @@
   <ul class="paper-list-inline">
     <li>{{#paper-radio value="1" selected=selectedValue}}Radio button 1{{/paper-radio}}</li>
     <li>{{#paper-radio value="2" selected=selectedValue}}Radio button 2{{/paper-radio}}</li>
-    <li>{{#paper-radio value="3" selected=selectedValue}}Radio button 3{{/paper-radio}}</li>
+    <li>{{#paper-radio value="3" selected=selectedValue changed="alertValue"}}Radio button 3{{/paper-radio}}</li>
   </ul>
   <p>Selected value: {{selectedValue}}</p>
 
   <p>{{paper-radio toggle=true label="Blockless version"}}</p>
+
   <h3>Template</h3>
   <pre>
     \{{#paper-radio}}A radio button\{{/paper-radio}}
@@ -31,7 +32,7 @@
 
     \{{#paper-radio value="1" selected=selectedValue}}Radio button 1\{{/paper-radio}}
     \{{#paper-radio value="2" selected=selectedValue}}Radio button 2\{{/paper-radio}}
-    \{{#paper-radio value="3" selected=selectedValue}}Radio button 3\{{/paper-radio}}
+    \{{#paper-radio value="3" selected=selectedValue changed="alertValue"}}Radio button 3\{{/paper-radio}}
 
     \{{paper-radio toggle=true label="Blockless version"}}
   </pre>

--- a/tests/unit/components/paper-radio-test.js
+++ b/tests/unit/components/paper-radio-test.js
@@ -32,6 +32,36 @@ test('should set checked css class', function(assert) {
   assert.ok(this.$().hasClass('md-checked'));
 });
 
+test('it updates when clicked, and triggers the `changed` action', function(assert) {
+  var changedActionCallCount = 0;
+  var component = this.subject({
+    value: 'component-value',
+    selected: 'initial-selected-value',
+    changed: 'changed',
+    targetObject: Ember.Controller.createWithMixins({
+      actions: {
+        changed: function() {
+          changedActionCallCount++;
+        }
+      }
+    })
+  });
+  this.append();
+
+  assert.equal(changedActionCallCount, 0);
+  assert.equal(component.$().hasClass('md-checked'), false);
+
+  Ember.run(function() {
+    component.$().trigger('click');
+  });
+
+  assert.equal(component.$().hasClass('md-checked'), true, 'updates element property');
+  assert.equal(component.get('checked'), true, 'updates component property');
+  assert.equal(component.get('selected'), 'component-value', 'updates selected ');
+
+  assert.equal(changedActionCallCount, 1);
+});
+
 test('it is possible to check and set selected property to value', function(assert) {
   var component = this.subject();
 


### PR DESCRIPTION
Allows you to call an action after a user interaction causes your `selected` value to update. Preferred over adding observers on the `selected` value.

Same as: https://github.com/yapplabs/ember-radio-button