### PR TITLE
Dialog API buff-up.

### DIFF
--- a/addon/components/paper-dialog-inner.js
+++ b/addon/components/paper-dialog-inner.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
 import Translate3dMixin from '../mixins/translate3d-mixin';
-import PaperDialog from './paper-dialog';
 
-const { Component, computed, $ } = Ember;
+const { Component } = Ember;
 
 export default Component.extend(Translate3dMixin, {
   tagName: 'md-dialog',
@@ -19,8 +18,10 @@ export default Component.extend(Translate3dMixin, {
     }
   },
 
-  onTranslateToEnd(origin) {
-    $(origin).focus();
+  onTranslateToEnd($origin) {
+    if ($origin) {
+      $origin.focus();
+    }
   },
 
   click(ev) {

--- a/addon/components/paper-dialog.js
+++ b/addon/components/paper-dialog.js
@@ -5,8 +5,7 @@ const {
   Component,
   computed,
   inject: { service },
-  isEmpty,
-  guidFor
+  isEmpty
 } = Ember;
 
 export default Component.extend({
@@ -38,7 +37,7 @@ export default Component.extend({
     }
     let id = $parent.attr('id');
     if (!id) {
-      id = guidFor(this);
+      id = `${this.elementId}-parent`;
       $parent.get(0).id = id;
     }
     return id;

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -58,7 +58,9 @@ export default Mixin.create({
       // Set the `main` styles and run the transition-in styles
       run.next(() => {
         this.waitTransitionEnd($(this.element)).then(() => {
-          this.onTranslateFromEnd();
+          if (!this.get('isDestroying') && !this.get('isDestroyed')) {
+            this.onTranslateFromEnd();
+          }
         });
         this.set('transformStyleApply', 'main');
         this.set('transformIn', true);

--- a/app/templates/components/paper-dialog.hbs
+++ b/app/templates/components/paper-dialog.hbs
@@ -1,4 +1,4 @@
-{{#ember-wormhole to=destination}}
+{{#ember-wormhole to=destinationId}}
   {{paper-backdrop
     locked-open=isLockedOpen
     opaque=true
@@ -8,10 +8,10 @@
   }}
   {{#paper-dialog-container outsideClicked=(action "outsideClicked")}}
     {{#paper-dialog-inner
-      parentElement=parentElementSelector
       origin=origin
-      openFrom=openFrom
-      closeTo=closeTo
+      defaultedParent=defaultedParent
+      defaultedOpenFrom=defaultedOpenFrom
+      defaultedCloseTo=defaultedCloseTo
       fullscreen=fullscreen
       clickOutsideToClose=clickOutsideToClose
       focusOnOpen=focusOnOpen

--- a/tests/dummy/app/controllers/dialog.js
+++ b/tests/dummy/app/controllers/dialog.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
+const { $ } = Ember;
 
 export default Ember.Controller.extend({
   actions: {
 
     /* Dialog with parent */
     openDialogWithParent(param, event) {
-      this.set('dialogOrigin', event.currentTarget);
+      this.set('dialogOrigin', $(event.currentTarget));
       this.set('showDialogWithParent', true);
     },
 
@@ -16,7 +17,7 @@ export default Ember.Controller.extend({
 
     /* Dialog */
     openDialog(param, event) {
-      this.set('dialogOrigin', event.currentTarget);
+      this.set('dialogOrigin', $(event.currentTarget));
       this.set('showDialog', true);
     },
 
@@ -27,8 +28,8 @@ export default Ember.Controller.extend({
 
     /* Prompt dialog */
     dogName: '',
-    openPromptDialog(param, event) {
-      this.set('dialogOrigin', event.currentTarget);
+    openPromptDialog(/* param, event */) {
+      this.set('dialogOrigin', null);
       this.set('showPromptDialog', true);
     },
 

--- a/tests/dummy/app/templates/dialog.hbs
+++ b/tests/dummy/app/templates/dialog.hbs
@@ -23,7 +23,7 @@
         {{#code-block language="handlebars"}}\{{#if showDialogWithParent}}
   \{{#paper-dialog
       onClose=(action "closeDialogWithParent" "cancel")
-      parent="paper-dialog-demo"
+      parent="#paper-dialog-demo"
       origin=dialogOrigin
       clickOutsideToClose=true}}
     &lt;form&gt;
@@ -136,7 +136,7 @@
               </tr>
               <tr>
                 <td><strong>parent</strong></td>
-                <td>id</td>
+                <td>jQuery object or selector</td>
                 <td>existing element where the modal and backdrop will be rendered</td>
               </tr>
               <tr>
@@ -146,7 +146,7 @@
               </tr>
               <tr>
                 <td><strong>origin</strong></td>
-                <td>selector</td>
+                <td>jQuery object or selector</td>
                 <td>
                   if present, the dialog will use it as openFrom and closeTo. Also,
                   focus will be returned to this element once the dialog closes.
@@ -154,12 +154,12 @@
               </tr>
               <tr>
                 <td><strong>openFrom</strong></td>
-                <td>selector</td>
+                <td>jQuery object or selector</td>
                 <td>source for opening the dialog with a transition</td>
               </tr>
               <tr>
                 <td><strong>closeTo</strong></td>
-                <td>selector</td>
+                <td>jQuery object or selector</td>
                 <td>target for closing the dialog with a transition</td>
               </tr>
               <tr>
@@ -196,7 +196,7 @@
 {{/paper-content}}
 
 {{#if showDialogWithParent}}
-  {{#paper-dialog onClose=(action "closeDialogWithParent" "cancel") parent="paper-dialog-demo" origin=dialogOrigin clickOutsideToClose=true}}
+  {{#paper-dialog onClose=(action "closeDialogWithParent" "cancel") parent="#paper-dialog-demo" origin=dialogOrigin clickOutsideToClose=true}}
     <form>
       {{#paper-toolbar}}
         <div class="md-toolbar-tools">

--- a/tests/dummy/app/templates/dialog.hbs
+++ b/tests/dummy/app/templates/dialog.hbs
@@ -140,11 +140,6 @@
                 <td>existing element where the modal and backdrop will be rendered</td>
               </tr>
               <tr>
-                <td><strong>fullscreen</strong></td>
-                <td>boolean</td>
-                <td>if true dialog becomes fullscreen at smaller breakpoints</td>
-              </tr>
-              <tr>
                 <td><strong>origin</strong></td>
                 <td>jQuery object or selector</td>
                 <td>
@@ -161,6 +156,11 @@
                 <td><strong>closeTo</strong></td>
                 <td>jQuery object or selector</td>
                 <td>target for closing the dialog with a transition</td>
+              </tr>
+              <tr>
+                <td><strong>fullscreen</strong></td>
+                <td>boolean</td>
+                <td>if true dialog becomes fullscreen at smaller breakpoints</td>
               </tr>
               <tr>
                 <td><strong>clickOutsideToClose</strong></td>

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -57,7 +57,7 @@ test('should render in specific wormhole if parent is defined', function(assert)
   this.render(hbs`
     <div id="paper-wormhole"></div>
     <div id="sagittarius-a"></div>
-    {{#paper-dialog parent="sagittarius-a"}}
+    {{#paper-dialog parent="#sagittarius-a"}}
       So this is singularity, eh?
     {{/paper-dialog}}
   `);
@@ -69,7 +69,7 @@ test('should render in specific wormhole if parent is defined', function(assert)
 test('should only prevent scrolling behind scoped modal', function(assert) {
   this.render(hbs`
     <div id="sagittarius-a"></div>
-    {{paper-dialog parent="sagittarius-a"}}
+    {{paper-dialog parent="#sagittarius-a"}}
   `);
 
   assert.equal(this.$('md-backdrop').css('position'), 'absolute', 'backdrop is absolute');
@@ -98,23 +98,24 @@ test('applies transitions when opening and closing', function(assert) {
   this.set('dialogOpen', true);
 
   let getDialogTransform = () => {
-    let dialogStyle = this.$('md-dialog').get(0).style;
-    return dialogStyle.webkitTransform || dialogStyle.transform;
+    let dialog = this.$('md-dialog').get(0);
+    assert.ok(dialog, 'dialog found');
+    return dialog && (dialog.style.webkitTransform || dialog.style.transform);
   };
 
   let dialogTransform = getDialogTransform();
-  assert.ok(dialogTransform.indexOf('translate3d') !== -1);
+  assert.ok(dialogTransform.indexOf('translate3d') !== -1, 'open translate was added');
 
   return wait().then(() => {
     let dialogTransform = getDialogTransform();
-    assert.ok(!dialogTransform, 'translate was removed');
+    assert.ok(!dialogTransform, 'open translate was removed');
 
     this.set('dialogOpen', false);
 
     return wait();
   }).then(() => {
     let dialogTransform = getDialogTransform();
-    assert.ok(dialogTransform.indexOf('translate3d') !== -1, 'translate was added');
+    assert.ok(dialogTransform.indexOf('translate3d') !== -1, 'close translate was added');
   });
 });
 


### PR DESCRIPTION
`parent`, `origin`, `openFrom`, `closeTo` are all optional and all take a jQuery selector or jQuery object.

I found the original API inconsistent and inconvenient in actual use. This PR normalized the API and cleans up some old code remnants. 

Note that `parent` is *not* an id, but a jQuery selector or object. An id is created, if needed, for `{{ember-wormhole}}`.