### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Sass is an important part of Ember-paper. Using sass you can override default va
 All the components and styles are ready to use in your application templates.
 Navigate through the docs to understand how to use each component.
 
+**Note** If upgrading from a previous version of ember-paper and you are seeing compile errors around `app.scss|sass` not existing, please make sure to remove `broccoli-sass` from your `package.json`, remove your `node_modules` and reinstall.
+
 ### Content Security Policy
 
 Ember Paper uses fonts from Google Fonts, so the URL to them has to be white listed.  You can set this by adding to the Content Security Policy defined in `config/environment.js` like so:


### PR DESCRIPTION
Adding a note explaining why someone might get a compile error around app.scss not existing if they were upgrading from previous versions of ember-paper.