### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "paper"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "https://miguelcobain.github.io/ember-paper"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".