### PR TITLE
Fixes autocomplete initial rendering problem, select by ENTER + focus problem.

### DIFF
--- a/addon/components/paper-autocomplete-list.js
+++ b/addon/components/paper-autocomplete-list.js
@@ -14,9 +14,6 @@ export default Ember.Component.extend({
   role: 'presentation',
   stickToElement: null,
 
-  hidden: true,
-  isVisible: Ember.computed.not('hidden'),
-
   mouseEnter() {
     this.sendAction('mouse-enter');
   },
@@ -28,15 +25,6 @@ export default Ember.Component.extend({
   mouseUp() {
     this.sendAction('mouse-up');
   },
-
-  hideSuggestionObserver: Ember.observer('hidden', function() {
-    if (this.get('hidden') === true) {
-      this.get('util').enableScrolling();
-    } else {
-      this.get('util').disableScrollAround(this.$());
-      this.positionDropdown();
-    }
-  }),
 
   //TODO reafactor into a computed property that binds directly to dropdown's `style`
   positionDropdown() {
@@ -108,6 +96,8 @@ export default Ember.Component.extend({
     var ul = this.$().detach();
     Ember.$('body').append(ul);
     Ember.$(window).on('resize', Ember.run.bind(this, this.resizeWindowEvent));
+    this.get('util').disableScrollAround(this.$());
+    this.positionDropdown();
   },
 
   willDestroyElement() {

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -36,7 +36,6 @@ export default Ember.Component.extend(HasBlockMixin, {
   noBlur: false,
   hasFocus: false,
   searchText: '',
-
   // wrap in a computed property so that cache
   // isn't shared among autocomplete instances
   itemCache: Ember.computed(function() {
@@ -54,13 +53,12 @@ export default Ember.Component.extend(HasBlockMixin, {
   noCache: false,
   notFoundMessage: 'No matches found for \'%@\'.',
 
-  init() {
-    this._super(...arguments);
+  // do not use init(): we need observer to fire.
+  setSearchText: Ember.on('init', function () {
     if (this.get('model')) {
       this.set('searchText', this.lookupLabelOfItem(this.get('model')));
-      this.set('debouncedSearchText', this.lookupLabelOfItem(this.get('model')));
     }
-  },
+  }),
 
   notFloating: Ember.computed.not('floating'),
   notHidden: Ember.computed.not('hidden'),
@@ -126,7 +124,11 @@ export default Ember.Component.extend(HasBlockMixin, {
         this.sendAction('cache-hit', searchText);
       }
       this.set('debouncedSearchText', searchText);
-      this.set('hidden', false);
+
+      // If the autocomplete is being triggered by a human / not on initial render.
+      if (this.get('hasFocus') || this.get('noBlur')) {
+        this.set('hidden', false);
+      }
     } else {
       this.set('hidden', true);
     }

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -156,10 +156,11 @@ export default Ember.Component.extend(HasBlockMixin, {
     var lookupKey = this.get('lookupKey');
     var searchText = (this.get('debouncedSearchText') || '').toLowerCase();
     var cachedItems = this.cacheGet(searchText);
+    var suggestions;
 
     if (cachedItems) {
       //We have cached results
-      return cachedItems;
+      suggestions = cachedItems;
     } else {
       //no cache
 
@@ -168,8 +169,14 @@ export default Ember.Component.extend(HasBlockMixin, {
         //cache when we have a PromiseArray
         this.cacheSet(searchText, data);
       }
-      return Ember.A(data);
+      suggestions = Ember.A(data);
     }
+    // If we have no item suggestions, and allowNonExisting is enabled
+    // We need to close the paper-autocomplete-list so all mouse events get activated again.
+    if (suggestions.length === 0 && this.get('allowNonExisting')){
+      this.set('hidden', true);
+    }
+    return suggestions;
   }).readOnly(),
 
 

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend(HasBlockMixin, {
 
   // Internal
   hidden: true,
-  selectedIndex: null,
+  selectedIndex: 0,
   messages: [],
   noBlur: false,
   hasFocus: false,
@@ -58,6 +58,7 @@ export default Ember.Component.extend(HasBlockMixin, {
     this._super(...arguments);
     if (this.get('model')) {
       this.set('searchText', this.lookupLabelOfItem(this.get('model')));
+      this.set('debouncedSearchText', this.lookupLabelOfItem(this.get('model')));
     }
   },
 
@@ -125,6 +126,9 @@ export default Ember.Component.extend(HasBlockMixin, {
         this.sendAction('cache-hit', searchText);
       }
       this.set('debouncedSearchText', searchText);
+      this.set('hidden', false);
+    } else {
+      this.set('hidden', true);
     }
     this.set('debouncingState', false);
   },
@@ -167,6 +171,7 @@ export default Ember.Component.extend(HasBlockMixin, {
       return Ember.A(data);
     }
   }).readOnly(),
+
 
   filterArray(array, searchText, lookupKey) {
     return array.filter(function(item) {
@@ -258,7 +263,7 @@ export default Ember.Component.extend(HasBlockMixin, {
           if (this.get('hidden') || this.get('loading') || this.get('selectedIndex') < 0 || this.get('suggestions').length < 1) {
             return;
           }
-          this.send('pickModel', Ember.get(this.get('suggestions'), this.get('selectedIndex')));
+          this.send('pickModel', this.get('suggestions').get(this.get('selectedIndex')));
           break;
         case this.get('constants').KEYCODE.ESCAPE:
           this.set('searchText', '');

--- a/app/templates/components/paper-autocomplete.hbs
+++ b/app/templates/components/paper-autocomplete.hbs
@@ -38,39 +38,40 @@
     {{paper-progress-linear}}
   {{/if}}
 
+  {{#if notHidden}}
+    {{#paper-autocomplete-list suggestions=suggestions selectedIndex=selectedIndex wrapToElementId=autocompleteWrapperId mouse-up="listMouseUp" mouse-leave="listMouseLeave" mouse-enter="listMouseEnter"}}
 
-  {{#paper-autocomplete-list suggestions=suggestions hidden=hidden selectedIndex=selectedIndex wrapToElementId=autocompleteWrapperId mouse-up="listMouseUp" mouse-leave="listMouseLeave" mouse-enter="listMouseEnter"}}
+        {{#each suggestions as |item index|}}
 
-    {{#each suggestions as |item index|}}
-
-      {{#paper-autocomplete-item lookupKey=lookupKey item=item selectedIndex=selectedIndex index=index pick="pickModel" as |label|}}
-        {{!-- Render block template, then named component then default --}}
-        {{#if hasBlock}}
-          {{yield searchText item index}}
-        {{else}}
-          {{#if itemComponent}}
-            {{component itemComponent searchText=searchText label=label index=index}}
-          {{else}}
-            {{paper-autocomplete-highlight searchText=searchText label=label}}
-          {{/if}}
-        {{/if}}
-      {{/paper-autocomplete-item}}
-
-    {{else}}
-        {{#if showLoadingBar}}
+          {{#paper-autocomplete-item lookupKey=lookupKey item=item selectedIndex=selectedIndex index=index pick="pickModel" as |label|}}
           {{!-- Render block template, then named component then default --}}
-          {{#if hasBlock}}
-            <li>{{yield searchText to="inverse"}}</li>
-          {{else}}
-            {{#if notFoundComponent}}
-              <li>{{component notFoundComponent searchText=searchText}}</li>
+            {{#if hasBlock}}
+              {{yield searchText item index}}
             {{else}}
-              <li>{{notFoundMsg}}</li>
+              {{#if itemComponent}}
+                {{component itemComponent searchText=searchText label=label index=index}}
+              {{else}}
+                {{paper-autocomplete-highlight searchText=searchText label=label}}
+              {{/if}}
+            {{/if}}
+          {{/paper-autocomplete-item}}
+
+        {{else}}
+          {{#if showLoadingBar}}
+          {{!-- Render block template, then named component then default --}}
+            {{#if hasBlock}}
+                <li>{{yield searchText to="inverse"}}</li>
+            {{else}}
+              {{#if notFoundComponent}}
+                  <li>{{component notFoundComponent searchText=searchText}}</li>
+              {{else}}
+                  <li>{{notFoundMsg}}</li>
+              {{/if}}
             {{/if}}
           {{/if}}
-        {{/if}}
-    {{/each}}
-  {{/paper-autocomplete-list}}
+        {{/each}}
+    {{/paper-autocomplete-list}}
+  {{/if}}
 </md-autocomplete-wrap>
 
 <aria-status class="md-visually-hidden" role="status" aria-live="assertive">

--- a/tests/unit/components/paper-autocomplete-list-test.js
+++ b/tests/unit/components/paper-autocomplete-list-test.js
@@ -10,8 +10,12 @@ moduleForComponent('paper-autocomplete-list', 'Unit | Component | paper autocomp
 test('it renders', function(assert) {
   assert.expect(2);
 
+  Ember.$('#qunit-fixture').append('<div id="elId"></div>');
+
   // Creates the component instance
-  var component = this.subject();
+  var component = this.subject({
+    wrapToElementId: 'elId'
+  });
   assert.equal(component._state, 'preRender');
 
   // Renders the component to the page
@@ -19,20 +23,6 @@ test('it renders', function(assert) {
   assert.equal(component._state, 'inDOM');
 });
 
-test('it renders correctly into body element.', function(assert) {
-  assert.expect(2);
-
-  // Creates the component instance
-  this.subject();
-
-  this.$();
-
-  assert.equal(this.$().parent().prop('tagName'), 'BODY', 'It has BODY as parent DOM element');
-
-  assert.equal(this.$().is(':visible'), false, 'Its hidden by default');
-
-
-});
 
 
 


### PR DESCRIPTION
Fixes:
- autocomplete initial rendering problem (by removing that ugly observer I created and not use isVisible!! So we don't trigger the computed property `suggestions` on-load.)
- fixes select item by ENTER key. 
- Also fixes focus problem if input was empty before the autocomplete did not open: It only opened if some text was there -> focus out  -> focus in. Now it works if empty text -> focus in [open if min-length was correct.].
