### PR TITLE
Fix issue with `border-bottom-color` in paper-select not correctly ge…

### DIFF
--- a/app/styles/paper-select.scss
+++ b/app/styles/paper-select.scss
@@ -227,7 +227,7 @@ md-select.md-#{$theme-name}-theme {
   }
   &:not([disabled]):focus {
     .md-select-value {
-      border-bottom-color: $primary;
+      border-bottom-color: color($primary);
       color: color($foreground, '1');
       &.md-select-placeholder {
         color: color($foreground, '1');


### PR DESCRIPTION
Paper-select is not using the $primary color directly. The stylesheet was referencing the $primary variable directly, instead of accessing it through the `color` function.