### PR TITLE
inputs with icons "shift" on focus

### DIFF
--- a/app/styles/paper-input.scss
+++ b/app/styles/paper-input.scss
@@ -18,7 +18,7 @@ $input-error-height: 24px !default;
 $icon-offset : 36px !default;
 
 $icon-float-top: -16px !default;
-$icon-float-focused-top: -8px !default;
+$icon-float-focused-top: $icon-float-top !default;
 
 md-input-container {
   display: flex;


### PR DESCRIPTION
This PR fixes a bug with inputs that have an icon in which they slightly shift when gaining/losing focus.