### PR TITLE
check if grid list is destroyed before invalidating it fixes #196

### DIFF
--- a/addon/components/paper-grid-list.js
+++ b/addon/components/paper-grid-list.js
@@ -326,7 +326,7 @@ export default Ember.Component.extend({
     },
 
     invalidateLayout() {
-      if (this.get('layoutInvalidated')) {
+      if (this.get('layoutInvalidated') || this.get('isDestroyed')) {
         return;
       }
       this.set('layoutInvalidated', true);


### PR DESCRIPTION
fixes #196 

Fix assertion thrown when invalidating destroyed `paper-grid-list` component.