### PR TITLE
Fixed a few stray color references that didnt use color utility

### DIFF
--- a/app/styles/paper-select.scss
+++ b/app/styles/paper-select.scss
@@ -234,10 +234,10 @@ md-select.md-#{$theme-name}-theme {
       }
     }
     &.md-accent .md-select-value {
-      border-bottom-color: $accent;
+      border-bottom-color: color($accent);
     }
     &.md-warn .md-select-value {
-      border-bottom-color: $warn;
+      border-bottom-color: color($warn);
     }
   }
   &[disabled] {


### PR DESCRIPTION
Same fix as #209 for a couple of different colors.  I searched the project and these appear to be the last two references to color definitions that don't use the `color` utility function.