### PR TITLE
Upgrade to ember 2.3.0 and use "transition-to" helper

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,16 @@
 {
   "name": "ember-paper",
   "dependencies": {
-    "ember": "1.13.11",
-    "ember-cli-shims": "0.0.6",
-    "ember-cli-test-loader": "0.2.1",
+    "ember": "2.3.0",
+    "ember-cli-shims": "0.1.0",
+    "ember-cli-test-loader": "0.2.2",
     "ember-load-initializers": "0.1.7",
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
     "hammerjs": "~2.0.4",
     "jquery": "1.11.3",
-    "loader.js": "ember-cli/loader.js#3.4.0",
+    "loader.js": "3.5.0",
     "matchMedia": "0.2.0",
     "prism": "*",
     "qunit": "~1.20.0"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-prism": "0.0.5",
+    "ember-route-action": "0.0.5",
     "ember-try": "~0.0.8"
   },
   "dependencies": {

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -2,9 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   actions: {
-    transitionTo(route) {
-      this.transitionTo(route);
-    },
     raisedButton() {
       alert('You pressed a raised button.');
     },

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -11,27 +11,27 @@
     {{#paper-content}}
 
       {{#paper-list}}
-        {{#paper-item action="transitionTo" param="index"}}Introduction{{/paper-item}}
-        {{#paper-item action="transitionTo" param="autocomplete"}}Autocomplete{{/paper-item}}
-        {{#paper-item action="transitionTo" param="sidenav"}}Sidenav{{/paper-item}}
-        {{#paper-item action="transitionTo" param="typography"}}Typography{{/paper-item}}
-        {{#paper-item action="transitionTo" param="list"}}List{{/paper-item}}
-        {{#paper-item action="transitionTo" param="grid-list"}}Grid List{{/paper-item}}
-        {{#paper-item action="transitionTo" param="list-controls"}}List Controls{{/paper-item}}
-        {{#paper-item action="transitionTo" param="progress-circular"}}Progress Circular{{/paper-item}}
-        {{#paper-item action="transitionTo" param="progress-linear"}}Progress Linear{{/paper-item}}
-        {{#paper-item action="transitionTo" param="divider"}}Divider{{/paper-item}}
-        {{#paper-item action="transitionTo" param="card"}}Card{{/paper-item}}
-        {{#paper-item action="transitionTo" param="button"}}Button{{/paper-item}}
-        {{#paper-item action="transitionTo" param="checkbox"}}Checkbox{{/paper-item}}
-        {{#paper-item action="transitionTo" param="menu"}}Menu{{/paper-item}}
-        {{#paper-item action="transitionTo" param="paper-select"}}Select{{/paper-item}}
-        {{#paper-item action="transitionTo" param="switch"}}Switch{{/paper-item}}
-        {{#paper-item action="transitionTo" param="slider"}}Slider{{/paper-item}}
-        {{#paper-item action="transitionTo" param="radio"}}Radio{{/paper-item}}
-        {{#paper-item action="transitionTo" param="input"}}Input{{/paper-item}}
-        {{#paper-item action="transitionTo" param="toolbar"}}Toolbar{{/paper-item}}
-        {{#paper-item action="transitionTo" param="icons"}}Icons{{/paper-item}}
+        {{#paper-item action=(transition-to "index")}}Introduction{{/paper-item}}
+        {{#paper-item action=(transition-to "autocomplete")}}Autocomplete{{/paper-item}}
+        {{#paper-item action=(transition-to "sidenav")}}Sidenav{{/paper-item}}
+        {{#paper-item action=(transition-to "typography")}}Typography{{/paper-item}}
+        {{#paper-item action=(transition-to "list")}}List{{/paper-item}}
+        {{#paper-item action=(transition-to "grid-list")}}Grid List{{/paper-item}}
+        {{#paper-item action=(transition-to "list-controls")}}List Controls{{/paper-item}}
+        {{#paper-item action=(transition-to "progress-circular")}}Progress Circular{{/paper-item}}
+        {{#paper-item action=(transition-to "progress-linear")}}Progress Linear{{/paper-item}}
+        {{#paper-item action=(transition-to "divider")}}Divider{{/paper-item}}
+        {{#paper-item action=(transition-to "card")}}Card{{/paper-item}}
+        {{#paper-item action=(transition-to "button")}}Button{{/paper-item}}
+        {{#paper-item action=(transition-to "checkbox")}}Checkbox{{/paper-item}}
+        {{#paper-item action=(transition-to "menu")}}Menu{{/paper-item}}
+        {{#paper-item action=(transition-to "paper-select")}}Select{{/paper-item}}
+        {{#paper-item action=(transition-to "switch")}}Switch{{/paper-item}}
+        {{#paper-item action=(transition-to "slider")}}Slider{{/paper-item}}
+        {{#paper-item action=(transition-to "radio")}}Radio{{/paper-item}}
+        {{#paper-item action=(transition-to "input")}}Input{{/paper-item}}
+        {{#paper-item action=(transition-to "toolbar")}}Toolbar{{/paper-item}}
+        {{#paper-item action=(transition-to "icons")}}Icons{{/paper-item}}
       {{/paper-list}}
 
     {{/paper-content}}

--- a/tests/dummy/app/templates/sidenav.hbs
+++ b/tests/dummy/app/templates/sidenav.hbs
@@ -42,8 +42,8 @@
 
     \{{#paper-content}}
       \{{#paper-list}}
-        \{{#paper-item action="transitionTo" param="index"}}Introduction\{{/paper-item}}
-        \{{#paper-item action="transitionTo" param="index"}}Another link\{{/paper-item}}
+        \{{#paper-item action=(transition-to "index")}}Introduction\{{/paper-item}}
+        \{{#paper-item action=(transition-to "index")}}Another link\{{/paper-item}}
       \{{/paper-list}}
     \{{/paper-content}}
   \{{/paper-sidenav}}


### PR DESCRIPTION
- Upgraded ember demo site to 2.3.0
- Use [transition-to](https://github.com/peec/ember-route-action) addon to route from components. This is not included as a dependency but rather dev-dependency. 
