### PR TITLE
paper-icon: add deprecation warning for old usage format

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -6,12 +6,24 @@ var PaperIconComponent = Ember.Component.extend(ColorMixin, {
   classNames: ['paper-icon', 'md-font', 'material-icons', 'md-default-theme'],
   classNameBindings: ['iconClass', 'sizeClass', 'spinClass'],
 
-  icon: '',
   spin: false,
   reverseSpin: false,
 
   iconClass: Ember.computed('icon', 'positionalIcon', function() {
-    var icon = this.getWithDefault('positionalIcon', this.get('icon'));
+    let oldIcon = this.get('icon');
+
+    Ember.deprecate(
+        'ember-paper: The `{{paper-icon icon="someIcon"}}` format is deprecated. Please use `{{paper-icon "someIcon"}}`.',
+        oldIcon === undefined,
+        {
+          id: 'ember-paper.paper-icon.non-positional-param',
+          until: '1.0.0',
+          url: 'https://github.com/miguelcobain/ember-paper/pull/288'
+        }
+      );
+
+    let icon = this.getWithDefault('positionalIcon', oldIcon);
+
     return Ember.String.dasherize(icon);
   }),
 

--- a/tests/integration/components/paper-icon-test.js
+++ b/tests/integration/components/paper-icon-test.js
@@ -8,7 +8,7 @@ moduleForComponent('paper-icon', 'Integration | Component | paper icon', {
 test('it renders with tag name', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{paper-icon icon="check"}}`);
+  this.render(hbs`{{paper-icon "check"}}`);
 
   assert.ok(this.$('md-icon').length);
 });


### PR DESCRIPTION
We can support only the `{{paper-icon "someIcon"}}` format in `1.0.0` as it's a major version bump.

This adds a deprecation warning for those using version `<1.0.0`. It uses `Ember.deprecate` with a deprecation ID so it can be managed using [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) for those who might want to remain on `<1.0.0` but not see the deprecations.