### PR TITLE
paper-card: implementation for v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Contributions and pull requests are always welcome. Contributors may often be fo
   - paper-select now uses attribute `itemLabelCallback` instead of `item-label-callback`.
   - paper-select now uses attribute `getItems` instead of `on-open`.
   - paper-menu now uses attribute `isOpen` instead of `is-open`.
+- [#338](https://github.com/miguelcobain/ember-paper/pull/338)
+  - paper-card now uses contextual components. The old paper-card-content and paper-card-title components still work.
+  - paper-card now supports the same configurations as the [Angular Material](https://material.angularjs.org/1.0.6/demo/card) version.
 
 ### 0.2.11
 

--- a/addon/components/paper-card-actions.js
+++ b/addon/components/paper-card-actions.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import FlexMixin from '../mixins/flex-mixin';
+
+const { Component, computed, String: Str } = Ember;
+
+export default Component.extend({
+  tagName: '',
+
+  layout: 'row',
+  layoutAlign: 'end center',
+
+  layoutAlignClassName: computed('layoutAlign', function() {
+    return Str.dasherize(this.get('layoutAlign'));
+  })
+});

--- a/addon/components/paper-card-actions.js
+++ b/addon/components/paper-card-actions.js
@@ -1,15 +1,20 @@
 import Ember from 'ember';
-import FlexMixin from '../mixins/flex-mixin';
 
-const { Component, computed, String: Str } = Ember;
+const { Component } = Ember;
 
 export default Component.extend({
-  tagName: '',
+  tagName: 'md-card-actions',
+  classNameBindings: ['defaultClasses'],
 
-  layout: 'row',
-  layoutAlign: 'end center',
+  didReceiveAttrs() {
+    this._super(...arguments);
 
-  layoutAlignClassName: computed('layoutAlign', function() {
-    return Str.dasherize(this.get('layoutAlign'));
-  })
+    // if the consumer didn't set layout classes, we should set them
+    // to the default (layout = row, layout align = end center)
+    let providedClasses = this.get('class');
+
+    if (!providedClasses || providedClasses.indexOf('layout-') === -1) {
+      this.set('defaultClasses', 'layout-row layout-align-end-center');
+    }
+  }
 });

--- a/addon/components/paper-card-avatar.js
+++ b/addon/components/paper-card-avatar.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-card-avatar'
 });

--- a/addon/components/paper-card-avatar.js
+++ b/addon/components/paper-card-avatar.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'md-card-avatar'
+});

--- a/addon/components/paper-card-content.js
+++ b/addon/components/paper-card-content.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
-import FlexMixin from '../mixins/flex-mixin';
 
-export default Ember.Component.extend(FlexMixin, {
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-card-content',
   classNames: ['paper-card-content']
 });

--- a/addon/components/paper-card-content.js
+++ b/addon/components/paper-card-content.js
@@ -3,6 +3,5 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card-content',
-  classNames: ['paper-card-content']
+  tagName: 'md-card-content'
 });

--- a/addon/components/paper-card-header-content.js
+++ b/addon/components/paper-card-header-content.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+const { Component, computed } = Ember;
+
+export default Component.extend({
+  tagName: 'span',
+  classNameBindings: ['mdType'],
+
+  type: '',
+
+  mdType: computed('type', function() {
+    let type = this.get('type');
+    return type.length ? `md-${type}` : '';
+  })
+});

--- a/addon/components/paper-card-header-text.js
+++ b/addon/components/paper-card-header-text.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import FlexMixin from '../mixins/flex-mixin';
+
+export default Ember.Component.extend(FlexMixin, {
+  tagName: 'md-card-header-text',
+  classNames: ['paper-card-header-text']
+});

--- a/addon/components/paper-card-header-text.js
+++ b/addon/components/paper-card-header-text.js
@@ -3,6 +3,5 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card-header-text',
-  classNames: ['paper-card-header-text']
+  tagName: 'md-card-header-text'
 });

--- a/addon/components/paper-card-header-text.js
+++ b/addon/components/paper-card-header-text.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
-import FlexMixin from '../mixins/flex-mixin';
 
-export default Ember.Component.extend(FlexMixin, {
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-card-header-text',
   classNames: ['paper-card-header-text']
 });

--- a/addon/components/paper-card-header.js
+++ b/addon/components/paper-card-header.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
-import FlexMixin from '../mixins/flex-mixin';
 
-export default Ember.Component.extend(FlexMixin, {
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-card-header',
   classNames: ['paper-card-header']
 });

--- a/addon/components/paper-card-header.js
+++ b/addon/components/paper-card-header.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 import FlexMixin from '../mixins/flex-mixin';
 
 export default Ember.Component.extend(FlexMixin, {
-  tagName: 'md-card-footer',
-  classNames: ['paper-card-footer']
+  tagName: 'md-card-header',
+  classNames: ['paper-card-header']
 });

--- a/addon/components/paper-card-icon-actions.js
+++ b/addon/components/paper-card-icon-actions.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  tagName: 'md-card-icon-actions'
+});

--- a/addon/components/paper-card-image.js
+++ b/addon/components/paper-card-image.js
@@ -3,5 +3,7 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card-header'
+  tagName: 'img',
+  classNames: ['md-card-image'],
+  attributeBindings: ['src', 'title', 'alt']
 });

--- a/addon/components/paper-card-media.js
+++ b/addon/components/paper-card-media.js
@@ -3,5 +3,7 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card-header'
+  tagName: '',
+
+  size: 'md'
 });

--- a/addon/components/paper-card-title-media.js
+++ b/addon/components/paper-card-title-media.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  tagName: 'md-card-title-media'
+});

--- a/addon/components/paper-card-title-media.js
+++ b/addon/components/paper-card-title-media.js
@@ -3,5 +3,7 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card-title-media'
+  tagName: 'md-card-title-media',
+
+  size: 'md'
 });

--- a/addon/components/paper-card-title-text.js
+++ b/addon/components/paper-card-title-text.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  tagName: 'md-card-title-text'
+});

