### PR TITLE
Fix `ember install ember-paper` errors

### DIFF
--- a/blueprints/ember-paper/index.js
+++ b/blueprints/ember-paper/index.js
@@ -9,8 +9,8 @@ module.exports = {
 
   afterInstall: function() {
     var _this = this;
-    return this.addBowerPackagesToProject(['hammerjs', 'material-design-icons']).then(function() {
-      return _this.addPackagesToProject(['ember-cli-sass']);
+    return this.addBowerPackagesToProject([{name: 'hammerjs', target:'latest'}, {name:'material-design-icons', target: 'latest'}]).then(function() {
+      return _this.addPackagesToProject([{name: 'ember-cli-sass', target: 'latest'}]);
     });
   }
 };


### PR DESCRIPTION
Hi!

I tried to user `ember-paper` in my project and got this error while installation process:

```
version: 0.2.7
Installed packages for tooling via npm.
installing
  create app/styles/app.scss
Cannot call method 'match' of undefined
TypeError: Cannot call method 'match' of undefined
    at Object.decompose (/private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/node_modules/bower-endpoint-parser/index.js:4:28)
    at /private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/lib/commands/install.js:22:31
    at Array.map (native)
    at install (/private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/lib/commands/install.js:21:30)
    at /private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/lib/commands/index.js:21:32
    at Promise.apply (/private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/node_modules/q/q.js:1165:26)
    at Promise.promise.promiseDispatch (/private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/node_modules/q/q.js:788:41)
    at /private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/node_modules/q/q.js:1391:14
    at runSingle (/private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/node_modules/q/q.js:137:13)
    at flush (/private/var/www/try-paper/node_modules/ember-cli/node_modules/bower/node_modules/q/q.js:125:13)
```

So, here it is fix for it.