### PR TITLE
Run JSCS on addon folder in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
+  - "npm install -g jscs"
 
 install:
   - npm install -g bower

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ install:
 
 script:
   - ember try $EMBER_TRY_SCENARIO test
+  - jscs -c .jscsrc addon


### PR DESCRIPTION
This is to work around an ember-cli issue where the addon folder is not being linted. We should probably remove this line once it is fixed upstream.

If this PR is implemented correctly, it should *fail* the automated Travis testing.