### PR TITLE
auto-complete: added guards to fix errors

### DIFF
--- a/addon/components/paper-autocomplete-list.js
+++ b/addon/components/paper-autocomplete-list.js
@@ -78,11 +78,21 @@ export default Ember.Component.extend({
       return;
     }
 
-    var ul = this.$(),
-      li  = ul.find('li:eq('+this.get('selectedIndex')+')')[0],
-      top = li.offsetTop,
-      bot = top + li.offsetHeight,
-      hgt = ul[0].clientHeight;
+    const ul = this.$();
+
+    if (!ul) {
+        return;
+    }
+
+    const li = ul.find('li:eq('+this.get('selectedIndex')+')')[0];
+
+    if (!li) {
+        return;
+    }
+
+    const top = li.offsetTop,
+                bot = top + li.offsetHeight,
+                hgt = ul[0].clientHeight;
     if (top < ul[0].scrollTop) {
       ul[0].scrollTop = top;
     } else if (bot > ul[0].scrollTop + hgt) {

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -115,8 +115,12 @@ export default Ember.Component.extend(HasBlockMixin, {
       this.set('previousSearchText', searchText);
     }
   }),
-  
+
   modelDidChange: Ember.observer('model', function() {
+    if (!this.get('model')) {
+        return;
+    }
+
     var model = this.get('model');
     var value = this.lookupLabelOfItem(model);
     // First set previousSearchText then searchText ( do not trigger observer only update value! ).
@@ -220,7 +224,7 @@ export default Ember.Component.extend(HasBlockMixin, {
   shouldHide: Ember.computed.not('isMinLengthMet'),
 
   isMinLengthMet: Ember.computed('searchText', 'minLength', function() {
-   return this.get('searchText').length >= this.get('minLength');
+   return this.get('searchText') ? this.get('searchText').length >= this.get('minLength') : false;
   }),
 
   /**


### PR DESCRIPTION
I had a lot of trouble with `{{paper-autocomplete}}` when following the documentation here: http://miguelcobain.github.io/ember-paper/#/autocomplete. I was not doing anything extremely novel or divergent from given examples. I had a very simple component definition, returning a promise as the source. 

Issues:
- Undefined `searchText` in `isMinLengthMet`, triggered when focusing on the component.
- `modelDidChange` will attempt to look up the label of a nulled out model. The odd symptom of this is that the first character typed into the input does not appear.
- `observeIndex` may be triggered before suggested elements appear in the DOM, triggering errors on either `ul.find` or `li.offsetTop`.

I found that a few guards were missing, and adding just a couple of additional checks makes the component more robust (at least for my needs).