### PR TITLE
Fix deprecation: paper-progress-linear

### DIFF
--- a/addon/components/paper-progress-linear.js
+++ b/addon/components/paper-progress-linear.js
@@ -23,7 +23,10 @@ export default Ember.Component.extend(ColorMixin, {
   didInsertElement() {
     this._super(...arguments);
 
-    this.set('ready', true);
+    // We must defer ready to avoid deprecation notice.
+    Ember.run.next(this, function() {
+      this.set('ready', true);
+    });
   },
 
   mode: 'indeterminate',

--- a/addon/components/paper-progress-linear.js
+++ b/addon/components/paper-progress-linear.js
@@ -20,15 +20,6 @@ export default Ember.Component.extend(ColorMixin, {
     this.setupTransforms();
   },
 
-  didInsertElement() {
-    this._super(...arguments);
-
-    // We must defer ready to avoid deprecation notice.
-    Ember.run.next(this, function() {
-      this.set('ready', true);
-    });
-  },
-
   mode: 'indeterminate',
 
   transforms: new Array(101),

--- a/app/templates/components/paper-progress-linear.hbs
+++ b/app/templates/components/paper-progress-linear.hbs
@@ -1,4 +1,4 @@
-<div class="md-container {{if ready "md-ready"}}">
+<div class="md-container md-ready">
     <div class="md-dashed"></div>
     <div class="md-bar md-bar1" style={{bar1Style}}></div>
     <div class="md-bar md-bar2" style={{bar2Style}}></div>


### PR DESCRIPTION
This PR fixes deprecation notice for progress-linear, tested with (1.13.3):

```
DEPRECATION: A property of <dummy@view:-outlet::ember279> was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation.
```