--- a/addon/components/paper-card-title.js
+++ b/addon/components/paper-card-title.js
@@ -3,6 +3,5 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card-title',
-  classNames: ['paper-card-title']
+  tagName: 'md-card-title'
 });

--- a/addon/components/paper-card-title.js
+++ b/addon/components/paper-card-title.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
-import FlexMixin from '../mixins/flex-mixin';
 
-export default Ember.Component.extend(FlexMixin, {
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-card-title',
   classNames: ['paper-card-title']
 });

--- a/addon/components/paper-card-title.js
+++ b/addon/components/paper-card-title.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import FlexMixin from '../mixins/flex-mixin';
+
+export default Ember.Component.extend(FlexMixin, {
+  tagName: 'md-card-title',
+  classNames: ['paper-card-title']
+});

--- a/addon/components/paper-card.js
+++ b/addon/components/paper-card.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
-import FlexMixin from '../mixins/flex-mixin';
 
-export default Ember.Component.extend(FlexMixin, {
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'md-card',
   classNames: ['paper-card']
 });

--- a/addon/components/paper-card.js
+++ b/addon/components/paper-card.js
@@ -3,6 +3,5 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  tagName: 'md-card',
-  classNames: ['paper-card']
+  tagName: 'md-card'
 });

--- a/app/components/paper-card-actions.js
+++ b/app/components/paper-card-actions.js
@@ -1,0 +1,3 @@
+import PaperCardActions from 'ember-paper/components/paper-card-actions';
+
+export default PaperCardActions;

--- a/app/components/paper-card-avatar.js
+++ b/app/components/paper-card-avatar.js
@@ -1,0 +1,3 @@
+import PaperCardAvatar from 'ember-paper/components/paper-card-avatar';
+
+export default PaperCardAvatar;

--- a/app/components/paper-card-footer.js
+++ b/app/components/paper-card-footer.js
@@ -1,3 +1,0 @@
-import PaperCardFooter from 'ember-paper/components/paper-card-footer';
-
-export default PaperCardFooter;

--- a/app/components/paper-card-header-content.js
+++ b/app/components/paper-card-header-content.js
@@ -1,0 +1,3 @@
+import PaperCardHeaderContent from 'ember-paper/components/paper-card-header-content';
+
+export default PaperCardHeaderContent;

--- a/app/components/paper-card-header-text.js
+++ b/app/components/paper-card-header-text.js
@@ -1,0 +1,3 @@
+import PaperCardHeaderText from 'ember-paper/components/paper-card-header-text';
+
+export default PaperCardHeaderText;

--- a/app/components/paper-card-header.js
+++ b/app/components/paper-card-header.js
@@ -1,0 +1,3 @@
+import PaperCardHeader from 'ember-paper/components/paper-card-header';
+
+export default PaperCardHeader;

--- a/app/components/paper-card-icon-actions.js
+++ b/app/components/paper-card-icon-actions.js
@@ -1,0 +1,3 @@
+import PaperCardIconActions from 'ember-paper/components/paper-card-icon-actions';
+
+export default PaperCardIconActions;

--- a/app/components/paper-card-image.js
+++ b/app/components/paper-card-image.js
@@ -1,0 +1,3 @@
+import PaperCardImage from 'ember-paper/components/paper-card-image';
+
+export default PaperCardImage;

--- a/app/components/paper-card-media.js
+++ b/app/components/paper-card-media.js
@@ -1,0 +1,3 @@
+import PaperCardMedia from 'ember-paper/components/paper-card-media';
+
+export default PaperCardMedia;

--- a/app/components/paper-card-title-media.js
+++ b/app/components/paper-card-title-media.js
@@ -1,0 +1,3 @@
+import PaperCardTitleMedia from 'ember-paper/components/paper-card-title-media';
+
+export default PaperCardTitleMedia;

--- a/app/components/paper-card-title-text.js
+++ b/app/components/paper-card-title-text.js
@@ -1,0 +1,3 @@
+import PaperCardTitleText from 'ember-paper/components/paper-card-title-text';
+
+export default PaperCardTitleText;

--- a/app/components/paper-card-title.js
+++ b/app/components/paper-card-title.js
@@ -1,0 +1,3 @@
+import PaperCardTitle from 'ember-paper/components/paper-card-title';
+
+export default PaperCardTitle;

--- a/app/templates/components/paper-card-actions.hbs
+++ b/app/templates/components/paper-card-actions.hbs
@@ -1,0 +1,3 @@
+<md-card-actions class="{{class}} layout-{{layout}} layout-align-{{layoutAlignClassName}}">
+  {{yield}}
+</md-card-actions>

--- a/app/templates/components/paper-card-actions.hbs
+++ b/app/templates/components/paper-card-actions.hbs
@@ -1,3 +1,0 @@
-<md-card-actions class="{{class}} layout-{{layout}} layout-align-{{layoutAlignClassName}}">
-  {{yield}}
-</md-card-actions>

--- a/app/templates/components/paper-card-actions.hbs
+++ b/app/templates/components/paper-card-actions.hbs
@@ -1,0 +1,3 @@
+{{yield (hash
+  icons=(component 'paper-card-icon-actions')
+)}}

--- a/app/templates/components/paper-card-header-text.hbs
+++ b/app/templates/components/paper-card-header-text.hbs
@@ -1,0 +1,4 @@
+{{yield (hash
+  title=(component 'paper-card-header-content' type='title')
+  subhead=(component 'paper-card-header-content' type='subhead')
+)}}

--- a/app/templates/components/paper-card-header.hbs
+++ b/app/templates/components/paper-card-header.hbs
@@ -1,0 +1,4 @@
+{{yield (hash
+  text=(component 'paper-card-header-text')
+  avatar=(component 'paper-card-avatar')
+)}}

