### PR TITLE
Autocomplete/feature Search for a parts of string

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -26,7 +26,7 @@ export default Ember.Component.extend(HasBlockMixin, {
 
   tagName: 'md-autocomplete',
   classNameBindings: ['notFloating:md-default-theme'],
-  attributeBindings: ['floating:md-floating-label', 'showDisabled:disabled'],
+  attributeBindings: ['floating:md-floating-label', 'showDisabled:disabled','flex'],
 
 
   // Internal

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -57,8 +57,16 @@ export default Ember.Component.extend(HasBlockMixin, {
     this._super(...arguments);
 
     if (this.get('model')) {
-      this.set('searchText', this.lookupLabelOfItem(this.get('model')));
-      this.searchTextDidChange();
+      if (this.get('model') instanceof Ember.ObjectProxy){
+        let model = this.get('model');
+        model.then((instance)=>{
+          this.set('searchText', this.lookupLabelOfItem(instance));
+          this.set('model',instance);
+        });
+      } else {
+        this.set('searchText', this.lookupLabelOfItem(this.get('model')));
+        this.searchTextDidChange();
+      } 
     }
   },
 
@@ -117,12 +125,14 @@ export default Ember.Component.extend(HasBlockMixin, {
   }),
   
   modelDidChange: Ember.observer('model', function() {
-    var model = this.get('model');
-    var value = this.lookupLabelOfItem(model);
-    // First set previousSearchText then searchText ( do not trigger observer only update value! ).
-    this.set('previousSearchText', value);
-    this.set('searchText', value);
-    this.set('hidden', true);
+    if (!Ember.isBlank(this.get('model'))) {
+      var model = this.get('model');
+      var value = this.lookupLabelOfItem(model);
+      // First set previousSearchText then searchText ( do not trigger observer only update value! ).
+      this.set('previousSearchText', value);
+      this.set('searchText', value);
+      this.set('hidden', true);
+    }
   }),
 
   setDebouncedSearchText() {

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -195,7 +195,7 @@ export default Ember.Component.extend(HasBlockMixin, {
         '\' value is a string.', isString(item) || (Ember.isPresent(lookupKey) && isString(Ember.get(item, lookupKey))) );
 
       var search = isString(item) ? item.toLowerCase() : Ember.get(item, lookupKey).toLowerCase();
-      return search;
+      return search.indexOf(searchText) !== -1;
     });
   },
 

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -195,7 +195,7 @@ export default Ember.Component.extend(HasBlockMixin, {
         '\' value is a string.', isString(item) || (Ember.isPresent(lookupKey) && isString(Ember.get(item, lookupKey))) );
 
       var search = isString(item) ? item.toLowerCase() : Ember.get(item, lookupKey).toLowerCase();
-      return search.indexOf(searchText) === 0;
+      return search;
     });
   },
 

--- a/addon/mixins/proxiable-mixin.js
+++ b/addon/mixins/proxiable-mixin.js
@@ -2,14 +2,18 @@ import Ember from 'ember';
 import ProxyMixin from './proxy-mixin';
 
 export default Ember.Mixin.create({
-  didInsertElement() {
-    this._super(...arguments);
-
-    var proxy = this.nearestOfType(ProxyMixin);
-    if (proxy) {
-      proxy.register(this);
+  init(){
+  	this._super(...arguments);
+  	Ember.run(()=>{
+  		Ember.run.scheduleOnce('afterRender', this, 'registerProxy');
+  	});
+	
+  },
+  registerProxy(){
+  	let proxy = this.nearestOfType(ProxyMixin);
+  	if (proxy) {
+  	  proxy.register(this);
     }
   },
-
   processProxy: null
 });

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-paper",
   "dependencies": {
-    "ember": "1.13.11",
+    "ember": "components/ember#release",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",
@@ -9,10 +9,13 @@
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
     "hammerjs": "~2.0.4",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "matchMedia": "0.2.0",
     "prism": "*",
     "qunit": "~1.20.0"
+  },
+  "resolutions": {
+    "ember": "release"
   }
 }


### PR DESCRIPTION
Take a set of words like full address which can consist from `City` `Street` `Country`. If your backend implements spliting the search string on to separate parts and making search across multiple tables the search result returned to autocomplete might not comply `search.indexOf(searchText) === 0;` The other case when it might not comply if you are doing letter-wise search on the backend. etc.

Added feature for paper-autocomplete to support providing promises to model property.

Added feature to set `flex` property on paper-autocomplete. The provided `flex` should be numeric value  `1-100` like `flex="60"`. Setting flex would scale the element to the provided percentage of parent container