### PR TITLE
Add aria-label support to `paper-icon`

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -5,6 +5,7 @@ var PaperIconComponent = Ember.Component.extend(ColorMixin, {
   tagName: 'md-icon',
   classNames: ['paper-icon', 'md-font', 'material-icons', 'md-default-theme'],
   classNameBindings: ['iconClass', 'sizeClass', 'spinClass'],
+  attributeBindings: ['aria-label'],
 
   icon: '',
   spin: false,
@@ -14,6 +15,8 @@ var PaperIconComponent = Ember.Component.extend(ColorMixin, {
     var icon = this.getWithDefault('positionalIcon', this.get('icon'));
     return Ember.String.dasherize(icon);
   }),
+
+  'aria-label': Ember.computed.reads('iconClass'),
 
   spinClass: Ember.computed('spin', 'reverseSpin', function() {
     if (this.get('spin')) {

--- a/tests/integration/components/paper-icon-test.js
+++ b/tests/integration/components/paper-icon-test.js
@@ -84,3 +84,33 @@ test('it renders with size class', function(assert) {
   this.set('size', 5);
   assert.ok($component.hasClass('md-5x'));
 });
+
+test('it renders with a default aria-label of the icon', function(assert) {
+  assert.expect(2);
+
+  this.set('icon', 'foo-bar');
+  this.render(hbs`{{paper-icon icon}}`);
+
+  let $component = this.$('md-icon');
+
+  assert.equal($component.attr('aria-label'), 'foo-bar');
+
+  this.set('icon', 'bar-baz');
+
+  assert.equal($component.attr('aria-label'), 'bar-baz');
+});
+
+test('it renders with a provided aria-label', function(assert) {
+  assert.expect(2);
+
+  this.set('ariaLabel', 'foo-bar');
+  this.render(hbs`{{paper-icon "check" aria-label=ariaLabel}}`);
+
+  let $component = this.$('md-icon');
+
+  assert.equal($component.attr('aria-label'), 'foo-bar');
+
+  this.set('ariaLabel', 'bar-baz');
+
+  assert.equal($component.attr('aria-label'), 'bar-baz');
+});


### PR DESCRIPTION
Closes #276.

A back-port of #290.