--- a/app/templates/components/paper-card-media.hbs
+++ b/app/templates/components/paper-card-media.hbs
@@ -1,0 +1,7 @@
+{{#if hasBlock}}
+  <div class="md-media-{{size}}">
+    {{yield}}
+  </div>
+{{else}}
+  <img class="md-media-{{size}}" src={{src}} alt={{alt}} title={{title}} />
+{{/if}}

--- a/app/templates/components/paper-card-title-media.hbs
+++ b/app/templates/components/paper-card-title-media.hbs
@@ -1,0 +1,7 @@
+{{#if hasBlock}}
+  <div class="md-media-{{size}}">
+    {{yield}}
+  </div>
+{{else}}
+  <img class="md-media-{{size}}" src={{src}} alt={{alt}} title={{title}} />
+{{/if}}

--- a/app/templates/components/paper-card-title-text.hbs
+++ b/app/templates/components/paper-card-title-text.hbs
@@ -1,0 +1,4 @@
+{{yield (hash
+  headline=(component 'paper-card-header-content' type="headline")
+  subhead=(component 'paper-card-header-content' type="subhead")
+)}}

--- a/app/templates/components/paper-card-title.hbs
+++ b/app/templates/components/paper-card-title.hbs
@@ -1,3 +1,4 @@
-<md-card-title-text>
-  <span class="md-headline">{{yield}}</span>
-</md-card-title-text>
+{{yield (hash
+  text=(component 'paper-card-title-text')
+  media=(component 'paper-card-title-media')
+)}}

--- a/app/templates/components/paper-card-title.hbs
+++ b/app/templates/components/paper-card-title.hbs
@@ -1,0 +1,3 @@
+<md-card-title-text>
+  <span class="md-headline">{{yield}}</span>
+</md-card-title-text>

--- a/app/templates/components/paper-card.hbs
+++ b/app/templates/components/paper-card.hbs
@@ -3,4 +3,6 @@
   content=(component 'paper-card-content')
   actions=(component 'paper-card-actions')
   header=(component 'paper-card-header')
+  image=(component 'paper-card-image')
+  media=(component 'paper-card-media')
 )}}

--- a/app/templates/components/paper-card.hbs
+++ b/app/templates/components/paper-card.hbs
@@ -1,0 +1,6 @@
+{{yield (hash
+  title=(component 'paper-card-title')
+  content=(component 'paper-card-content')
+  actions=(component 'paper-card-actions')
+  header=(component 'paper-card-header')
+)}}

--- a/tests/dummy/app/styles/demo.scss
+++ b/tests/dummy/app/styles/demo.scss
@@ -242,6 +242,12 @@ code.paper {
   }
 }
 
