### PR TITLE
Inject wormhole outlet through addon hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Ember Paper Changelog
 
+### 0.2.10
+- [#219](https://github.com/miguelcobain/ember-paper/pull/219) Inject wormhole outlet through addon hook
+
 ### 0.2.9 (Sep 20, 2015)
 - [#140](https://github.com/miguelcobain/ember-paper/pull/140) Implement Material Menu and Select component.
 - [#171](https://github.com/miguelcobain/ember-paper/pull/171) Add support for custom validations in paper-input component.

--- a/index.js
+++ b/index.js
@@ -16,11 +16,15 @@ module.exports = {
     app.import(app.bowerDirectory + '/matchMedia/matchMedia.js');
     app.import('vendor/propagating.js');
   },
+  contentFor: function(type) {
+    if (type === 'head') {
+      return "<div id='paper-wormhole'></div>";
+    }
+  },
   postprocessTree: function(type, tree) {
     if (type === 'all' || type === 'styles') {
       tree = autoprefixer(tree, { browsers: ['last 2 versions'] });
     }
-
     return tree;
   }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,3 @@
-<!-- paper-wormhole is needed for fixed positioned components and should be the first element in application.hbs. -->
-<div id="paper-wormhole"></div>
-
 {{#paper-nav-container class="site-nav-container"}}
   {{#paper-sidenav class="md-sidenav-left md-whiteframe-z2 site-sidenav" locked-open="gt-sm"}}
     {{#paper-toolbar class="site-content-toolbar"}}


### PR DESCRIPTION
Instead of needing to include the Wormhole outlet in your application manually, the addon will now add the `div` automatically.

Note: I'm not sure if this will be backward compatible with having it also defined in the template, for people that already are using it the previous way.

Closes #214