### PR TITLE
When icon present w/ textarea, use margin-left

### DIFF
--- a/app/styles/paper-input.scss
+++ b/app/styles/paper-input.scss
@@ -32,8 +32,9 @@ md-input-container {
     position: absolute;
     top: 5px;
     left: 2px;
-    + input {
-          margin-left: $icon-offset;
+    + input,
+    + textarea {
+      margin-left: $icon-offset;
     }
   }
 


### PR DESCRIPTION
Currently, icon sits on top of the textarea. Just use what is
already available with `input`

![screen shot 2016-01-03 at 11 50 26 am](https://cloud.githubusercontent.com/assets/672057/12080475/3f0e27fa-b210-11e5-94a7-c6ac32e1f4da.png)
![screen shot 2016-01-03 at 11 46 52 am](https://cloud.githubusercontent.com/assets/672057/12080476/40a3c7dc-b210-11e5-98e4-687d1d71809f.png)
