### PR TITLE
Allow 'type' attribute on {{paper-button}} component

### DIFF
--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -5,7 +5,7 @@ import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 
 export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
-  attributeBindings: ['target', 'action'],
+  attributeBindings: ['target', 'action', 'type'],
   tagName: 'button',
   themed: true,
   classNameBindings: ['raised:md-raised', 'icon-button:md-icon-button', 'focus:md-focused', 'themed:md-default-theme', 'themed:md-button'],


### PR DESCRIPTION
Allow `type` attribute to be passed to the `{{paper-button}}` component