### PR TITLE
Switch component must behave exactly like md angular example

### DIFF
--- a/addon/components/paper-switch.js
+++ b/addon/components/paper-switch.js
@@ -20,6 +20,8 @@ export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
   classNameBindings: ['value:md-checked', 'dragging:md-dragging'],
   toggle: true,
 
+  constants: inject.service(),
+
   /* Ripple Overrides */
   rippleContainerSelector: '.md-thumb',
   center: true,
@@ -29,8 +31,6 @@ export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
   value: false,
   disabled: false,
   dragging: false,
-
-  constants: inject.service(),
 
   thumbContainerStyle: computed('dragging', 'dragAmount', function() {
     if (!this.get('dragging')) {
@@ -74,20 +74,21 @@ export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
   },
 
   _setupSwitch() {
-    this.set('switchWidth', this.$('.md-bar').width());
+    this.set('switchWidth', this.$('.md-thumb-container').innerWidth());
 
-    // Enable dragging the switch
     let switchContainer = this.$('.md-container').get(0);
-    let switchContainerHammer = new Hammer(switchContainer);
-    this._switchContainerHammer = switchContainerHammer;
-    switchContainerHammer.get('pan').set({ threshold: 1 });
-    switchContainerHammer.on('panstart', run.bind(this, this._dragStart));
-    switchContainerHammer.on('panmove', run.bind(this, this._drag));
-    switchContainerHammer.on('panend', run.bind(this, this._dragEnd));
+    let switchHammer = new Hammer(switchContainer);
+    this._switchContainerHammer = switchHammer;
 
-    let switchHammer = new Hammer(this.element);
-    this._switchHammer = switchHammer;
-    switchHammer.on('tap', run.bind(this, this._dragEnd));
+    // Enable dragging the switch container
+    switchHammer.get('pan').set({ threshold: 1 });
+    switchHammer.on('panstart', run.bind(this, this._dragStart))
+      .on('panmove', run.bind(this, this._drag))
+      .on('panend', run.bind(this, this._dragEnd));
+
+    // Enable tapping gesture on the switch
+    this._switchHammer = new Hammer(this.element);
+    this._switchHammer.on('tap', run.bind(this, this._dragEnd));
   },
 
   _teardownSwitch() {
@@ -119,6 +120,13 @@ export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
       }
       this.set('dragging', false);
       this.set('dragAmount', null);
+    }
+  },
+
+  focusIn() {
+    // Focusing in w/o being pressed should use the default behavior
+    if (!this.get('pressed')) {
+      this._super(...arguments);
     }
   },
 

--- a/tests/integration/components/paper-switch-test.js
+++ b/tests/integration/components/paper-switch-test.js
@@ -21,6 +21,30 @@ test('should set selected class correctly', function(assert) {
   assert.ok(!this.$().hasClass('md-checked'));
 });
 
+test('should not set focused class', function(assert) {
+  this.render(hbs`
+    {{#paper-switch value=switchValue onChange=(action (mut switchValue))}}
+      Radio button 1
+    {{/paper-switch}}
+  `);
+  this.$('md-switch').click();
+
+  assert.ok(!this.$('md-switch').hasClass('md-focused'));
+});
+
+test('should set focused class', function(assert) {
+  this.render(hbs`
+    {{#paper-switch value=switchValue onChange=(action (mut switchValue))}}
+      Radio button 1
+    {{/paper-switch}}
+  `);
+  this.$('md-switch').click();
+  this.$('md-switch').focusout();
+  this.$('md-switch').focusin();
+
+  assert.ok(this.$('md-switch').hasClass('md-focused'));
+});
+
 test('should render block content as label', function(assert) {
   this.set('foo', () => { });
   this.set('switchValue', true);
@@ -52,8 +76,8 @@ test('blockless mode should render label', function(assert) {
     this.render(hbs`{{paper-switch value=switchValue onChange=(action (mut switchValue))}}`);
     assert.equal(this.get('switchValue'), false);
 
-    let e = Ember.$.Event('keypress');
-    e.which = keyCode; // # Some key code value
+    let e = Ember.$.Event('keypress', { which: keyCode });
+    // e.which = keyCode; // # Some key code value
     this.$('md-switch').trigger(e);
 
     assert.equal(this.get('switchValue'), true);


### PR DESCRIPTION
Fixed a couple of issues I've noticed:
1. When a pressed switch looses focus, and then re-gains it - the thumb must glow.
  1.a. Further changes to the pressed/unpressed state must keep the thumb glowing.
  1.b. When tapping the thumb ripple should be generate over the glow.
2. Clicking on the actual switch should not generate ripple effect on the thumb.
3. Space/Enter key on focused switch should behave like 1.a.
4. Fixed the drag --> was using the wrong elemen's innerWidth()

Compare this <-> ember-paper/master <-> angular md