### PR TITLE
Ember cli 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ ember install ember-paper
 Ember-paper uses sass for its styles. To import them run:
 
 ```
-$ npm install --save-dev broccoli-sass
+$ ember install ember-cli-sass
 ```
 
 and then create a file in `app/styles/app.scss` and import the styles at the beginning of your file:

--- a/bower.json
+++ b/bower.json
@@ -4,12 +4,13 @@
     "ember": "1.11.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.1",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "hammerjs": "~2.0.4",
-    "jquery": "1.11.1",
+    "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
   included: function(app){
+    this._super.included(app);
     app.import('vendor/material-icons/styles.css', { destDir: '/' });
     app.import('vendor/material-icons/fonts/material-icon-font.eot', { destDir: 'assets/fonts' });
     app.import('vendor/material-icons/fonts/material-icon-font.svg', { destDir: 'assets/fonts' });

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 'use strict';
 
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -41,18 +41,15 @@
     "ember-try": "0.0.4"
   },
   "keywords": [
-    "ember-addon"
-  ],
-  "dependencies": {
-    "ember-cli-babel": "^5.0.0"
-  },
-  "keywords": [
     "ember-addon",
     "material",
     "design",
     "ember",
     "paper"
   ],
+  "dependencies": {
+    "ember-cli-babel": "^5.0.0"
+  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/package.json
+++ b/package.json
@@ -26,17 +26,23 @@
     "broccoli-merge-trees": "~0.2.1",
     "broccoli-sass": "~0.6.5",
     "broccoli-static-compiler": "~0.2.1",
-    "ember-cli": "0.2.3",
+    "ember-cli": "0.2.5",
     "ember-cli-app-version": "0.3.3",
+    "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "~0.7.6",
-    "ember-cli-ic-ajax": "~0.1.2",
+    "ember-cli-htmlbars": "0.7.4",
+    "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "~0.3.11",
+    "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",
+    "ember-data": "1.0.0-beta.16.1",
+    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-export-application-global": "^1.0.2"
+    "ember-try": "0.0.4"
   },
+  "keywords": [
+    "ember-addon"
+  ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "broccoli-asset-rev": "^2.0.2",
     "broccoli-autoprefixer": "^2.1.0",
     "broccoli-merge-trees": "~0.2.1",
-    "broccoli-sass": "~0.6.5",
     "broccoli-static-compiler": "~0.2.1",
     "ember-cli": "0.2.5",
     "ember-cli-app-version": "0.3.3",
@@ -36,8 +35,8 @@
     "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.4"
   },
   "keywords": [
@@ -48,6 +47,7 @@
     "paper"
   ],
   "dependencies": {
+    "ember-cli-sass": "4.0.0-beta.5",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,9 +3,11 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
+var App;
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-var App = Ember.Application.extend({
+App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -24,7 +24,7 @@
   <p>Ember-paper uses sass for its styles. To import them run:</p>
 
   <div class="preview-block">
-    <pre style="margin:0">$ npm install --save-dev broccoli-sass</pre>
+    <pre style="margin:0">$ ember install ember-cli-sass</pre>
   </div>
 
   <p>and then create a file in <pre style="display:inline">app/styles/app.scss</pre> and import the styles at the beginning of your file:</p>


### PR DESCRIPTION
I started working on an update to ember-cli 0.2.5. Right now this is a pretty minimal approach: just compare the diff from `ember update` and adjust appropriately.

There are probably still some things that should be done, either with this PR or soon after. In particualar I can think of the following:
- Move to `ember-cli-sass` as this is the recommenced tool to use for Sass according to the docs. I have an initial attempt in this branch https://github.com/rxfork/ember-paper/tree/ember-cli-sass ~~but when I test with `ember serve`, the css files are 404. I tried following the [Addon Usage section](https://github.com/aexmachina/ember-cli-sass#addon-usage) in the docs but it didn't fix it for me. Maybe it is expecting a different folder structure? Not sure here.~~ Works now and added to PR.
- More dependency bumps? There seem to be some other PRs for those. I'm not sure how you want to handle that.
- Content Security Policy violations for things hosted on github.io (buttons I think). Maybe update the addon's `config/environment.js` to fix these and also add a note to the README alongside the one about the fonts.