### PR TITLE
Move `paper-wormhole` div out of head tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#307](https://github.com/miguelcobain/ember-paper/pull/307) Add paper-card title components
 - [#283](https://github.com/miguelcobain/ember-paper/pull/283) Adds support for `fullTextSearch` attribute on `{{paper-autocomplete}}`. Enables passing Promises to the `model` attribute on `{{paper-autocomplete}}`. Docs updated.
+- [#311](https://github.com/miguelcobain/ember-paper/pull/311) Fixed issue with `paper-wormhole` div in `<head>` tag.
 
 ### 0.2.11
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     app.import('vendor/propagating.js');
   },
   contentFor: function(type) {
-    if (type === 'head') {
+    if (type === 'body') {
       return "<div id='paper-wormhole'></div>";
     }
   },


### PR DESCRIPTION
The `paper-wormhole` div is currently insterted into the `<head>` of the index.html page,
which causes DOM parsing problems for browsers. The `div` element cannot appear in the
`<head>`, and causes Chrome to move the `<body>` tag up to enclose the first `<div>`, breaking
all subsequent `<head>` tags (favicons meta, etc.)

This change places the tag as the first element in the `<body>` tag, which should
be equivalent for Paper.