### PR TITLE
Allow paper-menu's to be displayed with md-dense.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#286](https://github.com/miguelcobain/ember-paper/pull/286) paper-radio no longer has the class `paper-radio`
 - [#286](https://github.com/miguelcobain/ember-paper/pull/286) paper-radio now uses `groupValue` instead of `selected`
 - [#286](https://github.com/miguelcobain/ember-paper/pull/286) paper-radio now sends the action `onchange` instead of `changed` and it is mandatory (see ddau)
+- [#303](https://github.com/miguelcobain/ember-paper/pull/303) paper-menu template may now specify `dense=true` to display menu items compactly 
 
 ### 0.2.11
 

--- a/addon/components/paper-menu-content-pane.js
+++ b/addon/components/paper-menu-content-pane.js
@@ -7,8 +7,10 @@ export default Ember.Component.extend({
   constants: Ember.inject.service(),
 
   classNames: ['md-default-theme'],
+  classNameBindings: ['dense:md-dense'],
   attributeBindings: ['width'],
   width: 4,
+  dense: false,
 
   menuAbstract: Ember.computed(function() {
     let container = this.nearestOfType(PaperMenuAbstract);

--- a/app/templates/components/paper-menu-content.hbs
+++ b/app/templates/components/paper-menu-content.hbs
@@ -1,4 +1,4 @@
-{{#paper-menu-content-pane width=width}}
+{{#paper-menu-content-pane width=width dense=dense}}
   {{yield this}}
 {{/paper-menu-content-pane}}
 {{#ember-wormhole to="paper-wormhole"}}

--- a/app/templates/components/paper-menu.hbs
+++ b/app/templates/components/paper-menu.hbs
@@ -1,6 +1,6 @@
 {{yield this}}
 {{#if isOpen}}
-  {{#paper-menu-content width=width}}
+  {{#paper-menu-content width=width dense=dense}}
     {{yield to="inverse"}}
   {{/paper-menu-content}}
 {{/if}}


### PR DESCRIPTION
Angular defines a md-dense style, but because it needs to be applied in the paper-menu-content-pane, which is in the paper-menu-content, which is in turn in the paper-menu, there is no easy way for md-dense to be specified. This PR adds a "dense=true" option to paper-menu, which "bubbles down" (sinks??) down to the paper-menu-content-pane, where it adds the required class.