### PR TITLE
fix dep errors + version number

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ module.exports = {
       'components/dialog/dialog-theme.scss'
     ];
 
-    var pathBase = this.project.addonPackages['ember-paper'].path;
-    var angularMaterialPath =  'node_modules/angular-material-source/src';
+    var pathBase = this.project.nodeModulesPath;
+    var angularMaterialPath =  'angular-material-source/src';
 
     var angularScssFiles = new Funnel(path.join(pathBase,angularMaterialPath), {
       files: scssFiles,


### PR DESCRIPTION
3 minor changes:

- add ember-route-action to dependencies instead of devDependencies
- point to the projects nodeModulesPath - this allows consumers to see angular-material-source in their node_modules directory(and keeps the demo working as well)
- changed the version back to 0.2.12 as it was overwritten in 8b7dd871496e312afad5ef0d9e928a36307ebdfd

