### PR TITLE
fixed icon size parameters and added 'md-sm'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.2.7 (Aug 04, 2015)
 - [#132](https://github.com/miguelcobain/ember-paper/pull/132) Added autocomplete component.
+- [#144](https://github.com/miguelcobain/ember-paper/pull/144) Fixed paper-icon sizes and added new size md-sm (size="sm").
 
 ### 0.2.6 (Jul 20, 2015)
 

--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -25,6 +25,8 @@ export default Ember.Component.extend(ColorMixin, {
     switch(this.get('size')) {
       case 'lg':
         return ' md-lg';
+      case 'sm':
+        return ' md-sm';
       case 2:
         return ' md-2x';
       case 3:

--- a/app/styles/paper-icon.scss
+++ b/app/styles/paper-icon.scss
@@ -11,17 +11,6 @@ md-icon {
   width: 3 * $baseline-grid;
   line-height: 3 * $baseline-grid;
 }
-
-// Icon sizes
-.md-lg {
-  font-size: 1.5em;
-  line-height: .5em;
-  vertical-align: -35%;
-}
-.md-2x { font-size: 2em; }
-.md-3x { font-size: 3em; }
-.md-4x { font-size: 4em; }
-.md-5x { font-size: 5em; }
 */
 
 // Icon spinners
@@ -2505,3 +2494,29 @@ md-icon.md-#{$theme-name}-theme {
   	content: "\e900"
   }
 }
+
+// Icon sizes
+.md-lg {
+    font-size: 1.5em;
+}
+
+.md-sm {
+    font-size: 1em;
+}
+
+.md-2x {
+    font-size: 2em;
+}
+
+.md-3x {
+    font-size: 3em;
+}
+
+.md-4x {
+    font-size: 4em;
+}
+
+.md-5x {
+    font-size: 5em;
+}
+

--- a/tests/dummy/app/templates/icons.hbs
+++ b/tests/dummy/app/templates/icons.hbs
@@ -12,14 +12,17 @@
   <h3>Template</h3>
   <h4>Basic Icons</h4>
   {{#code-block language='handlebars'}}
-\{{paper-icon icon="check"}}{{/code-block}}
-  <h4>Larger Icons</h4>
+    \{{paper-icon icon="check"}}
+  {{/code-block}}
+  <h4>Changing Sizes</h4>
     {{#code-block language='handlebars'}}
-\{{paper-icon icon="check" size="lg"}}
-\{{paper-icon icon="check" size=2}}
-\{{paper-icon icon="check" size=3}}
-\{{paper-icon icon="check" size=4}}
-\{{paper-icon icon="check" size=5}}{{/code-block}}
+      \{{paper-icon icon="check" size="sm"}}
+      \{{paper-icon icon="check" size="lg"}}
+      \{{paper-icon icon="check" size=2}}
+      \{{paper-icon icon="check" size=3}}
+      \{{paper-icon icon="check" size=4}}
+      \{{paper-icon icon="check" size=5}}
+    {{/code-block}}
   <h4>Spinners</h4>
     {{#code-block language='handlebars'}}
 \{{paper-icon icon="rotate-right" spin=true}}


### PR DESCRIPTION
Icon sizes were disabled because the css was commented for some reason. I have fixed those and also added a new size 'md-sm' for smaller icon sizes.