### PR TITLE
[1.0.0] Remove old non-positional-param usage of paper-icon

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -6,14 +6,8 @@ let PaperIconComponent = Ember.Component.extend(ColorMixin, {
   classNames: ['paper-icon', 'md-font', 'material-icons', 'md-default-theme'],
   classNameBindings: ['sizeClass', 'spinClass'],
 
-  icon: '',
   spin: false,
   reverseSpin: false,
-
-  iconClass: Ember.computed('icon', 'positionalIcon', function() {
-    let icon = this.getWithDefault('positionalIcon', this.get('icon'));
-    return icon;
-  }),
 
   spinClass: Ember.computed('spin', 'reverseSpin', function() {
     if (this.get('spin')) {
@@ -42,8 +36,7 @@ let PaperIconComponent = Ember.Component.extend(ColorMixin, {
 });
 
 PaperIconComponent.reopenClass({
-  positionalParams: ['positionalIcon']
+  positionalParams: ['icon']
 });
 
 export default PaperIconComponent;
-

--- a/app/templates/components/paper-icon.hbs
+++ b/app/templates/components/paper-icon.hbs
@@ -1,1 +1,1 @@
-{{iconClass}}
+{{~icon~}}

--- a/tests/integration/components/paper-icon-test.js
+++ b/tests/integration/components/paper-icon-test.js
@@ -8,7 +8,7 @@ moduleForComponent('paper-icon', 'Integration | Component | paper icon', {
 test('it renders with tag name', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{paper-icon icon="check"}}`);
+  this.render(hbs`{{paper-icon "check"}}`);
 
   assert.ok(this.$('md-icon').length);
 });


### PR DESCRIPTION
Also removes `iconClass` and just uses `icon` as it is no longer being used as a class.

If we're going to remove support for an existing syntax we should probably add a deprecation warning for older versions to help developers who are upgrading. See #288 for a PR addressing this.