+.card-demo {
+  .card-media {
+    background-color: #999999;
+  }
+}
+
 .grid-list-demo-dynamicTiles {
   md-icon {
     width: 50%;

--- a/tests/dummy/app/styles/demo.scss
+++ b/tests/dummy/app/styles/demo.scss
@@ -245,6 +245,8 @@ code.paper {
 .card-demo {
   .card-media {
     background-color: #999999;
+    height: 100%;
+    width: 100%;
   }
 }
 

--- a/tests/dummy/app/templates/card.hbs
+++ b/tests/dummy/app/templates/card.hbs
@@ -80,9 +80,10 @@
         {{/paper-card}}
       </div>
     </div>
+  {{/paper-content}}
 
-    <h3>Template</h3>
-    {{#code-block language="handlebars"}}
+  <h3>Template</h3>
+  {{#code-block language="handlebars"}}
 &lt;h2>Basic Usage&lt;/h2>
 &lt;div class="layout-row">
   &lt;div class="flex-50">
@@ -153,7 +154,6 @@
     \{{/paper-card}}
   &lt;/div>
 &lt;/div>{{/code-block}}
-  {{/paper-content}}
 
   {{#paper-content class="class-demo"}}
     <h2>Card Action Buttons</h2>
@@ -371,5 +371,192 @@
     \{{/paper-card}}
   &lt;/div>
 &lt;/div>{{/code-block}}
+
+  {{#paper-content class="class-demo"}}
+    <h2>Card Action Buttons</h2>
+    <div class="layout-row">
+      <div class="flex-50">
+        {{#paper-card as |card|}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">In-card mixed actions</span>
+            {{/title.text}}
+          {{/card.title}}
+          {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
+            {{#actions.icons}}
+              {{#paper-button iconButton=true}}{{paper-icon 'favorite'}}{{/paper-button}}
+              {{#paper-button iconButton=true}}{{paper-icon 'share'}}{{/paper-button}}
+            {{/actions.icons}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+        {{/paper-card}}
+
+        {{#paper-card as |card|}}
+          {{#card.header as |header|}}
+            {{#header.avatar}}
+              <img src="tomster.png" alt="tomster" />
+            {{/header.avatar}}
+            {{#header.text}}
+              <span class="md-title">User</span>
+              <span class="md-subhead">subhead</span>
+            {{/header.text}}
+          {{/card.header}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">In-card mixed actions</span>
+              <span class="md-subhead">Reversed</span>
+            {{/title.text}}
+          {{/card.title}}
+          {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+            {{#actions.icons}}
+              {{#paper-button iconButton=true}}{{paper-icon 'expand_less'}}{{/paper-button}}
+            {{/actions.icons}}
+          {{/card.actions}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+        {{/paper-card}}
+      </div>
+
+      <div class="flex-50">
+        {{#paper-card as |card|}}
+          {{#card.header as |header|}}
+            {{#header.avatar}}
+              <img src="tomster.png" alt="tomster" />
+            {{/header.avatar}}
+            {{#header.text}}
+              <span class="md-title">Title</span>
+              <span class="md-subhead">subhead</span>
+            {{/header.text}}
+          {{/card.header}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">In-card mixed actions</span>
+              <span class="md-subhead">Description</span>
+            {{/title.text}}
+          {{/card.title}}
+          {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+        {{/paper-card}}
+      </div>
+    </div>
+  {{/paper-content}}
+
+  <h3>Template</h3>
+  {{#code-block language='handlebars'}}
+&lt;h2>Card Action Buttons&lt;/h2>
+&lt;div class="layout-row">
+  &lt;div class="flex-50">
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">In-card mixed actions&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.actions class="layout-row layout-align-start-center" as |actions|}}
+        \{{#actions.icons}}
+          \{{#paper-button iconButton=true}}\{{paper-icon 'favorite'}}\{{/paper-button}}
+          \{{#paper-button iconButton=true}}\{{paper-icon 'share'}}\{{/paper-button}}
+        \{{/actions.icons}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      \{{#card.header as |header|}}
+        \{{#header.avatar}}
+          &lt;img src="tomster.png" alt="tomster" />
+        \{{/header.avatar}}
+        \{{#header.text}}
+          &lt;span class="md-title">User&lt;/span>
+          &lt;span class="md-subhead">subhead&lt;/span>
+        \{{/header.text}}
+      \{{/card.header}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">In-card mixed actions&lt;/span>
+          &lt;span class="md-subhead">Reversed&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.actions class="layout-row layout-align-start-center" as |actions|}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+        \{{#actions.icons}}
+          \{{#paper-button iconButton=true}}\{{paper-icon 'expand_less'}}\{{/paper-button}}
+        \{{/actions.icons}}
+      \{{/card.actions}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+    \{{/paper-card}}
+  &lt;/div>
+
+  &lt;div class="flex-50">
+    \{{#paper-card as |card|}}
+      \{{#card.header as |header|}}
+        \{{#header.avatar}}
+          &lt;img src="tomster.png" alt="tomster" />
+        \{{/header.avatar}}
+        \{{#header.text}}
+          &lt;span class="md-title">Title&lt;/span>
+          &lt;span class="md-subhead">subhead&lt;/span>
+        \{{/header.text}}
+      \{{/card.header}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">In-card mixed actions&lt;/span>
+          &lt;span class="md-subhead">Description&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.actions class="layout-row layout-align-start-center" as |actions|}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+    \{{/paper-card}}
+  &lt;/div>
+&lt;/div>{{/code-block}}
+
 </div>
 {{/paper-content}}

--- a/tests/dummy/app/templates/card.hbs
+++ b/tests/dummy/app/templates/card.hbs
@@ -9,69 +9,188 @@
 
 {{#paper-content class="md-padding"}}
 <div class="doc-content">
-  {{#paper-content class="md-whiteframe-z1 list-demo"}}
-    {{#paper-card}}
-      <img src="washedout.png" alt="Washed Out">
-      {{#paper-card-content}}
-        <h2>Paracosm</h2>
-        <p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        </p>
-      {{/paper-card-content}}
-      <div class="md-actions" layout="row" layout-align="end center">
-        {{#paper-button}}Action 1{{/paper-button}}
-        {{#paper-button}}Action 2{{/paper-button}}
-      </div>
-    {{/paper-card}}
-    {{#paper-card}}
-      <img src="washedout.png" alt="Washed Out">
-      {{#paper-card-content}}
-        <h2>Paracosm</h2>
-        <p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        </p>
-      {{/paper-card-content}}
-      <div class="md-actions" layout="row" layout-align="end center">
-        {{#paper-button}}Action 1{{/paper-button}}
-        {{#paper-button}}Action 2{{/paper-button}}
+  {{#paper-content class="list-demo"}}
+    <div layout="row">
+      <div layout="column" flex>
+        {{#paper-card as |card|}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title}}Action buttons{{/card.title}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+          {{#card.actions}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
+
+        {{#paper-card as |card|}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title}}Vertical action buttons{{/card.title}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+          {{#card.actions layout="column" layoutAlign="start stretch"}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
       </div>
 
-    {{/paper-card}}
-    {{#paper-card}}
-      <img src="washedout.png" alt="Washed Out">
-      {{#paper-card-content}}
-        <h2>Paracosm</h2>
-        <p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        </p>
-      {{/paper-card-content}}
-      <div class="md-actions" layout="row" layout-align="end center">
-        {{#paper-button}}Action 1{{/paper-button}}
-        {{#paper-button}}Action 2{{/paper-button}}
-      </div>
+      <div flex>
+        {{#paper-card as |card|}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title}}Vertical action buttons{{/card.title}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+          {{#card.actions}}
+            {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
+            {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
+            {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
 
-    {{/paper-card}}
+        {{#paper-card as |card|}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.actions}}
+            {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
+            {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
+            {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
+
+        {{#paper-card as |card|}}
+          {{#card.header as |header|}}
+            {{#header.avatar}}
+              <img src="tomster.png" alt="tomster" />
+            {{/header.avatar}}
+            {{#header.text}}
+              <span class="md-title">Ember</span>
+              <span class="md-subhead">Paper</span>
+            {{/header.text}}
+          {{/card.header}}
+          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{#card.title}}Card header{{/card.title}}
+          {{#card.content}}
+            <p>
+              The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+              two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+            </p>
+          {{/card.content}}
+        {{/paper-card}}
+      </div>
+    </div>
   {{/paper-content}}
 
 
   <h3>Template</h3>
   {{#code-block language='handlebars'}}
-  \{{#paper-card}}
-    &lt;img src="washedout.png" alt="Washed Out"&gt;
-    \{{#paper-card-content}}
-      &lt;h2&gt;Paracosm&lt;/h2&gt;
-      &lt;p&gt;
-        The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-        two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-      &lt;/p&gt;
-    \{{/paper-card-content}}
-    &lt;div class="md-actions" layout="row" layout-align="end center"&gt;
-      \{{#paper-button}}Action 1\{{/paper-button}}
-      \{{#paper-button}}Action 2\{{/paper-button}}
-    &lt;/div&gt;
-  \{{/paper-card}}{{/code-block}}
+&lt;div layout="row">
+  &lt;div layout="column" flex>
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title}}Action buttons\{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+      \{{#card.actions}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title}}Vertical action buttons\{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+      \{{#card.actions layout="column" layoutAlign="start stretch"}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+  &lt;/div>
+
+  &lt;div flex>
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title}}Vertical action buttons\{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+      \{{#card.actions}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.actions}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      \{{#card.header as |header|}}
+        \{{#header.avatar}}
+          &lt;img src="tomster.png" alt="tomster" />
+        \{{/header.avatar}}
+        \{{#header.text}}
+          &lt;span class="md-title">Ember&lt;/span>
+          &lt;span class="md-subhead">Paper&lt;/span>
+        \{{/header.text}}
+      \{{/card.header}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title}}Card header\{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+    \{{/paper-card}}
+  &lt;/div>
+&lt;/div>
+  {{/code-block}}
 </div>
 {{/paper-content}}

--- a/tests/dummy/app/templates/card.hbs
+++ b/tests/dummy/app/templates/card.hbs
@@ -9,12 +9,163 @@
 
 {{#paper-content class="md-padding"}}
 <div class="doc-content">
-  {{#paper-content class="list-demo"}}
+  {{#paper-content class="card-demo"}}
+    <h2>Basic Usage</h2>
     <div class="layout-row">
-      <div>
+      <div class="flex-50">
+        {{#paper-card as |card|}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Card with image</span>
+              <span class="md-subhead">Large</span>
+            {{/title.text}}
+            {{#title.media}}
+              <div class="md-media-lg card-media"></div>
+            {{/title.media}}
+          {{/card.title}}
+          {{#card.actions}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
+
+        {{#paper-card as |card|}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Card with image</span>
+              <span class="md-subhead">Extra large</span>
+            {{/title.text}}
+          {{/card.title}}
+          {{#card.content class="layout-row layout-align-space-between"}}
+            <div class="md-media-xl card-media"></div>
+            {{#card.actions class="layout-column"}}
+              {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
+              {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
+              {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
+            {{/card.actions}}
+          {{/card.content}}
+        {{/paper-card}}
+      </div>
+      <div class="flex-50">
+        {{#paper-card as |card|}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Card with image</span>
+              <span class="md-subhead">Small</span>
+            {{/title.text}}
+            {{#title.media}}
+              <div class="md-media-sm card-media"></div>
+            {{/title.media}}
+          {{/card.title}}
+          {{#card.actions}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
+
+        {{#paper-card as |card|}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Card with image</span>
+              <span class="md-subhead">Medium</span>
+            {{/title.text}}
+            {{#title.media}}
+              <div class="md-media-md card-media"></div>
+            {{/title.media}}
+          {{/card.title}}
+          {{#card.actions}}
+            {{#paper-button}}Action 1{{/paper-button}}
+            {{#paper-button}}Action 2{{/paper-button}}
+          {{/card.actions}}
+        {{/paper-card}}
+      </div>
+    </div>
+
+    <h3>Template</h3>
+    {{#code-block language="handlebars"}}
+&lt;h2>Basic Usage&lt;/h2>
+&lt;div class="layout-row">
+  &lt;div class="flex-50">
+    \{{#paper-card as |card|}}
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Card with image&lt;/span>
+          &lt;span class="md-subhead">Large&lt;/span>
+        \{{/title.text}}
+        \{{#title.media}}
+          &lt;div class="md-media-lg card-media">&lt;/div>
+        \{{/title.media}}
+      \{{/card.title}}
+      \{{#card.actions}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Card with image&lt;/span>
+          &lt;span class="md-subhead">Extra large&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.content class="layout-row layout-align-space-between"}}
+        &lt;div class="md-media-xl card-media">&lt;/div>
+        \{{#card.actions class="layout-column"}}
+          \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
+          \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
+          \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
+        \{{/card.actions}}
+      \{{/card.content}}
+    \{{/paper-card}}
+  &lt;/div>
+  &lt;div class="flex-50">
+    \{{#paper-card as |card|}}
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Card with image&lt;/span>
+          &lt;span class="md-subhead">Small&lt;/span>
+        \{{/title.text}}
+        \{{#title.media}}
+          &lt;div class="md-media-sm card-media">&lt;/div>
+        \{{/title.media}}
+      \{{/card.title}}
+      \{{#card.actions}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Card with image&lt;/span>
+          &lt;span class="md-subhead">Medium&lt;/span>
+        \{{/title.text}}
+        \{{#title.media}}
+          &lt;div class="md-media-md card-media">&lt;/div>
+        \{{/title.media}}
+      \{{/card.title}}
+      \{{#card.actions}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+  &lt;/div>
+&lt;/div>{{/code-block}}
+  {{/paper-content}}
+
+  {{#paper-content class="class-demo"}}
+    <h2>Card Action Buttons</h2>
+    <div class="layout-row">
+      <div class="flex-50">
         {{#paper-card as |card|}}
           <img class="md-card-image" src="washedout.png" alt="washed out" />
-          {{#card.title}}Action buttons{{/card.title}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Action buttons</span>
+            {{/title.text}}
+          {{/card.title}}
           {{#card.content}}
             <p>
               The titles of Washed Out's breakthrough song and the first single from Paracosm share the
@@ -37,7 +188,11 @@
 
         {{#paper-card as |card|}}
           <img class="md-card-image" src="washedout.png" alt="washed out" />
-          {{#card.title}}Vertical action buttons{{/card.title}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Vertical action buttons</span>
+            {{/title.text}}
+          {{/card.title}}
           {{#card.content}}
             <p>
               The titles of Washed Out's breakthrough song and the first single from Paracosm share the
@@ -51,10 +206,14 @@
         {{/paper-card}}
       </div>
 
-      <div>
+      <div class="flex-50">
         {{#paper-card as |card|}}
           <img class="md-card-image" src="washedout.png" alt="washed out" />
-          {{#card.title}}Vertical action buttons{{/card.title}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Icon action buttons</span>
+            {{/title.text}}
+          {{/card.title}}
           {{#card.content}}
             <p>
               The titles of Washed Out's breakthrough song and the first single from Paracosm share the
@@ -88,7 +247,11 @@
             {{/header.text}}
           {{/card.header}}
           <img class="md-card-image" src="washedout.png" alt="washed out" />
-          {{#card.title}}Card header{{/card.title}}
+          {{#card.title as |title|}}
+            {{#title.text}}
+              <span class="md-headline">Card header</span>
+            {{/title.text}}
+          {{/card.title}}
           {{#card.content}}
             <p>
               The titles of Washed Out's breakthrough song and the first single from Paracosm share the
@@ -103,7 +266,110 @@
 
   <h3>Template</h3>
   {{#code-block language='handlebars'}}
+&lt;h2>Card Action Buttons&lt;/h2>
+&lt;div class="layout-row">
+  &lt;div class="flex-50">
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Action buttons&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+      \{{#card.actions}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
 
-  {{/code-block}}
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Vertical action buttons&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+      \{{#card.actions class="layout-column"}}
+        \{{#paper-button}}Action 1\{{/paper-button}}
+        \{{#paper-button}}Action 2\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+  &lt;/div>
+
+  &lt;div class="flex-50">
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Icon action buttons&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+      \{{#card.actions}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.actions}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
+        \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
+      \{{/card.actions}}
+    \{{/paper-card}}
+
+    \{{#paper-card as |card|}}
+      \{{#card.header as |header|}}
+        \{{#header.avatar}}
+          &lt;img src="tomster.png" alt="tomster" />
+        \{{/header.avatar}}
+        \{{#header.text}}
+          &lt;span class="md-title">Ember&lt;/span>
+          &lt;span class="md-subhead">Paper&lt;/span>
+        \{{/header.text}}
+      \{{/card.header}}
+      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{#card.title as |title|}}
+        \{{#title.text}}
+          &lt;span class="md-headline">Card header&lt;/span>
+        \{{/title.text}}
+      \{{/card.title}}
+      \{{#card.content}}
+        &lt;p>
+          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+        &lt;/p>
+      \{{/card.content}}
+    \{{/paper-card}}
+  &lt;/div>
+&lt;/div>{{/code-block}}
 </div>
 {{/paper-content}}

--- a/tests/dummy/app/templates/card.hbs
+++ b/tests/dummy/app/templates/card.hbs
@@ -10,8 +10,8 @@
 {{#paper-content class="md-padding"}}
 <div class="doc-content">
   {{#paper-content class="list-demo"}}
-    <div layout="row">
-      <div layout="column" flex>
+    <div class="layout-row">
+      <div>
         {{#paper-card as |card|}}
           <img class="md-card-image" src="washedout.png" alt="washed out" />
           {{#card.title}}Action buttons{{/card.title}}
@@ -44,14 +44,14 @@
               two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
             </p>
           {{/card.content}}
-          {{#card.actions layout="column" layoutAlign="start stretch"}}
+          {{#card.actions class="layout-column"}}
             {{#paper-button}}Action 1{{/paper-button}}
             {{#paper-button}}Action 2{{/paper-button}}
           {{/card.actions}}
         {{/paper-card}}
       </div>
 
-      <div flex>
+      <div>
         {{#paper-card as |card|}}
           <img class="md-card-image" src="washedout.png" alt="washed out" />
           {{#card.title}}Vertical action buttons{{/card.title}}
@@ -103,94 +103,7 @@
 
   <h3>Template</h3>
   {{#code-block language='handlebars'}}
-&lt;div layout="row">
-  &lt;div layout="column" flex>
-    \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
-      \{{#card.title}}Action buttons\{{/card.title}}
-      \{{#card.content}}
-        &lt;p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        &lt;/p>
-        &lt;p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        &lt;/p>
-        &lt;p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        &lt;/p>
-      \{{/card.content}}
-      \{{#card.actions}}
-        \{{#paper-button}}Action 1\{{/paper-button}}
-        \{{#paper-button}}Action 2\{{/paper-button}}
-      \{{/card.actions}}
-    \{{/paper-card}}
 
-    \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
-      \{{#card.title}}Vertical action buttons\{{/card.title}}
-      \{{#card.content}}
-        &lt;p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        &lt;/p>
-      \{{/card.content}}
-      \{{#card.actions layout="column" layoutAlign="start stretch"}}
-        \{{#paper-button}}Action 1\{{/paper-button}}
-        \{{#paper-button}}Action 2\{{/paper-button}}
-      \{{/card.actions}}
-    \{{/paper-card}}
-  &lt;/div>
-
-  &lt;div flex>
-    \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
-      \{{#card.title}}Vertical action buttons\{{/card.title}}
-      \{{#card.content}}
-        &lt;p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        &lt;/p>
-      \{{/card.content}}
-      \{{#card.actions}}
-        \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
-        \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
-        \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
-      \{{/card.actions}}
-    \{{/paper-card}}
-
-    \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
-      \{{#card.actions}}
-        \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
-        \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
-        \{{#paper-button iconButton=true}}\{{paper-icon "share"}}\{{/paper-button}}
-      \{{/card.actions}}
-    \{{/paper-card}}
-
-    \{{#paper-card as |card|}}
-      \{{#card.header as |header|}}
-        \{{#header.avatar}}
-          &lt;img src="tomster.png" alt="tomster" />
-        \{{/header.avatar}}
-        \{{#header.text}}
-          &lt;span class="md-title">Ember&lt;/span>
-          &lt;span class="md-subhead">Paper&lt;/span>
-        \{{/header.text}}
-      \{{/card.header}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
-      \{{#card.title}}Card header\{{/card.title}}
-      \{{#card.content}}
-        &lt;p>
-          The titles of Washed Out's breakthrough song and the first single from Paracosm share the
-          two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
-        &lt;/p>
-      \{{/card.content}}
-    \{{/paper-card}}
-  &lt;/div>
-&lt;/div>
   {{/code-block}}
 </div>
 {{/paper-content}}

--- a/tests/dummy/app/templates/card.hbs
+++ b/tests/dummy/app/templates/card.hbs
@@ -15,13 +15,11 @@
       <div class="flex-50">
         {{#paper-card as |card|}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Card with image</span>
-              <span class="md-subhead">Large</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Card with image{{/text.headline}}
+              {{#text.subhead}}Large{{/text.subhead}}
             {{/title.text}}
-            {{#title.media}}
-              <div class="md-media-lg card-media"></div>
-            {{/title.media}}
+            {{title.media size="lg" src="tomster.png" alt="Tomster" title="Tomster"}}
           {{/card.title}}
           {{#card.actions}}
             {{#paper-button}}Action 1{{/paper-button}}
@@ -31,13 +29,15 @@
 
         {{#paper-card as |card|}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Card with image</span>
-              <span class="md-subhead">Extra large</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Card with block{{/text.headline}}
+              {{#text.subhead}}Extra large{{/text.subhead}}
             {{/title.text}}
           {{/card.title}}
           {{#card.content class="layout-row layout-align-space-between"}}
-            <div class="md-media-xl card-media"></div>
+            {{#card.media size="xl"}}
+              <div class="card-media"></div>
+            {{/card.media}}
             {{#card.actions class="layout-column"}}
               {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
               {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
@@ -49,13 +49,11 @@
       <div class="flex-50">
         {{#paper-card as |card|}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Card with image</span>
-              <span class="md-subhead">Small</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Card with image{{/text.headline}}
+              {{#text.subhead}}Small{{/text.subhead}}
             {{/title.text}}
-            {{#title.media}}
-              <div class="md-media-sm card-media"></div>
-            {{/title.media}}
+            {{title.media size="sm" src="tomster.png" alt="Tomster" title="Tomster"}}
           {{/card.title}}
           {{#card.actions}}
             {{#paper-button}}Action 1{{/paper-button}}
@@ -65,12 +63,12 @@
 
         {{#paper-card as |card|}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Card with image</span>
-              <span class="md-subhead">Medium</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Card with block{{/text.headline}}
+              {{#text.subhead}}Medium{{/text.subhead}}
             {{/title.text}}
-            {{#title.media}}
-              <div class="md-media-md card-media"></div>
+            {{#title.media size="md"}}
+              <div class="card-media"></div>
             {{/title.media}}
           {{/card.title}}
           {{#card.actions}}
@@ -89,13 +87,11 @@
   &lt;div class="flex-50">
     \{{#paper-card as |card|}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Card with image&lt;/span>
-          &lt;span class="md-subhead">Large&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Card with image\{{/text.headline}}
+          \{{#text.subhead}}Large\{{/text.subhead}}
         \{{/title.text}}
-        \{{#title.media}}
-          &lt;div class="md-media-lg card-media">&lt;/div>
-        \{{/title.media}}
+        \{{title.media size="lg" src="tomster.png" alt="Tomster" title="Tomster"}}
       \{{/card.title}}
       \{{#card.actions}}
         \{{#paper-button}}Action 1\{{/paper-button}}
@@ -105,13 +101,15 @@
 
     \{{#paper-card as |card|}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Card with image&lt;/span>
-          &lt;span class="md-subhead">Extra large&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Card with block\{{/text.headline}}
+          \{{#text.subhead}}Extra large\{{/text.subhead}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.content class="layout-row layout-align-space-between"}}
-        &lt;div class="md-media-xl card-media">&lt;/div>
+        \{{#card.media size="xl"}}
+          &lt;div class="card-media">&lt;/div>
+        \{{/card.media}}
         \{{#card.actions class="layout-column"}}
           \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
           \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
@@ -123,13 +121,11 @@
   &lt;div class="flex-50">
     \{{#paper-card as |card|}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Card with image&lt;/span>
-          &lt;span class="md-subhead">Small&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Card with image\{{/text.headline}}
+          \{{#text.subhead}}Small\{{/text.subhead}}
         \{{/title.text}}
-        \{{#title.media}}
-          &lt;div class="md-media-sm card-media">&lt;/div>
-        \{{/title.media}}
+        \{{title.media size="sm" src="tomster.png" alt="Tomster" title="Tomster"}}
       \{{/card.title}}
       \{{#card.actions}}
         \{{#paper-button}}Action 1\{{/paper-button}}
@@ -139,12 +135,12 @@
 
     \{{#paper-card as |card|}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Card with image&lt;/span>
-          &lt;span class="md-subhead">Medium&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Card with block\{{/text.headline}}
+          \{{#text.subhead}}Medium\{{/text.subhead}}
         \{{/title.text}}
-        \{{#title.media}}
-          &lt;div class="md-media-md card-media">&lt;/div>
+        \{{#title.media size="md"}}
+          &lt;div class="card-media">&lt;/div>
         \{{/title.media}}
       \{{/card.title}}
       \{{#card.actions}}
@@ -160,10 +156,10 @@
     <div class="layout-row">
       <div class="flex-50">
         {{#paper-card as |card|}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Action buttons</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Action buttons{{/text.headline}}
             {{/title.text}}
           {{/card.title}}
           {{#card.content}}
@@ -187,10 +183,10 @@
         {{/paper-card}}
 
         {{#paper-card as |card|}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Vertical action buttons</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Vertical action buttons{{/text.headline}}
             {{/title.text}}
           {{/card.title}}
           {{#card.content}}
@@ -208,10 +204,10 @@
 
       <div class="flex-50">
         {{#paper-card as |card|}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Icon action buttons</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Icon action buttons{{/text.headline}}
             {{/title.text}}
           {{/card.title}}
           {{#card.content}}
@@ -228,7 +224,7 @@
         {{/paper-card}}
 
         {{#paper-card as |card|}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.actions}}
             {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
             {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
@@ -241,15 +237,15 @@
             {{#header.avatar}}
               <img src="tomster.png" alt="tomster" />
             {{/header.avatar}}
-            {{#header.text}}
-              <span class="md-title">Ember</span>
-              <span class="md-subhead">Paper</span>
+            {{#header.text as |text|}}
+              {{#text.title}}Ember{{/text.title}}
+              {{#text.subhead}}Paper{{/text.subhead}}
             {{/header.text}}
           {{/card.header}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">Card header</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}Card header{{/text.headline}}
             {{/title.text}}
           {{/card.title}}
           {{#card.content}}
@@ -270,10 +266,10 @@
 &lt;div class="layout-row">
   &lt;div class="flex-50">
     \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Action buttons&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Action buttons\{{/text.headline}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.content}}
@@ -297,10 +293,10 @@
     \{{/paper-card}}
 
     \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Vertical action buttons&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Vertical action buttons\{{/text.headline}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.content}}
@@ -318,10 +314,10 @@
 
   &lt;div class="flex-50">
     \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Icon action buttons&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Icon action buttons\{{/text.headline}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.content}}
@@ -338,7 +334,7 @@
     \{{/paper-card}}
 
     \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.actions}}
         \{{#paper-button iconButton=true}}\{{paper-icon "favorite"}}\{{/paper-button}}
         \{{#paper-button iconButton=true}}\{{paper-icon "settings"}}\{{/paper-button}}
@@ -351,15 +347,15 @@
         \{{#header.avatar}}
           &lt;img src="tomster.png" alt="tomster" />
         \{{/header.avatar}}
-        \{{#header.text}}
-          &lt;span class="md-title">Ember&lt;/span>
-          &lt;span class="md-subhead">Paper&lt;/span>
+        \{{#header.text as |text|}}
+          \{{#text.title}}Ember\{{/text.title}}
+          \{{#text.subhead}}Paper\{{/text.subhead}}
         \{{/header.text}}
       \{{/card.header}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">Card header&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}Card header\{{/text.headline}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.content}}
@@ -377,10 +373,10 @@
     <div class="layout-row">
       <div class="flex-50">
         {{#paper-card as |card|}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">In-card mixed actions</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}In-card mixed actions{{/text.headline}}
             {{/title.text}}
           {{/card.title}}
           {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
@@ -404,16 +400,16 @@
             {{#header.avatar}}
               <img src="tomster.png" alt="tomster" />
             {{/header.avatar}}
-            {{#header.text}}
-              <span class="md-title">User</span>
-              <span class="md-subhead">subhead</span>
+            {{#header.text as |text|}}
+              {{#text.title}}User{{/text.title}}
+              {{#text.subhead}}subhead{{/text.subhead}}
             {{/header.text}}
           {{/card.header}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">In-card mixed actions</span>
-              <span class="md-subhead">Reversed</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}In-card mixed actions{{/text.headline}}
+              {{#text.subhead}}Reversed{{/text.subhead}}
             {{/title.text}}
           {{/card.title}}
           {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
@@ -438,16 +434,16 @@
             {{#header.avatar}}
               <img src="tomster.png" alt="tomster" />
             {{/header.avatar}}
-            {{#header.text}}
-              <span class="md-title">Title</span>
-              <span class="md-subhead">subhead</span>
+            {{#header.text as |text|}}
+              {{#text.title}}Title{{/text.title}}
+              {{#text.subhead}}subhead{{/text.subhead}}
             {{/header.text}}
           {{/card.header}}
-          <img class="md-card-image" src="washedout.png" alt="washed out" />
+          {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
           {{#card.title as |title|}}
-            {{#title.text}}
-              <span class="md-headline">In-card mixed actions</span>
-              <span class="md-subhead">Description</span>
+            {{#title.text as |text|}}
+              {{#text.headline}}In-card mixed actions{{/text.headline}}
+              {{#text.subhead}}Description{{/text.subhead}}
             {{/title.text}}
           {{/card.title}}
           {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
@@ -471,10 +467,10 @@
 &lt;div class="layout-row">
   &lt;div class="flex-50">
     \{{#paper-card as |card|}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">In-card mixed actions&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}In-card mixed actions\{{/text.headline}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.actions class="layout-row layout-align-start-center" as |actions|}}
@@ -498,16 +494,16 @@
         \{{#header.avatar}}
           &lt;img src="tomster.png" alt="tomster" />
         \{{/header.avatar}}
-        \{{#header.text}}
-          &lt;span class="md-title">User&lt;/span>
-          &lt;span class="md-subhead">subhead&lt;/span>
+        \{{#header.text as |text|}}
+          \{{#text.title}}User\{{/text.title}}
+          \{{#text.subhead}}subhead\{{/text.subhead}}
         \{{/header.text}}
       \{{/card.header}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">In-card mixed actions&lt;/span>
-          &lt;span class="md-subhead">Reversed&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}In-card mixed actions\{{/text.headline}}
+          \{{#text.subhead}}Reversed\{{/text.subhead}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.actions class="layout-row layout-align-start-center" as |actions|}}
@@ -532,16 +528,16 @@
         \{{#header.avatar}}
           &lt;img src="tomster.png" alt="tomster" />
         \{{/header.avatar}}
-        \{{#header.text}}
-          &lt;span class="md-title">Title&lt;/span>
-          &lt;span class="md-subhead">subhead&lt;/span>
+        \{{#header.text as |text|}}
+          \{{#text.title}}Title\{{/text.title}}
+          \{{#text.subhead}}subhead\{{/text.subhead}}
         \{{/header.text}}
       \{{/card.header}}
-      &lt;img class="md-card-image" src="washedout.png" alt="washed out" />
+      \{{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
       \{{#card.title as |title|}}
-        \{{#title.text}}
-          &lt;span class="md-headline">In-card mixed actions&lt;/span>
-          &lt;span class="md-subhead">Description&lt;/span>
+        \{{#title.text as |text|}}
+          \{{#text.headline}}In-card mixed actions\{{/text.headline}}
+          \{{#text.subhead}}Description\{{/text.subhead}}
         \{{/title.text}}
       \{{/card.title}}
       \{{#card.actions class="layout-row layout-align-start-center" as |actions|}}


### PR DESCRIPTION
Re-submitting #338.

- [x] Add support for headers & avatars
- [x] Create components for most common card 'parts' (actions, header, title, content)
- [x] Use contextual components (but not mandatory)
- [x] Add support for in-card media
- [x] Bring examples on par with [Angular Material](https://material.angularjs.org/1.0.6/demo/card)
- [x] Update changelog