### PR TITLE
Allow paper-input to be a block component, so user can add helper text

### DIFF
--- a/app/templates/components/paper-input.hbs
+++ b/app/templates/components/paper-input.hbs
@@ -21,3 +21,5 @@
 {{#if maxlength}}
     <div class="md-char-counter">{{renderCharCount}}</div>
 {{/if}}
+
+{{yield this}}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -241,6 +241,18 @@ p {
   text-align: center;
 }
 
+md-input-container {
+  ng-messages,
+  [ng-message], [data-ng-message], [x-ng-message] {
+
+    &.helper-text {
+      color: color($foreground, '3');
+    }
+
+  }
+
+}
+
 md-input-container:not(.md-input-invalid) > md-icon.email {
   color: green;
 }

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -22,7 +22,13 @@
 
   <h3>Input Errors</h3>
   <p>
-    {{paper-input label="Address" value=address required=true required-errortext="Address is required."}}
+    {{#paper-input label="Address" value=address required=true required-errortext="Address is required." helper="Hello" as |paper|}}
+      <div ng-messages>
+          <div ng-message class="helper-text {{if paper.isInvalid 'ng-leave ng-leave-active' 'ng-enter ng-enter-active'}}">
+              Please input your address.
+          </div>
+      </div>
+    {{/paper-input}}
     {{paper-input type="number" label="Maximum Value" value=maxNumber max="5" max-errortext="Enter 5 or less."}}
     {{paper-input type="number" label="Minimum Value" value=minNumber min="1" min-errortext="Enter at least 1."}}
     {{paper-input label="Maximum Character Length" value=maxLength required=true maxlength="10" maxlength-errortext="Maximum length exceeded."}}
@@ -51,7 +57,13 @@
 \{{paper-input label="Submission date" type="date" value=date}}
 \{{paper-input textarea=true label="Biography" value=biography}}
 
-\{{paper-input label="Address" value=address required=true required-errortext="Address is required."}}
+\{{#paper-input label="Address" value=address required=true required-errortext="Address is required." helper="Hello" as |paper|}}
+  &lt;div ng-messages&gt;
+    &lt;div ng-message class="helper-text \{{if paper.isInvalid 'ng-leave ng-leave-active' 'ng-enter ng-enter-active'}}"&gt;
+    Please input your address.
+    &lt;/div&gt;
+  &lt;/div&gt;
+\{{/paper-input}}{{paper-input label="Address" value=address required=true required-errortext="Address is required."}}
 \{{paper-input label="Maximum Value" value=maxNumber max="5" max-errortext="Enter 5 or less."}}
 \{{paper-input label="Minimum Value" value=minNumber min="1" min-errortext="Enter at least 1."}}
 \{{paper-input label="Maximum Character Length" value=maxLength required=true maxlength="10" maxlength-errortext="Maximum length exceeded."}}


### PR DESCRIPTION
User can add anything else they want inside the `md-input-container` block.

Also add an example of how to use this new block format to create a helper text.
