### PR TITLE
Fixes #296: CSS for class md-spin and md-spin-reverse is missing. Icons don't spin.

### DIFF
--- a/app/styles/ember-paper.scss
+++ b/app/styles/ember-paper.scss
@@ -39,6 +39,35 @@
   padding-right: 5px;
 }
 
+// Icon spinners (not part of angular-material)
+.md-spin {
+   animation: md-spin 1.5s infinite linear;
+}
+
+.md-spin-reverse {
+  animation: md-spin-reverse 1.5s infinite linear;
+}
+
+// Spin
+@keyframes md-spin {
+  0% {
+    transform: rotate(0deg);
+   }
+  100% {
+    transform: rotate(359deg);
+  }
+}
+
+// Spin Reverse
+@keyframes md-spin-reverse {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(-359deg);
+  }
+}
+
 // Core styles
 @import 'color-palette';
 @import 'default-theme';


### PR DESCRIPTION
This PR adds back the CSS which was lost in the conversion to importing from angular-material. I have searched angular-material-source for references to the CSS class md-spin and there are none. 