### PR TITLE
don't import hammerjs and match media if being called from node

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,11 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/hammer.js/hammer.js');
-    app.import(app.bowerDirectory + '/matchMedia/matchMedia.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/hammer.js/hammer.js')
+      app.import(app.bowerDirectory + '/matchMedia/matchMedia.js');
+    };
+
     app.import('vendor/propagating.js');
   },
 


### PR DESCRIPTION
While adding Ember Fastboot support to an application, I was receiving:

```javascript
$ ember fastboot --serve-assets
Built project successfully. Stored in "fastboot-dist".
Installing FastBoot npm dependencies
document is not defined
ReferenceError: document is not defined
```

This was because HammerJS and MatchMedia use the `document`, but NodeJS, which Fastboot uses, doesn't use the `document`, which leads the `ReferenceError`. Therefore, if Ember Fastboot is requiring `ember-paper`, lets skip HammerJS and MatchMedia.