### PR TITLE
Remove inverse template for autocomplete as it doesnt accept parameters

### DIFF
--- a/app/templates/components/paper-autocomplete.hbs
+++ b/app/templates/components/paper-autocomplete.hbs
@@ -49,7 +49,7 @@
               {{yield searchText item index}}
             {{else}}
               {{#if itemComponent}}
-                {{component itemComponent searchText=searchText label=label index=index}}
+                {{component itemComponent searchText=searchText item=item index=index}}
               {{else}}
                 {{paper-autocomplete-highlight searchText=searchText label=label}}
               {{/if}}

--- a/app/templates/components/paper-autocomplete.hbs
+++ b/app/templates/components/paper-autocomplete.hbs
@@ -58,15 +58,11 @@
 
         {{else}}
           {{#if showLoadingBar}}
-          {{!-- Render block template, then named component then default --}}
-            {{#if hasBlock}}
-                <li>{{yield searchText to="inverse"}}</li>
+          {{!-- Render named component then default --}}
+            {{#if notFoundComponent}}
+                <li>{{component notFoundComponent searchText=searchText}}</li>
             {{else}}
-              {{#if notFoundComponent}}
-                  <li>{{component notFoundComponent searchText=searchText}}</li>
-              {{else}}
-                  <li>{{notFoundMsg}}</li>
-              {{/if}}
+                <li>{{notFoundMsg}}</li>
             {{/if}}
           {{/if}}
         {{/each}}

--- a/tests/dummy/app/templates/autocomplete.hbs
+++ b/tests/dummy/app/templates/autocomplete.hbs
@@ -177,13 +177,11 @@
 
 <h3>Template</h3>
 {{#code-block language="handlebars"}}
-\{{#paper-autocomplete minLength=0 placeholder="Type e.g. ember, paper, one, two etc." source=arrayOfItems model=fourthModel as |searchText item index|}}}
+\{{#paper-autocomplete minLength=0 placeholder="Type e.g. ember, paper, one, two etc." source=arrayOfItems model=fourthModel notFoundMessage="Whoops! Could not find \"%@\." as |searchText item index|}}}
   &lt;span class="item-title"&gt;
     \{{paper-icon "star"}}
   &lt;span&gt; \{{paper-autocomplete-highlight searchText=searchText label=item}} &lt;/span&gt;
   &lt;/span&gt;
-\{{else}}
-  Whoops! Could not find "\{{searchText}}".
 \{{/paper-autocomplete}}{{/code-block}}
 
 <p>The custom template receives <strong>3 block parameters</strong> (searchText, item and index).
@@ -192,8 +190,8 @@
 <ul>
   <li><strong>searchText</strong> This is the original searchText from the user.</li>
   <li><strong>item</strong> This is the item directly from the source array. If it is an object you would forexample
-  need to reference it with <code>\{{item.name}}</code>. Not defined in the inverse template.</li>
-  <li><strong>index</strong> This is the index of the suggestions that are currently in the list. Not defined in the inverse template.</li>
+  need to reference it with <code>\{{item.name}}</code>.</li>
+  <li><strong>index</strong> This is the index of the suggestions that are currently in the list.</li>
 </ul>
 
 <h2>Blockless Custom template</h2>


### PR DESCRIPTION
Inverse component templates can not recieve parameters. This means
there is no access to `searchText` in the inverse block.

- Removed inverse template rendering. Instead try to render
notFoundComponent then default to notFoundMsg
- Update documentation app to reflect these changes

See: https://github.com/emberjs/ember.js/pull/11084