### PR TITLE
Fix SRI issue #224

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "demoURL": "https://miguelcobain.github.io/ember-paper"
+    "demoURL": "https://miguelcobain.github.io/ember-paper",
+    "before": "ember-cli-sri"
   }
 }


### PR DESCRIPTION
ember-paper runs autoprefixer in a postprocessTree hook, it therefore must run before ember-cli-sri or sri errors will ensue