### PR TITLE
Add missing code template for button with icon

### DIFF
--- a/tests/dummy/app/templates/button.hbs
+++ b/tests/dummy/app/templates/button.hbs
@@ -53,6 +53,9 @@
     \{{#paper-button raised=true classNames="md-primary" action="targetButton" target=component bubbles=false}}Button no bubble\{{/paper-button}}
   &lt;/p&gt;
   &lt;p&gt;
+    \{{#paper-button classNames="md-icon-button"}}\{{paper-icon icon="more-vert"}}\{{/paper-button}}
+  &lt;/p&gt;
+  &lt;p&gt;
     \{{paper-button raised=true label="Blockless version"}}
   &lt;/p&gt;{{/code-block}}
 </div>


### PR DESCRIPTION
Paper button could be used together with paper-icon as shown in the example in [this](http://miguelcobain.github.io/ember-paper/#/button) page. However, the code template is missing example code to use paper-button with paper-icon. This pull request added the missing code.

Thank you and great work on the ember paper project!