### PR TITLE
Expose actions on checkbox, switch, and text field

### DIFF
--- a/addon/components/paper-checkbox.js
+++ b/addon/components/paper-checkbox.js
@@ -26,6 +26,7 @@ export default BaseFocusable.extend(RippleMixin, {
   click: function() {
     if (!this.get('disabled')) {
       this.toggleProperty('checked');
+      this.sendAction('changed', this.get('checked'));
     }
   },
 

--- a/addon/components/paper-switch.js
+++ b/addon/components/paper-switch.js
@@ -80,6 +80,7 @@ export default BaseFocusable.extend(RippleMixin, {
          (this.get('checked') && this.get('dragAmount') < 0.5) ||
          (!this.get('checked') && this.get('dragAmount') > 0.5)) {
       this.toggleProperty('checked');
+      this.sendAction('changed', this.get('checked'));
     }
 
     // Cleanup

--- a/addon/components/paper-text.js
+++ b/addon/components/paper-text.js
@@ -13,9 +13,11 @@ export default BaseFocusable.extend({
   actions: {
     focusIn: function() {
       this.set('focus',true);
+      this.sendAction('focusIn', this.get('value'));
     },
     focusOut: function() {
       this.set('focus',false);
+      this.sendAction('focusOut', this.get('value'));
     }
   }
 });

--- a/tests/dummy/app/controllers/textfield.js
+++ b/tests/dummy/app/controllers/textfield.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  isEditingText: null,
+
+  actions: {
+    notifyEditingText: function(/* value */) {
+      this.set('isEditingText', true);
+    },
+    alertFocusedOut: function(value) {
+      this.set('isEditingText', false);
+      alert('Focused out. Value: ' + value);
+    }
+  }
+});

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -14,8 +14,11 @@ export default Ember.Route.extend({
     willTransition: function() {
       this.controller.set('drawerOpen',false);
     },
-    alertValue: function(value) {
+    alertRadioValue: function(value) {
       alert('You clicked Radio button: ' + value);
+    },
+    alertCheckboxValue: function(value) {
+      if(value) { alert('The box is checked!'); }
     }
   }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -19,6 +19,9 @@ export default Ember.Route.extend({
     },
     alertCheckboxValue: function(value) {
       if(value) { alert('The box is checked!'); }
+    },
+    alertSwitchValue: function(value) {
+      alert('Switch is toggling to: ' + value);
     }
   }
 });

--- a/tests/dummy/app/templates/checkbox.hbs
+++ b/tests/dummy/app/templates/checkbox.hbs
@@ -8,7 +8,7 @@
 {{/paper-toolbar}}
 {{#paper-content classNames="md-padding"}}
 <div class="doc-content">
-  {{#paper-checkbox checked=value1}}A checkbox: {{value1}}{{/paper-checkbox}}
+  {{#paper-checkbox checked=value1 changed="alertCheckboxValue"}}A checkbox: {{value1}}{{/paper-checkbox}}
   {{#paper-checkbox checked=value2}}A checkbox: {{#if value2}}yep{{else}}nope{{/if}}{{/paper-checkbox}}
   {{#paper-checkbox disabled=true}}Checkbox (disabled){{/paper-checkbox}}
   {{#paper-checkbox disabled=true checked=true}}Checkbox (disabled and checked){{/paper-checkbox}}
@@ -18,7 +18,7 @@
 
   <h3>Template</h3>
   <pre>
-    \{{#paper-checkbox checked=value1}}A checkbox: \{{value1}}\{{/paper-checkbox}}
+    \{{#paper-checkbox checked=value1 changed="alertCheckboxValue"}}A checkbox: \{{value1}}\{{/paper-checkbox}}
     \{{#paper-checkbox checked=value2}}A checkbox: \{{#if value2}}yep\{{else}}nope\{{/if}}\{{/paper-checkbox}}
     \{{#paper-checkbox disabled=true}}Checkbox (disabled)\{{/paper-checkbox}}
     \{{#paper-checkbox disabled=true checked=true}}Checkbox (disabled and checked)\{{/paper-checkbox}}

--- a/tests/dummy/app/templates/radio.hbs
+++ b/tests/dummy/app/templates/radio.hbs
@@ -18,7 +18,7 @@
   <ul class="paper-list-inline">
     <li>{{#paper-radio value="1" selected=selectedValue}}Radio button 1{{/paper-radio}}</li>
     <li>{{#paper-radio value="2" selected=selectedValue}}Radio button 2{{/paper-radio}}</li>
-    <li>{{#paper-radio value="3" selected=selectedValue changed="alertValue"}}Radio button 3{{/paper-radio}}</li>
+    <li>{{#paper-radio value="3" selected=selectedValue changed="alertRadioValue"}}Radio button 3{{/paper-radio}}</li>
   </ul>
   <p>Selected value: {{selectedValue}}</p>
 
@@ -32,7 +32,7 @@
 
     \{{#paper-radio value="1" selected=selectedValue}}Radio button 1\{{/paper-radio}}
     \{{#paper-radio value="2" selected=selectedValue}}Radio button 2\{{/paper-radio}}
-    \{{#paper-radio value="3" selected=selectedValue changed="alertValue"}}Radio button 3\{{/paper-radio}}
+    \{{#paper-radio value="3" selected=selectedValue changed="alertRadioValue"}}Radio button 3\{{/paper-radio}}
 
     \{{paper-radio toggle=true label="Blockless version"}}
   </pre>

--- a/tests/dummy/app/templates/switch.hbs
+++ b/tests/dummy/app/templates/switch.hbs
@@ -11,7 +11,7 @@
 <div class="doc-content">
   <p>
     {{#paper-switch checked=booleanProp1}} {{booleanProp1}} {{/paper-switch}}
-    {{#paper-switch checked=booleanProp2}} {{booleanProp2}} {{/paper-switch}}
+    {{#paper-switch checked=booleanProp2 changed="alertSwitchValue"}} {{booleanProp2}} {{/paper-switch}}
     {{#paper-switch disabled=true}} Disabled switch {{/paper-switch}}
     {{#paper-switch noink=true}} Noink switch {{/paper-switch}}
 
@@ -21,7 +21,7 @@
   <pre>
     \{{#paper-switch checked=booleanProp1}} \{{booleanProp1}} \{{/paper-switch}}
 
-    \{{#paper-switch checked=booleanProp2}} \{{booleanProp2}} \{{/paper-switch}}
+    \{{#paper-switch checked=booleanProp2 changed="alertSwitchValue"}} \{{booleanProp2}} \{{/paper-switch}}
 
     \{{#paper-switch disabled=true}} Disabled switch \{{/paper-switch}}
 

--- a/tests/dummy/app/templates/textfield.hbs
+++ b/tests/dummy/app/templates/textfield.hbs
@@ -11,16 +11,17 @@
 <div class="doc-content">
   <ul class="paper-list-inline">
     <li>{{paper-text label="Name" value=name}}</li>
-    <li>{{paper-text label="E-mail" type="email" value=email}}</li>
+    <li>{{paper-text label="E-mail" type="email" value=email focusIn="notifyEditingText" focusOut="alertFocusedOut"}}</li>
     <li>{{paper-text label="Password" type="password"}}</li>
     <li>{{paper-text label="E-mail" type="email" disabled=true}}</li>
   </ul>
   <p>Name: {{name}}</p>
   <p>Email: {{email}}</p>
+  {{#if isEditingText}}<p>Currently editing text</p>{{/if}}
   <h3>Template</h3>
   <pre>
     \{{paper-text label="Name" value=name}}
-    \{{paper-text label="E-mail" type="email" value=email}}
+    \{{paper-text label="E-mail" type="email" value=email focusIn="notifyEditingText" focusOut="alertFocusedOut"}}
     \{{paper-text label="Password" type="password"}}
     \{{paper-text label="E-mail" type="email" disabled=true}}
   </pre>

--- a/tests/unit/components/paper-checkbox-test.js
+++ b/tests/unit/components/paper-checkbox-test.js
@@ -39,6 +39,34 @@ test('element should be focusable if not disabled', function(assert) {
   assert.equal(this.$().attr('tabindex'), '0');
 });
 
+test('it updates when clicked, and triggers the `changed` action', function(assert) {
+  var changedActionCallCount = 0;
+  var component = this.subject({
+    checked: false,
+    changed: 'changed',
+    targetObject: Ember.Controller.createWithMixins({
+      actions: {
+        changed: function() {
+          changedActionCallCount++;
+        }
+      }
+    })
+  });
+  this.append();
+
+  assert.equal(changedActionCallCount, 0);
+  assert.equal(component.$().hasClass('md-checked'), false);
+
+  Ember.run(function() {
+    component.$().trigger('click');
+  });
+
+  assert.equal(component.$().hasClass('md-checked'), true, 'updates element property');
+  assert.equal(component.get('checked'), true, 'updates component property');
+
+  assert.equal(changedActionCallCount, 1);
+});
+
 test('element should not be focusable if disabled', function(assert) {
   var component = this.subject();
   this.render();

--- a/tests/unit/components/paper-switch-test.js
+++ b/tests/unit/components/paper-switch-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import {
   moduleForComponent,
   test
@@ -18,4 +19,15 @@ test('it renders', function(assert) {
   // appends the component to the page
   this.render();
   assert.equal(component._state, 'inDOM');
+});
+
+test('should set checked css class', function(assert) {
+  var component = this.subject();
+  this.render();
+
+  Ember.run(function() {
+    component.set('checked', true);
+  });
+
+  assert.ok(this.$().hasClass('md-checked'));
 });


### PR DESCRIPTION
Similar to: https://github.com/miguelcobain/ember-paper/pull/77

Adding tests for switch and text-field are non-trivial because of the way their events are triggered. Could use a hand.