### PR TITLE
Add paper-slider component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist
 /tmp
+.idea
 
 # dependencies
 /node_modules

--- a/addon/components/paper-slider.js
+++ b/addon/components/paper-slider.js
@@ -10,6 +10,7 @@ var MdSlider = BaseFocusable.extend(EventsMixin, {
 
   attributeBindings: ['min', 'max', 'step', 'md-discrete', 'flex', 'tabindex'],
 
+  classNames: ['md-default-theme'],
   classNameBindings: ['isMinimum:md-min', 'active', 'dragging'],
 
   min: 0,

--- a/addon/components/paper-slider.js
+++ b/addon/components/paper-slider.js
@@ -1,0 +1,146 @@
+import Ember from 'ember';
+import EventsMixin from '../mixins/events-mixin';
+import BaseFocusable from './base-focusable';
+
+var MdSlider = BaseFocusable.extend(EventsMixin, {
+
+  constants: Ember.inject.service('constants'),
+
+  tagName: 'md-slider',
+
+  attributeBindings: ['min', 'max', 'step', 'md-discrete', 'flex', 'tabindex'],
+
+  classNameBindings: ['isMinimum:md-min', 'active', 'dragging'],
+
+  min: 0,
+  max: 100,
+  step: 1,
+  tabindex: 0,
+
+  trackContainer: Ember.computed(function() {
+    var element = this.$()[0];
+
+    return this.$(element.querySelector('.md-track-container'));
+  }),
+
+  activeTrackStyle: Ember.computed('percent', function() {
+    var percent = this.get('percent') || 0;
+    return Ember.String.htmlSafe("width: " + (percent * 100) + "%");
+  }),
+
+  thumbContainerStyle: Ember.computed('percent', function() {
+    var percent = this.get('percent') || 0;
+    return Ember.String.htmlSafe("left: " + (percent * 100) + "%");
+  }),
+
+  isMinimum: Ember.computed('percent', 'min', function() {
+    return this.get('percent') === this.get('min');
+  }),
+
+  percent: Ember.computed('value', 'min', 'max', function() {
+    var min = parseInt(this.get('min'), 10);
+    var max = parseInt(this.get('max'), 10);
+
+    return (this.get('value') - min) / (max - min);
+  }),
+
+  positionToPercent(x) {
+    return Math.max(0, Math.min(1, (x - this.get('sliderDimensions.left')) / this.get('sliderDimensions.width')));
+  },
+
+  percentToValue(x) {
+    var min = parseInt(this.get('min'), 10);
+    var max = parseInt(this.get('max'), 10);
+    return (min + x * (max - min));
+  },
+
+  minMaxValidator(value) {
+    var min = parseInt(this.get('min'), 10);
+    var max = parseInt(this.get('max'), 10);
+    return Math.max(min, Math.min(max, value));
+  },
+
+  stepValidator(value) {
+    var step = parseInt(this.get('step'), 10);
+    return Math.round(value / step) * step;
+  },
+
+  active: false,
+  dragging: false,
+
+  sliderDimensions: Ember.computed(function() {
+    return this.get('trackContainer')[0].getBoundingClientRect();
+  }),
+
+  setValueFromEvent(event) {
+    //var exactVal = this.percentToValue(this.positionToPercent(event.deltaX || event.clientX));
+    var exactVal = this.percentToValue(this.positionToPercent(event.clientX || event.originalEvent.touches[0].clientX));
+    var closestVal = this.minMaxValidator(this.stepValidator(exactVal));
+
+    this.set('value', closestVal);
+  },
+
+  down(event) {
+    if (this.get('disabled')) {
+      return;
+    }
+
+    this.set('active', true);
+    this.set('dragging', true);
+    this.$().focus();
+
+    this.get('sliderDimensions');
+
+    this.setValueFromEvent(event);
+  },
+
+  up(event) {
+    if (this.get('disabled')) {
+      return;
+    }
+
+    event.stopPropagation();
+
+    this.beginPropertyChanges();
+    this.set('active', false);
+    this.set('dragging', false);
+    this.endPropertyChanges();
+  },
+
+  move(event) {
+    if (this.get('disabled') || !this.get('dragging')) {
+      return;
+    }
+
+    this.setValueFromEvent(event);
+
+  },
+
+  keyDown(event) {
+    if (this.get('disabled')) {
+      return;
+    }
+
+    var changeAmount;
+
+    if (event.keyCode === this.get('constants.KEYCODE.LEFT_ARROW')) {
+      changeAmount = this.get('step') * -1;
+    } else if (event.keyCode === this.get('constants.KEYCODE.RIGHT_ARROW')) {
+      changeAmount = this.get('step');
+    }
+
+    if (changeAmount) {
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        changeAmount *= 4;
+      }
+
+      this.incrementProperty('value', changeAmount);
+
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+});
+
+export default MdSlider;

--- a/addon/mixins/events-mixin.js
+++ b/addon/mixins/events-mixin.js
@@ -21,5 +21,24 @@ export default Ember.Mixin.create({
   },
   up: Ember.K,
   down: Ember.K,
-  contextMenu: Ember.K
+  contextMenu: Ember.K,
+
+  /*
+   * Move events
+   */
+
+  mouseMove: function(e) {
+    return this.move(e);
+  },
+
+  touchMove: function(e) {
+    return this.move(e);
+  },
+
+  pointerMove: function(e) {
+    return this.move(e);
+  },
+
+  move: Ember.K,
+
 });

--- a/app/components/paper-slider.js
+++ b/app/components/paper-slider.js
@@ -1,0 +1,3 @@
+import paperSlider from 'ember-paper/components/paper-slider';
+
+export default paperSlider;

--- a/app/services/constants.js
+++ b/app/services/constants.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+var Constants = Ember.Service.extend({
+
+  MEDIA: {
+    'sm'    : '(max-width: 600px)',
+    'gt-sm' : '(min-width: 600px)',
+    'md'    : '(min-width: 600px) and (max-width: 960px)',
+    'gt-md' : '(min-width: 960px)',
+    'lg'    : '(min-width: 960px) and (max-width: 1200px)',
+    'gt-lg' : '(min-width: 1200px)'
+  },
+
+  KEYCODE: {
+    ENTER:          13,
+    ESCAPE:         27,
+    SPACE:          32,
+    LEFT_ARROW:     37,
+    UP_ARROW:       38,
+    RIGHT_ARROW:    39,
+    DOWN_ARROW:     40,
+    TAB:            9
+  }
+
+
+
+});
+
+export default Constants;

--- a/app/styles/color-palette.scss
+++ b/app/styles/color-palette.scss
@@ -1,3 +1,26 @@
+// Utility Color Classes
+
+$light-contrast-color: rgba(255, 255, 255, 0.87);
+$dark-contrast-color: rgba(0, 0, 0, 0.87);
+$strong-light-contrast-color: rgb(255, 255, 255);
+
+$foreground-light: (
+  "1": rgba(255, 255, 255, 1.0),
+  "2": rgba(255, 255, 255, 0.7),
+  "3": rgba(255, 255, 255, 0.3),
+  "4": rgba(255, 255, 255, 0.12)
+);
+
+$foreground-dark: (
+  "1": rgba(0, 0, 0, 0.87),
+  "2": rgba(0, 0, 0, 0.54),
+  "3": rgba(0, 0, 0, 0.26),
+  "4": rgba(0, 0, 0, 0.12)
+);
+
+$foreground-dark-shadow: 1px 1px 0px rgba(0, 0, 0, 0.4), -1px -1px 0px rgba(0, 0, 0, 0.4);
+$foreground-light-shadow: none;
+
 $color-red: (
   '50': #ffebee,
   '100': #ffcdd2,
@@ -12,7 +35,8 @@ $color-red: (
   'A100': #ff8a80,
   'A200': #ff5252,
   'A400': #ff1744,
-  'A700': #d50000
+  'A700': #d50000,
+  "contrast": $light-contrast-color
 );
 
 // Pink
@@ -32,7 +56,8 @@ $color-pink: (
   'A100': #ff80ab,
   'A200': #ff4081,
   'A400': #f50057,
-  'A700': #c51162
+  'A700': #c51162,
+  "contrast" : $light-contrast-color
 );
 
 // Purple
@@ -52,9 +77,9 @@ $color-purple: (
   'A100': #ea80fc,
   'A200': #e040fb,
   'A400': #d500f9,
-  'A700': #aa00ff
+  'A700': #aa00ff,
+  "contrast": $light-contrast-color
 );
-
 
 // Deep Purple
 // ----------------------------
@@ -73,7 +98,8 @@ $color-deep-purple: (
   'A100': #b388ff,
   'A200': #7c4dff,
   'A400': #651fff,
-  'A700': #6200ea
+  'A700': #6200ea,
+  "contrast": $light-contrast-color
 );
 
 // Indigo
@@ -93,9 +119,9 @@ $color-indigo: (
   'A100': #8c9eff,
   'A200': #536dfe,
   'A400': #3d5afe,
-  'A700': #304ffe
+  'A700': #304ffe,
+  "contrast": $light-contrast-color
 );
-
 
 // Blue
 // ----------------------------
@@ -114,9 +140,9 @@ $color-blue: (
   'A100': #82b1ff,
   'A200': #448aff,
   'A400': #2979ff,
-  'A700': #2962ff
+  'A700': #2962ff,
+  "contrast": $light-contrast-color
 );
-
 
 // Light Blue
 // ----------------------------
@@ -135,9 +161,9 @@ $color-light-blue: (
   'A100': #80d8ff,
   'A200': #40c4ff,
   'A400': #00b0ff,
-  'A700': #0091ea
+  'A700': #0091ea,
+  "contrast": $dark-contrast-color
 );
-
 
 // Cyan
 // ----------------------------
@@ -156,9 +182,9 @@ $color-cyan: (
   'A100': #84ffff,
   'A200': #18ffff,
   'A400': #00e5ff,
-  'A700': #00b8d4
+  'A700': #00b8d4,
+  "contrast": $dark-contrast-color
 );
-
 
 // Teal
 // ----------------------------
@@ -177,9 +203,9 @@ $color-teal: (
   'A100': #a7ffeb,
   'A200': #64ffda,
   'A400': #1de9b6,
-  'A700': #00bfa5
+  'A700': #00bfa5,
+  "contrast": $dark-contrast-color
 );
-
 
 // Green
 // ----------------------------
@@ -198,9 +224,9 @@ $color-green: (
   'A100': #b9f6ca,
   'A200': #69f0ae,
   'A400': #00e676,
-  'A700': #00c853
+  'A700': #00c853,
+  "contrast": $dark-contrast-color
 );
-
 
 // Light Green
 // ----------------------------
@@ -219,9 +245,9 @@ $color-light-green: (
   'A100': #ccff90,
   'A200': #b2ff59,
   'A400': #76ff03,
-  'A700': #64dd17
+  'A700': #64dd17,
+  "contrast": $dark-contrast-color
 );
-
 
 // Lime
 // ----------------------------
@@ -240,9 +266,9 @@ $color-lime: (
   'A100': #f4ff81,
   'A200': #eeff41,
   'A400': #c6ff00,
-  'A700': #aeea00
+  'A700': #aeea00,
+  "contrast": $dark-contrast-color
 );
-
 
 // Yellow
 // ----------------------------
@@ -260,9 +286,9 @@ $color-yellow: (
   'A100': #ffff8d,
   'A200': #ffff00,
   'A400': #ffea00,
-  'A700': #ffd600
+  'A700': #ffd600,
+  "contrast": $dark-contrast-color
 );
-
 
 // Amber
 // ----------------------------
@@ -281,9 +307,9 @@ $color-amber: (
   'A100': #ffe57f,
   'A200': #ffd740,
   'A400': #ffc400,
-  'A700': #ffab00
+  'A700': #ffab00,
+  "contrast": $dark-contrast-color
 );
-
 
 // Orange
 // ----------------------------
@@ -302,9 +328,9 @@ $color-orange: (
   'A100': #ffd180,
   'A200': #ffab40,
   'A400': #ff9100,
-  'A700': #ff6d00
+  'A700': #ff6d00,
+  "contrast": $dark-contrast-color
 );
-
 
 // Deep Orange
 // ----------------------------
@@ -323,9 +349,9 @@ $color-deep-orange: (
   'A100': #ff9e80,
   'A200': #ff6e40,
   'A400': #ff3d00,
-  'A700': #dd2c00
+  'A700': #dd2c00,
+  "contrast": $light-contrast-color
 );
-
 
 // Brown
 // ----------------------------
@@ -340,9 +366,13 @@ $color-brown: (
   '600': #6d4c41,
   '700': #5d4037,
   '800': #4e342e,
-  '900': #3e2723
+  '900': #3e2723,
+  "A100": #d7ccc8,
+  "A200": #bcaaa4,
+  "A400": #8d6e63,
+  "A700": #5d4037,
+  "contrast": $light-contrast-color
 );
-
 
 // Grey
 // ----------------------------
@@ -359,7 +389,11 @@ $color-grey: (
   '800': #424242,
   '900': #212121,
   '1000': #000000,
-  'A100': #ffffff
+  'A100': #ffffff,
+  "A200": #eeeeee,
+  "A400": #bdbdbd,
+  "A700": #616161,
+  "contrast": $dark-contrast-color
 );
 
 // Blue Grey
@@ -374,5 +408,56 @@ $color-blue-grey: (
   '600': #546e7a,
   '700': #455a64,
   '800': #37474f,
-  '900': #263238
+  '900': #263238,
+  "A100": #cfd8dc,
+  "A200": #b0bec5,
+  "A400": #78909c,
+  "A700": #455a64,
+  "contrast": $light-contrast-color
 );
+
+$shades: (
+  "black": #000000,
+  "white": #FFFFFF
+);
+
+$colors: (
+  "red": $color-red,
+  "pink": $color-pink,
+  "purple": $color-purple,
+  "deep-purple": $color-deep-purple,
+  "indigo": $color-indigo,
+  "blue": $color-blue,
+  "light-blue": $color-light-blue,
+  "cyan": $color-cyan,
+  "teal": $color-teal,
+  "green": $color-green,
+  "light-green": $color-light-green,
+  "lime": $color-lime,
+  "yellow": $color-yellow,
+  "amber": $color-amber,
+  "orange": $color-orange,
+  "deep-orange": $color-deep-orange,
+  "brown": $color-brown,
+  "blue-grey": $color-blue-grey,
+  "grey": $color-grey,
+  "shades": $shades,
+  "foreground-light": $foreground-light,
+  "foreground-dark": $foreground-dark
+);
+
+@function color($color, $type: $default-color) {
+  @if map-has-key($colors, $color) {
+    $curr_color: map-get($colors, $color);
+    @if map-has-key($curr_color, $type) {
+      @return map-get($curr_color, $type);
+    }
+  } @else {
+    @if map-has-key($color, $type) {
+      @return map-get($color, $type);
+    }
+  }
+
+  @warn "Unknown `#{$type}` in $colors. `#{$color}`";
+  @return null;
+}

--- a/app/styles/color-palette.scss
+++ b/app/styles/color-palette.scss
@@ -5,17 +5,17 @@ $dark-contrast-color: rgba(0, 0, 0, 0.87);
 $strong-light-contrast-color: rgb(255, 255, 255);
 
 $foreground-light: (
-  "1": rgba(255, 255, 255, 1.0),
-  "2": rgba(255, 255, 255, 0.7),
-  "3": rgba(255, 255, 255, 0.3),
-  "4": rgba(255, 255, 255, 0.12)
+  '1': rgba(255, 255, 255, 1.0),
+  '2': rgba(255, 255, 255, 0.7),
+  '3': rgba(255, 255, 255, 0.3),
+  '4': rgba(255, 255, 255, 0.12)
 );
 
 $foreground-dark: (
-  "1": rgba(0, 0, 0, 0.87),
-  "2": rgba(0, 0, 0, 0.54),
-  "3": rgba(0, 0, 0, 0.26),
-  "4": rgba(0, 0, 0, 0.12)
+  '1': rgba(0, 0, 0, 0.87),
+  '2': rgba(0, 0, 0, 0.54),
+  '3': rgba(0, 0, 0, 0.26),
+  '4': rgba(0, 0, 0, 0.12)
 );
 
 $foreground-dark-shadow: 1px 1px 0px rgba(0, 0, 0, 0.4), -1px -1px 0px rgba(0, 0, 0, 0.4);
@@ -36,7 +36,7 @@ $color-red: (
   'A200': #ff5252,
   'A400': #ff1744,
   'A700': #d50000,
-  "contrast": $light-contrast-color
+  'contrast': $light-contrast-color
 );
 
 // Pink
@@ -57,7 +57,7 @@ $color-pink: (
   'A200': #ff4081,
   'A400': #f50057,
   'A700': #c51162,
-  "contrast" : $light-contrast-color
+  'contrast' : $light-contrast-color
 );
 
 // Purple
@@ -78,7 +78,7 @@ $color-purple: (
   'A200': #e040fb,
   'A400': #d500f9,
   'A700': #aa00ff,
-  "contrast": $light-contrast-color
+  'contrast': $light-contrast-color
 );
 
 // Deep Purple
@@ -99,7 +99,7 @@ $color-deep-purple: (
   'A200': #7c4dff,
   'A400': #651fff,
   'A700': #6200ea,
-  "contrast": $light-contrast-color
+  'contrast': $light-contrast-color
 );
 
 // Indigo
@@ -120,7 +120,7 @@ $color-indigo: (
   'A200': #536dfe,
   'A400': #3d5afe,
   'A700': #304ffe,
-  "contrast": $light-contrast-color
+  'contrast': $light-contrast-color
 );
 
 // Blue
@@ -141,7 +141,7 @@ $color-blue: (
   'A200': #448aff,
   'A400': #2979ff,
   'A700': #2962ff,
-  "contrast": $light-contrast-color
+  'contrast': $light-contrast-color
 );
 
 // Light Blue
@@ -162,7 +162,7 @@ $color-light-blue: (
   'A200': #40c4ff,
   'A400': #00b0ff,
   'A700': #0091ea,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Cyan
@@ -183,7 +183,7 @@ $color-cyan: (
   'A200': #18ffff,
   'A400': #00e5ff,
   'A700': #00b8d4,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Teal
@@ -204,7 +204,7 @@ $color-teal: (
   'A200': #64ffda,
   'A400': #1de9b6,
   'A700': #00bfa5,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Green
@@ -225,7 +225,7 @@ $color-green: (
   'A200': #69f0ae,
   'A400': #00e676,
   'A700': #00c853,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Light Green
@@ -246,7 +246,7 @@ $color-light-green: (
   'A200': #b2ff59,
   'A400': #76ff03,
   'A700': #64dd17,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Lime
@@ -267,7 +267,7 @@ $color-lime: (
   'A200': #eeff41,
   'A400': #c6ff00,
   'A700': #aeea00,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Yellow
@@ -287,7 +287,7 @@ $color-yellow: (
   'A200': #ffff00,
   'A400': #ffea00,
   'A700': #ffd600,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Amber
@@ -308,7 +308,7 @@ $color-amber: (
   'A200': #ffd740,
   'A400': #ffc400,
   'A700': #ffab00,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Orange
@@ -329,7 +329,7 @@ $color-orange: (
   'A200': #ffab40,
   'A400': #ff9100,
   'A700': #ff6d00,
-  "contrast": $dark-contrast-color
+  'contrast': $dark-contrast-color
 );
 
 // Deep Orange
@@ -350,7 +350,7 @@ $color-deep-orange: (
   'A200': #ff6e40,
   'A400': #ff3d00,
   'A700': #dd2c00,
-  "contrast": $light-contrast-color
+  'contrast': $light-contrast-color
 );
 
 // Brown
@@ -367,11 +367,11 @@ $color-brown: (
   '700': #5d4037,
   '800': #4e342e,
   '900': #3e2723,
-  "A100": #d7ccc8,
-  "A200": #bcaaa4,
-  "A400": #8d6e63,
-  "A700": #5d4037,
-  "contrast": $light-contrast-color
+  'A100': #d7ccc8,
+  'A200': #bcaaa4,
+  'A400': #8d6e63,
+  'A700': #5d4037,
+  'contrast': $light-contrast-color
 );
 
 // Grey
@@ -390,10 +390,10 @@ $color-grey: (
   '900': #212121,
   '1000': #000000,
   'A100': #ffffff,
-  "A200": #eeeeee,
-  "A400": #bdbdbd,
-  "A700": #616161,
-  "contrast": $dark-contrast-color
+  'A200': #eeeeee,
+  'A400': #bdbdbd,
+  'A700': #616161,
+  'contrast': $dark-contrast-color
 );
 
 // Blue Grey
@@ -409,41 +409,42 @@ $color-blue-grey: (
   '700': #455a64,
   '800': #37474f,
   '900': #263238,
-  "A100": #cfd8dc,
-  "A200": #b0bec5,
-  "A400": #78909c,
-  "A700": #455a64,
-  "contrast": $light-contrast-color
+  'A100': #cfd8dc,
+  'A200': #b0bec5,
+  'A400': #78909c,
+  'A700': #455a64,
+  'contrast': $light-contrast-color
 );
 
 $shades: (
-  "black": #000000,
-  "white": #FFFFFF
+  'black': #000000,
+  'white': #FFFFFF
 );
 
+
 $colors: (
-  "red": $color-red,
-  "pink": $color-pink,
-  "purple": $color-purple,
-  "deep-purple": $color-deep-purple,
-  "indigo": $color-indigo,
-  "blue": $color-blue,
-  "light-blue": $color-light-blue,
-  "cyan": $color-cyan,
-  "teal": $color-teal,
-  "green": $color-green,
-  "light-green": $color-light-green,
-  "lime": $color-lime,
-  "yellow": $color-yellow,
-  "amber": $color-amber,
-  "orange": $color-orange,
-  "deep-orange": $color-deep-orange,
-  "brown": $color-brown,
-  "blue-grey": $color-blue-grey,
-  "grey": $color-grey,
-  "shades": $shades,
-  "foreground-light": $foreground-light,
-  "foreground-dark": $foreground-dark
+  'red': $color-red,
+  'pink': $color-pink,
+  'purple': $color-purple,
+  'deep-purple': $color-deep-purple,
+  'indigo': $color-indigo,
+  'blue': $color-blue,
+  'light-blue': $color-light-blue,
+  'cyan': $color-cyan,
+  'teal': $color-teal,
+  'green': $color-green,
+  'light-green': $color-light-green,
+  'lime': $color-lime,
+  'yellow': $color-yellow,
+  'amber': $color-amber,
+  'orange': $color-orange,
+  'deep-orange': $color-deep-orange,
+  'brown': $color-brown,
+  'blue-grey': $color-blue-grey,
+  'grey': $color-grey,
+  'shades': $shades,
+  'foreground-light': $foreground-light,
+  'foreground-dark': $foreground-dark
 );
 
 @function color($color, $type: $default-color) {
@@ -458,6 +459,6 @@ $colors: (
     }
   }
 
-  @warn "Unknown `#{$type}` in $colors. `#{$color}`";
+  @warn 'Unknown `#{$type}` in $colors. `#{$color}`';
   @return null;
 }

--- a/app/styles/ember-paper.scss
+++ b/app/styles/ember-paper.scss
@@ -58,6 +58,7 @@
 @import 'paper-whiteframe';
 @import 'paper-toolbar';
 @import 'paper-icon';
+@import 'paper-slider';
 
 @import 'paper-sidenav';
 @import 'paper-backdrop';

--- a/app/styles/paper-slider.scss
+++ b/app/styles/paper-slider.scss
@@ -276,7 +276,7 @@ md-slider {
   }
 }
 
-md-slider {
+md-slider.md-#{$theme-name}-theme {
 
   &.md-warn {
     .md-track.md-track-fill {
@@ -294,7 +294,7 @@ md-slider {
       }
     }
     .md-thumb-text {
-      color: color($warn-color-palette, "contrast");
+      color: color($warn-color-palette, 'contrast');
     }
   }
 
@@ -314,27 +314,27 @@ md-slider {
       }
     }
     .md-thumb-text {
-      color: color($primary-color-palette, "contrast");
+      color: color($primary-color-palette, 'contrast');
     }
   }
 
   .md-track {
-    background-color: color($foreground, "3");
+    background-color: color($foreground, '3');
   }
   .md-track-ticks {
-    background-color: color($foreground, "4");
+    background-color: color($foreground, '4');
   }
   .md-focus-thumb {
-    background-color: color($foreground, "2");
+    background-color: color($foreground, '2');
   }
   .md-focus-ring {
-    border-color: color($foreground, "4");
+    border-color: color($foreground, '4');
   }
   .md-disabled-thumb {
-    border-color: color($background-color-palette, "A100");
+    border-color: color($background-color-palette, 'A100');
   }
   &.md-min .md-thumb:after {
-    background-color: color($background-color-palette, "A100");
+    background-color: color($background-color-palette, 'A100');
   }
 
   .md-track.md-track-fill {
@@ -351,15 +351,15 @@ md-slider {
     }
   }
   .md-thumb-text {
-    color: color($accent-color-palette, "contrast");
+    color: color($accent-color-palette, 'contrast');
   }
 
   &[disabled] {
     .md-thumb:after {
-      border-color: color($foreground, "3");
+      border-color: color($foreground, '3');
     }
     &:not(.md-min) .md-thumb:after {
-      background-color: color($foreground, "3");
+      background-color: color($foreground, '3');
     }
   }
 }

--- a/app/styles/paper-slider.scss
+++ b/app/styles/paper-slider.scss
@@ -1,0 +1,365 @@
+$slider-background-color: rgb(200, 200, 200) !default;
+$slider-height: 48px !default;
+
+$slider-track-height: 2px !default;
+$slider-thumb-width: 32px !default;
+$slider-thumb-height: $slider-thumb-width !default;
+
+$slider-thumb-default-scale: 0.5 !default;
+$slider-thumb-hover-scale: 0.6 !default;
+$slider-thumb-focus-scale: 0.85 !default;
+$slider-thumb-disabled-scale: 0.35 !default;
+$slider-thumb-disabled-border: 6px !default;
+
+$slider-focus-thumb-width: 48px !default;
+$slider-focus-thumb-height: $slider-focus-thumb-width !default;
+$slider-focus-ring-border-width: 3px !default;
+
+$slider-arrow-height: 16px !default;
+$slider-arrow-width: 28px !default;
+
+$slider-sign-height: 28px !default;
+$slider-sign-width: 28px !default;
+$slider-sign-top: ($slider-height / 2) - ($slider-thumb-default-scale * $slider-thumb-height / 2) - ($slider-sign-height) - ($slider-arrow-height) + 8px !default;
+
+@keyframes sliderFocusThumb {
+  0% {
+    opacity: 0;
+    transform: scale(0.0);
+  }
+  50% {
+    transform: scale(1.0);
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@mixin slider-thumb-position($width: $slider-thumb-width, $height: $slider-thumb-height) {
+  position: absolute;
+  left: -$width / 2;
+  top: ($slider-height / 2) - ($height / 2);
+  width: $width;
+  height: $height;
+  border-radius: max($width, $height);
+}
+
+md-slider {
+  height: $slider-height;
+  position: relative;
+  display: block;
+  margin-left: 4px;
+  margin-right: 4px;
+  padding: 0;
+
+  .md-slider-wrapper {
+    position: relative;
+  }
+
+  /**
+    * Track
+    */
+  .md-track-container {
+    width: 100%;
+    position: absolute;
+    top: ($slider-height / 2) - ($slider-track-height) / 2;
+    height: $slider-track-height;
+  }
+  .md-track {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 100%;
+  }
+  .md-track-fill {
+    transition: width 0.05s linear;
+  }
+  .md-track-ticks {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 100%;
+  }
+
+  /**
+    * Slider thumb
+    */
+  .md-thumb-container {
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    transition: left 0.1s linear;
+  }
+  .md-thumb {
+    z-index: 1;
+
+    // Positioning the outer area of the thumb 6px bigger than it needs to be keeps
+    // the :after area being clipped by the background of the focus-thumb animation.
+    @include slider-thumb-position($slider-thumb-width + 6, $slider-thumb-height + 6);
+
+    // We render thumb in an :after selector to fix an obscure problem with the
+    // thumb being clipped by the focus-ring and focus-thumb while running the focus
+    // animation.
+    &:after {
+      content: '';
+      position: absolute;
+      left: 3px;
+      top: 3px;
+      width: $slider-thumb-width;
+      height: $slider-thumb-height;
+      border-radius: max($slider-thumb-width, $slider-thumb-height);
+      border: 3px solid;
+    }
+
+    transform: scale($slider-thumb-default-scale);
+    transition: all 0.1s linear;
+  }
+
+  .md-sign {
+    /* Center the children (slider-thumb-text) */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: absolute;
+    left: -($slider-sign-height / 2);
+    top: $slider-sign-top;
+    width: $slider-sign-width;
+    height: $slider-sign-height;
+    border-radius: max($slider-sign-height, $slider-sign-width);
+
+    transform: scale(0.4) translate3d(0, (-$slider-sign-top + 8) / 0.4, 0);
+    transition: all 0.2s ease-in-out;
+
+    /* The arrow point down under the sign */
+    &:after {
+      position: absolute;
+      content: '';
+      left: -($slider-sign-width / 2 - $slider-arrow-width / 2);
+      border-radius: $slider-arrow-height;
+      top: 19px;
+      border-left: $slider-arrow-width / 2 solid transparent;
+      border-right: $slider-arrow-width / 2 solid transparent;
+      border-top: $slider-arrow-height solid;
+
+      opacity: 0;
+      transform: translate3d(0, -8px, 0);
+      transition: all 0.2s ease-in-out;
+    }
+
+    .md-thumb-text {
+      z-index: 1;
+      font-size: 12px;
+      font-weight: bold;
+    }
+  }
+
+  /**
+   * The border/background that comes in when focused and in non-discrete mode
+   */
+  .md-focus-thumb {
+    @include slider-thumb-position($slider-focus-thumb-width, $slider-focus-thumb-height);
+    display: none;
+    opacity: 0;
+    background-color: #C0C0C0;
+    animation: sliderFocusThumb 0.4s linear;
+  }
+  .md-focus-ring {
+    @include slider-thumb-position($slider-focus-thumb-width, $slider-focus-thumb-height);
+    border: 2px solid #D6D6D6;
+    background-color: transparent;
+    transform: scale(0);
+    transition: all 0.2s linear;
+  }
+  .md-disabled-thumb {
+    @include slider-thumb-position(
+      $slider-thumb-width + $slider-thumb-disabled-border * 2,
+      $slider-thumb-height + $slider-thumb-disabled-border * 2
+    );
+    transform: scale($slider-thumb-disabled-scale);
+    border: $slider-thumb-disabled-border solid;
+    display: none;
+  }
+
+  &.md-min {
+    .md-thumb {
+      &:after {
+        background-color: white;
+      }
+    }
+    .md-sign {
+      opacity: 0;
+    }
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  /* Don't animate left/right while panning */
+  &.dragging {
+    .md-thumb-container,
+    .md-track-fill {
+      transition: none;
+    }
+  }
+
+  &:not([md-discrete]) {
+    /* Hide the sign and ticks in non-discrete mode */
+    .md-track-ticks,
+    .md-sign {
+      display: none;
+    }
+
+    &:not([disabled]) {
+      &:hover {
+        .md-thumb {
+          transform: scale($slider-thumb-hover-scale);
+        }
+      }
+
+      &:focus,
+      &.active {
+        .md-focus-thumb {
+          display: block;
+        }
+        .md-focus-ring {
+          transform: scale(1);
+        }
+        .md-thumb {
+          transform: scale($slider-thumb-focus-scale);
+        }
+      }
+    }
+  }
+
+  &[md-discrete] {
+    /* Hide the focus thumb in discrete mode */
+    .md-focus-thumb,
+    .md-focus-ring {
+      display: none;
+    }
+
+    &:not([disabled]) {
+      &:focus,
+      &.active {
+        .md-sign,
+        .md-sign:after {
+          opacity: 1;
+          transform: translate3d(0, 0, 0) scale(1.0);
+        }
+      }
+    }
+  }
+
+  &[disabled] {
+    .md-track-fill {
+      display: none;
+    }
+    .md-sign {
+      display: none;
+    }
+    .md-thumb {
+      transform: scale($slider-thumb-disabled-scale);
+    }
+    .md-disabled-thumb {
+      display: block;
+    }
+  }
+}
+
+@media screen and (-ms-high-contrast: active) {
+  md-slider .md-track {
+    border-bottom: 1px solid #fff;
+  }
+}
+
+md-slider {
+
+  &.md-warn {
+    .md-track.md-track-fill {
+      background-color: color($warn-color-palette);
+    }
+    .md-thumb:after {
+      border-color: color($warn-color-palette);
+      background-color: color($warn-color-palette);
+    }
+    .md-sign {
+      background-color: color($warn-color-palette);
+
+      &:after {
+        border-top-color: color($warn-color-palette);
+      }
+    }
+    .md-thumb-text {
+      color: color($warn-color-palette, "contrast");
+    }
+  }
+
+  &.md-primary {
+    .md-track.md-track-fill {
+      background-color: color($primary-color-palette);
+    }
+    .md-thumb:after {
+      border-color: color($primary-color-palette);
+      background-color: color($primary-color-palette);
+    }
+    .md-sign {
+      background-color: color($primary-color-palette);
+
+      &:after {
+        border-top-color: color($primary-color-palette);
+      }
+    }
+    .md-thumb-text {
+      color: color($primary-color-palette, "contrast");
+    }
+  }
+
+  .md-track {
+    background-color: color($foreground, "3");
+  }
+  .md-track-ticks {
+    background-color: color($foreground, "4");
+  }
+  .md-focus-thumb {
+    background-color: color($foreground, "2");
+  }
+  .md-focus-ring {
+    border-color: color($foreground, "4");
+  }
+  .md-disabled-thumb {
+    border-color: color($background-color-palette, "A100");
+  }
+  &.md-min .md-thumb:after {
+    background-color: color($background-color-palette, "A100");
+  }
+
+  .md-track.md-track-fill {
+    background-color: color($accent-color-palette);
+  }
+  .md-thumb:after {
+    border-color: color($accent-color-palette);
+    background-color: color($accent-color-palette);
+  }
+  .md-sign {
+    background-color: color($accent-color-palette);
+    &:after {
+      border-top-color: color($accent-color-palette);
+    }
+  }
+  .md-thumb-text {
+    color: color($accent-color-palette, "contrast");
+  }
+
+  &[disabled] {
+    .md-thumb:after {
+      border-color: color($foreground, "3");
+    }
+    &:not(.md-min) .md-thumb:after {
+      background-color: color($foreground, "3");
+    }
+  }
+}

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -1,3 +1,12 @@
+$default-color: '500' !default;
+
+$foreground: "foreground-dark" !default;
+$foreground-shadow: $foreground-light-shadow !default;
+
+$base-background-color: white !default;
+$base-color: rgba(0, 0, 0, 0.87) !default;
+
+
 $theme-name: 'default' !default;
 
 // Font Variables

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -1,6 +1,6 @@
 $default-color: '500' !default;
 
-$foreground: "foreground-dark" !default;
+$foreground: 'foreground-dark' !default;
 $foreground-shadow: $foreground-light-shadow !default;
 
 $base-background-color: white !default;

--- a/app/templates/components/paper-slider.hbs
+++ b/app/templates/components/paper-slider.hbs
@@ -1,0 +1,16 @@
+<div class="md-slider-wrapper">
+    <div class="md-track-container">
+        <div class="md-track"></div>
+        <div class="md-track md-track-fill" style={{activeTrackStyle}}></div>
+        <div class="md-track-ticks"></div>
+    </div>
+    <div class="md-thumb-container" style={{thumbContainerStyle}}>
+        <div class="md-thumb"></div>
+        <div class="md-focus-thumb"></div>
+        <div class="md-focus-ring"></div>
+        <div class="md-sign">
+            <span class="md-thumb-text">{{value}}</span>
+        </div>
+        <div class="md-disabled-thumb"></div>
+    </div>
+</div>

--- a/tests/dummy/app/controllers/slider.js
+++ b/tests/dummy/app/controllers/slider.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  color: {
+    red: Math.floor(Math.random() * 255),
+    green: Math.floor(Math.random() * 255),
+    blue: Math.floor(Math.random() * 255)
+  },
+
+  colorStyle: Ember.computed('color.red', 'color.green', 'color.blue', function() {
+    return Ember.String.htmlSafe("border: 1px solid #333; background: rgb(" + this.get('color.red') + "," + this.get('color.green') + "," + this.get('color.blue') + ")");
+  }),
+
+  rating1: 3,
+  rating2: 2,
+  rating3: 4,
+
+  disabled1: 0,
+  disabled2: 70
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -19,4 +19,5 @@ export default Router.map(function() {
   this.route('textfield');
   this.route('toolbar');
   this.route('icons');
+  this.route('slider');
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,6 +22,7 @@
           <li>{{#link-to "button"}}Button{{/link-to}}</li>
           <li>{{#link-to "checkbox"}}Checkbox{{/link-to}}</li>
           <li>{{#link-to "switch"}}Switch{{/link-to}}</li>
+          <li>{{#link-to "slider"}}Slider{{/link-to}}</li>
           <li>{{#link-to "radio"}}Radio{{/link-to}}</li>
           <li>{{#link-to "textfield"}}Text Field{{/link-to}}</li>
           <li>{{#link-to "toolbar"}}Toolbar{{/link-to}}</li>

--- a/tests/dummy/app/templates/slider.hbs
+++ b/tests/dummy/app/templates/slider.hbs
@@ -1,0 +1,74 @@
+{{#paper-toolbar}}
+    <h2 class="md-toolbar-tools">
+      {{#paper-sidenav-toggle class="menu-sidenav-toggle"}}
+        {{paper-icon icon="menu"}}
+      {{/paper-sidenav-toggle}}
+        <span>Switches</span>
+    </h2>
+{{/paper-toolbar}}
+
+{{#paper-content classNames="md-padding"}}
+
+        <h3>
+            RGB <span style={{colorStyle}}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+        </h3>
+
+        <div layout>
+            <div flex="10" layout layout-align="center center">
+                <span>R</span>
+            </div>
+          {{paper-slider flex='' min='0' max='255' value=color.red}}
+            <div flex="20" layout layout-align="center center">
+              {{input type="number" value=color.red}}
+            </div>
+        </div>
+
+        <div layout>
+            <div flex="10" layout layout-align="center center">
+                <span>G</span>
+            </div>
+          {{paper-slider flex='' min='0' max='255' value=color.green classNames='md-accent'}}
+            <div flex="20" layout layout-align="center center">
+              {{input type="number" value=color.green}}
+            </div>
+        </div>
+
+        <div layout>
+            <div flex="10" layout layout-align="center center">
+                <span>B</span>
+            </div>
+          {{paper-slider flex='' min='0' max='255' value=color.blue classNames='md-primary'}}
+            <div flex="20" layout layout-align="center center">
+              {{input type="number" value=color.blue}}
+            </div>
+        </div>
+
+        <h3>Rating: {{rating}}/5 - demo of theming classes</h3>
+        <div layout>
+            <div flex="10" layout layout-align="center center">
+                <span>default</span>
+            </div>
+          {{paper-slider flex='' md-discrete='' value=rating1 step='1' min='1' max='5'}}
+        </div>
+        <div layout>
+            <div flex="10" layout layout-align="center center">
+                <span>md-warn</span>
+            </div>
+          {{paper-slider flex='' classNames="md-warn" md-discrete='' value=rating2 step="1" min="1" max="5"}}
+        </div>
+        <div layout>
+            <div flex="10" layout layout-align="center center">
+                <span>md-primary</span>
+            </div>
+          {{paper-slider flex='' classNames="md-primary" md-discrete='' value=rating3 step="1" min="1" max="5"}}
+        </div>
+
+        <h3>Disabled</h3>
+      {{paper-slider value=disabled1 disabled=true}}
+      {{paper-slider value=disabled2 disabled=true}}
+
+        <h3>Disabled, Discrete</h3>
+      {{paper-slider value=disabled1 disabled=true step="3" md-discrete='' min="0" max="10"}}
+      {{paper-slider value=disabled2 disabled=true step="10" md-discrete=''}}
+
+{{/paper-content}}

--- a/tests/unit/components/paper-slider-test.js
+++ b/tests/unit/components/paper-slider-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('paper-slider', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // Renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/tests/unit/services/constants-test.js
+++ b/tests/unit/services/constants-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('service:constants', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
I combined the paper-slider component my [ember-material-design](https://github.com/mike1o1/ember-material-design) project and added a demo page. 

There are some .scss differences, as I have a `color($color, $type)` method, which tries to mirror the theming support from the angular project. If you'd rather those be simple `map-get` calls, I can refactor.