### PR TITLE
Upgrade to ember 2.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Ember Paper Changelog
 
+### 0.2.8 (Aug 13, 2015)
+- Upgrade to ember 2.0.0 and fix deprecation with Ember.String.fmt
+
 ### 0.2.7 (Aug 11, 2015)
 - [#132](https://github.com/miguelcobain/ember-paper/pull/132) Added autocomplete component.
 - [#144](https://github.com/miguelcobain/ember-paper/pull/144) Fixed paper-icon sizes and added new size md-sm (size="sm").

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -51,7 +51,7 @@ export default Ember.Component.extend(HasBlockMixin, {
   minLength: 1,
   allowNonExisting: false,
   noCache: false,
-  notFoundMessage: 'No matches found for \'%@\'.',
+  notFoundMessage: "No matches found for \"$searchText\".",
 
   init() {
     this._super(...arguments);
@@ -75,7 +75,7 @@ export default Ember.Component.extend(HasBlockMixin, {
   },
 
   notFoundMsg: Ember.computed('searchText', 'notFoundMessage', function() {
-    return Ember.String.fmt(this.get('notFoundMessage'), [this.get('searchText')]);
+    return this.get('notFoundMessage').replace('$searchText', this.get('searchText'));
   }),
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
   "name": "ember-paper",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "2.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.2.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-paper",
   "description": "The Ember approach to Material Design.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -22,27 +22,27 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
-    "broccoli-merge-trees": "~0.2.1",
+    "broccoli-merge-trees": "~0.2.3",
     "broccoli-static-compiler": "~0.2.1",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
-    "ember-cli-github-pages": "0.0.4",
+    "ember-cli-github-pages": "0.0.6",
     "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.0",
-    "ember-cli-release": "0.2.3",
+    "ember-cli-release": "0.2.5",
     "ember-cli-sass": "4.0.0-beta.5",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-disable-proxy-controllers": "^1.0.0",
+    "ember-disable-prototype-extensions": "^1.0.1",
+    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.3",
     "ember-prism": "0.0.5",
-    "ember-try": "0.0.6"
+    "ember-try": "0.0.8"
   },
   "dependencies": {
     "broccoli-autoprefixer": "^3.0.0",

--- a/tests/dummy/app/templates/autocomplete.hbs
+++ b/tests/dummy/app/templates/autocomplete.hbs
@@ -18,7 +18,7 @@
   {{paper-autocomplete
     disabled=firstDisabled
     placeholder="Select a Country ..."
-    notFoundMessage="Oops country: \"%@\" doesn't exist here."
+    notFoundMessage="Oops country: \"$searchText\" doesn't exist here."
     source=items lookupKey="name"
     model=myModel}}
   <p>
@@ -38,7 +38,7 @@
 \{{paper-autocomplete
     disabled=firstDisabled
     placeholder="Select a Country ..."
-    notFoundMessage="Oops country: \"%@\" doesn't exist here."
+    notFoundMessage="Oops country: \"$searchText\" doesn't exist here."
     source=items lookupKey="name"
     model=myModel}}{{/code-block}}
 
@@ -285,7 +285,7 @@ Whoops! Could not find "\{{searchText}}".{{/code-block}}
     <tr>
       <td>notFoundMessage</td>
       <td>string</td>
-      <td>The message to display if no items was found. Default is: <code>No matches found for "%@".</code>. The <code>%@</code> part will be replaced by the users input.</td>
+      <td>The message to display if no items was found. Default is: <code>"No matches found for "$searchText"."</code>. The <code>$searchText</code> part will be replaced by the users input.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
- Upgrades to ember 2.0.0
- Autocomplete: Fix deprecation, Ember.String.fmt is deprecated in 2.0.0, and no alternative for that exist (only compile time ES6 (does not work with the use-case we have)). So, only used `.replace` for the dynamic part `$searchText`. 
