### PR TITLE
Enable paper-input to display server generated errors

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -15,14 +15,25 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
   inputElementId: Ember.computed('elementId', function() {
     return 'input-' + this.get('elementId');
   }),
-  isInvalid: Ember.computed('isTouched', 'value', function() {
-    return this.validate();
+  isInvalid: Ember.computed('hasAppliedErrors', 'isTouched', 'value', function() {
+    return this.get('hasAppliedErrors') || this.validate();
   }),
   renderCharCount: Ember.computed('value', function() {
     var currentLength = this.get('value') ? this.get('value').length : 0;
     return currentLength + '/' + this.get('maxlength');
   }),
   iconFloat: Ember.computed.and('icon', 'label'),
+
+  // Set to display errors from server or other client side validation framework (ember-validations)
+  // Expects array of JavaScript objects. Objects must respond to a 'message' property.
+  errors: [],
+  hasAppliedErrors: Ember.computed.notEmpty('errors'),
+  _setAppliedError: Ember.on('init', Ember.observer('hasAppliedErrors', function() {
+    var errors = this.get('errors');
+    if(this.get('hasAppliedErrors')) {
+      this.set('errortext', errors.map( (item) => { return item.message; }).join(', ') );
+    }
+  })),
 
   didInsertElement() {
     if (this.get('textarea')) {

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -37,6 +37,24 @@
     }}
   </p>
 
+  <h3>Errors from outside paper-input (server side errors)</h3>
+  <p>
+  Server side or other client generated errors can be displayed via paper-input using the
+  {{#code-inline}}errors{{/code-inline}} attribute. The {{#code-inline}}errors{{/code-inline}} attribute
+  expects an array of JavaScript objects which each respond to a {{#code-inline}}message{{/code-inline}}
+  attribute.  Below is an example of how one might wire up the DS.Errors object directly off of your
+  model to display server side errors.
+  </p>
+  <p>
+  The {{#code-inline}}errors{{/code-inline}} attribute can be used in conjunction with
+  paper-input native errors.  In the case where both types of errors
+  occur simultaneously, only the {{#code-inline}}errors{{/code-inline}} attribute messages
+  will be displayed.
+  </p>
+{{#code-block language="handlebars"}}
+\{{paper-input label="Name" value=model.name errors=model.name.errors}}{{/code-block}}
+
+
   <h3>Icons</h3>
   <p>
       {{paper-input label="Name" value=name icon="person" icon-class="name"}}

--- a/tests/unit/components/paper-input-test.js
+++ b/tests/unit/components/paper-input-test.js
@@ -63,6 +63,21 @@ test('it does not set isInvalid when required is true, text has no value and isT
   assert.equal(component.get('isInvalid'), false, 'isInvalid is true');
 });
 
+test('it sets isInvalid when it is otherwise valid and the errors input is set', function(assert) {
+  assert.expect(2);
+  var component = this.subject();
+  component.set('required', true);
+  component.set('value', '');
+  component.set('isTouched', false);
+
+  // verify it is otherwise valid
+  assert.equal(component.get('isInvalid'), false, 'isInvalid is true');
+
+  // set the errors input property
+  component.set('errors', [{message: 'some custom error message'}]);
+  assert.equal(component.get('isInvalid'), true, 'isInvalid is false when the errors input is set');
+});
+
 test('it adds md-input-invalid css class when isInvalid', function(assert) {
   assert.expect(2);
   var inputGroup,
@@ -91,6 +106,28 @@ test('it sets error text when isInvalid', function(assert) {
   component.set('value', '');
   component.set('errorText', expectedError);
   component.set('isTouched', true);
+
+  this.render();
+
+  inputGroup = document.getElementsByTagName('md-input-container');
+
+  assert.equal(inputGroup.length === 1, true);
+
+  errorDiv = document.getElementById('error-input-' + inputGroup[0].id);
+
+  assert.equal(errorDiv.innerHTML, expectedError, 'Error text does not equal ' + expectedError);
+});
+
+test('it sets error text when errors input is set', function(assert) {
+  assert.expect(2);
+  var inputGroup,
+      errorDiv,
+      expectedError = 'A custom error message',
+      component = this.subject();
+
+  component.set('value', '');
+  component.set('isTouched', true);
+  component.set('errors', [{message: expectedError}]);
 
   this.render();
 


### PR DESCRIPTION
Server side or other client generated errors can be displayed via paper-input using the `errors` attribute. The `errors` attribute expects an array of JavaScript objects which each respond to a `message` attribute.  `errors` can be set to the DS.Errors object directly off of your model to easily display server side errors.

The `errors` attribute can be used in conjunction with paper-input native errors.  In the case where both types of errors occur simultaneously, only the `errors` attribute messages will be displayed.

This would resolve #216