### PR TITLE
Fix #299: Regression cause by array spread with jQuery objects.

### DIFF
--- a/addon/components/paper-autocomplete-list.js
+++ b/addon/components/paper-autocomplete-list.js
@@ -79,7 +79,7 @@ export default Ember.Component.extend({
     }
 
     let ul = this.$();
-    let li  = ul.find(`li:eq(${this.get('selectedIndex')})`)[0];
+    let li  = ul.find(`li:eq(${this.get('selectedIndex')})`).get(0);
     let top = li.offsetTop;
     let bot = top + li.offsetHeight;
     let hgt = ul[0].clientHeight;

--- a/addon/components/paper-autocomplete-list.js
+++ b/addon/components/paper-autocomplete-list.js
@@ -79,7 +79,7 @@ export default Ember.Component.extend({
     }
 
     let ul = this.$();
-    let [li]  = ul.find(`li:eq(${this.get('selectedIndex')})`);
+    let li  = ul.find(`li:eq(${this.get('selectedIndex')})`)[0];
     let top = li.offsetTop;
     let bot = top + li.offsetHeight;
     let hgt = ul[0].clientHeight;

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -36,7 +36,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
 
   setupTextarea() {
     let textarea = this.$().children('textarea').first();
-    let textareaNode = textarea[0];
+    let textareaNode = textarea.get(0);
     let container = this.get('element');
     let minRows = NaN;
     let lineHeight = null;

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -36,7 +36,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
 
   setupTextarea() {
     let textarea = this.$().children('textarea').first();
-    let [textareaNode] = textarea;
+    let textareaNode = textarea[0];
     let container = this.get('element');
     let minRows = NaN;
     let lineHeight = null;

--- a/addon/components/paper-menu.js
+++ b/addon/components/paper-menu.js
@@ -44,9 +44,9 @@ export default PaperMenuAbstract.extend({
 
   positionMenu(el) {
     // containerNode = wrapper
-    let containerNode = el[0];
+    let containerNode = el.get(0);
     // md-menu-content / any other child.z
-    let openMenuNode = containerNode.firstElementChild;
+    let openMenuNode = el[0].firstElementChild;
     let openMenuNodeRect = openMenuNode.getBoundingClientRect();
     // body
     let boundryNode = document.body;

--- a/addon/components/paper-menu.js
+++ b/addon/components/paper-menu.js
@@ -46,7 +46,7 @@ export default PaperMenuAbstract.extend({
     // containerNode = wrapper
     let containerNode = el.get(0);
     // md-menu-content / any other child.z
-    let openMenuNode = el[0].firstElementChild;
+    let openMenuNode = containerNode.firstElementChild;
     let openMenuNodeRect = openMenuNode.getBoundingClientRect();
     // body
     let boundryNode = document.body;

--- a/addon/components/paper-menu.js
+++ b/addon/components/paper-menu.js
@@ -44,9 +44,9 @@ export default PaperMenuAbstract.extend({
 
   positionMenu(el) {
     // containerNode = wrapper
-    let [containerNode] = el;
+    let containerNode = el[0];
     // md-menu-content / any other child.z
-    let openMenuNode = el[0].firstElementChild;
+    let openMenuNode = containerNode.firstElementChild;
     let openMenuNodeRect = openMenuNode.getBoundingClientRect();
     // body
     let boundryNode = document.body;

--- a/addon/components/paper-select-core.js
+++ b/addon/components/paper-select-core.js
@@ -114,11 +114,11 @@ export default PaperMenuAbstract.extend({
       contentEl: element.find('md-content')
     };
 
-    let [containerNode] = element;
+    let containerNode = element[0];
     let targetNode = opts.target[0].firstElementChild; // target the label
-    let [parentNode] = opts.parent;
-    let [selectNode] = opts.selectEl;
-    let [contentNode] = opts.contentEl;
+    let parentNode = opts.parent[0];
+    let selectNode = opts.selectEl[0];
+    let contentNode = opts.contentEl[0];
     let parentRect = parentNode.getBoundingClientRect();
     let targetRect = targetNode.getBoundingClientRect();
     let shouldOpenAroundTarget = false;

--- a/addon/components/paper-select-core.js
+++ b/addon/components/paper-select-core.js
@@ -114,11 +114,11 @@ export default PaperMenuAbstract.extend({
       contentEl: element.find('md-content')
     };
 
-    let containerNode = element[0];
+    let containerNode = element.get(0);
     let targetNode = opts.target[0].firstElementChild; // target the label
-    let parentNode = opts.parent[0];
-    let selectNode = opts.selectEl[0];
-    let contentNode = opts.contentEl[0];
+    let parentNode = opts.parent.get(0);
+    let selectNode = opts.selectEl.get(0);
+    let contentNode = opts.contentEl.get(0);
     let parentRect = parentNode.getBoundingClientRect();
     let targetRect = targetNode.getBoundingClientRect();
     let shouldOpenAroundTarget = false;


### PR DESCRIPTION
#299 reports a regression where `let [x] = someJqueryObject;` raises an exception because Babel expects the right-side expression to be an actual Array or iterable object, which jQuery objects aren't