### PR TITLE
paper-menu: update paper-menu-abstract to ES6 and add onOpenMenu/onCloseMenu

### DIFF
--- a/addon/components/paper-menu-content-pane.js
+++ b/addon/components/paper-menu-content-pane.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import PaperMenuAbstract from './paper-menu-abstract';
 
-export default Ember.Component.extend({
+const { $, Component, inject: { service }, run: { later } } = Ember;
+
+export default Component.extend({
   tagName: 'md-menu-content',
 
-  constants: Ember.inject.service(),
+  constants: service(),
 
   classNames: ['md-default-theme'],
   classNameBindings: ['dense:md-dense'],
@@ -12,16 +14,16 @@ export default Ember.Component.extend({
   width: 4,
   dense: false,
 
-  menuAbstract: Ember.computed(function() {
-    let container = this.nearestOfType(PaperMenuAbstract);
-    return container;
-  }),
-
+  // menuAbstract: Ember.computed(function() {
+  //   let container = this.nearestOfType(PaperMenuAbstract);
+  //   return container;
+  // }),
+  //
   keyDown(ev) {
     let KeyCodes = this.get('constants').KEYCODE;
     switch (ev.keyCode) {
       case KeyCodes.get('ESCAPE'):
-        this.get('menuAbstract').send('toggleMenu');
+        this.nearestOfType(PaperMenuAbstract).send('toggleMenu');
         break;
       case KeyCodes.get('UP_ARROW'):
         this.focusMenuItem(ev, -1);
@@ -33,23 +35,21 @@ export default Ember.Component.extend({
   },
 
   didInsertElement() {
-    let _self = this;
     // kick off initial focus in the menu on the first element
-
-    Ember.run.later(function() {
-      let focusTarget = _self.$().find('.md-menu-focus-target');
+    later(() => {
+      let focusTarget = this.$().find('.md-menu-focus-target');
       if (!focusTarget.length) {
-        focusTarget = _self.$().children().eq(0).children().eq(0);
+        focusTarget = this.$().children().eq(0).children().eq(0);
       }
       focusTarget.focus();
     });
   },
 
   focusMenuItem(e, direction) {
-    let currentItem = Ember.$(e.target).closest('md-menu-item');
+    let currentItem = $(e.target).closest('md-menu-item');
 
     let children = this.$().children();
-    let items = Ember.$.makeArray(children);
+    let items = $.makeArray(children);
     let currentIndex = children.index(currentItem);
 
     // Traverse through our elements in the specified direction (+/-1) and try to
@@ -71,30 +71,6 @@ export default Ember.Component.extend({
         return false;
       }
     }
-  },
-
-  checkClickTarget(e) {
-    let { target } = e;
-
-    // Traverse up the event until we get to the menuAbstract to see
-    // if there is a click and that the element is not disabled
-    do {
-      if (target === this.get('element')) {
-        return;
-      }
-
-      if (target.hasAttribute('action')) {
-        if (!target.hasAttribute('disabled')) {
-          this.get('menuAbstract').send('toggleMenu');
-        }
-        break;
-      }
-    } while (target = target.parentNode);
-
-  },
-
-  click(e) {
-    this.checkClickTarget(e);
   }
 
 });

--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -1,10 +1,14 @@
 import Ember from 'ember';
+import PaperMenuAbstract from './paper-menu-abstract';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-menu-item',
 
   actions: {
     action() {
+      this.nearestOfType(PaperMenuAbstract).send('toggleMenu');
       this.sendAction('action', this.get('param'));
     }
   }


### PR DESCRIPTION
This is just a minor update to this one file to allow my development to proceed. It adds two actions: `onMenuOpen` and `onMenuClose`. I would have named these `onOpen` and `onClose` but for the existing attribute `onMenu`, which accepts a promise that yields menu items.

@miguelcobain: My hope is to merge this into `wip/v1.0.0` as a minor update, rather than taking on all of the menu-related components right now.

To-do:
Consider renaming `onMenu` to `getItems` so that the actions can be `onOpen` and `onClose`.