### PR TITLE
make guards for fastboot

### DIFF
--- a/addon/components/paper-autocomplete-list.js
+++ b/addon/components/paper-autocomplete-list.js
@@ -1,3 +1,4 @@
+import isBrowser from '../utils/is-browser';
 import Ember from 'ember';
 
 // TODO Move to constants?
@@ -16,6 +17,11 @@ export default Ember.Component.extend({
 
   init() {
     this._super(...arguments);
+
+    if (!isBrowser()) {
+      return;
+    }
+
     this._resizeWindowEvent = Ember.run.bind(this, this.resizeWindowEvent);
   },
 

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -1,3 +1,4 @@
+import isBrowser from '../utils/is-browser';
 import Ember from 'ember';
 import { promiseArray } from 'ember-paper/utils/promise-proxies';
 
@@ -53,6 +54,10 @@ export default Ember.Component.extend({
 
   init() {
     this._super(...arguments);
+
+    if (!isBrowser()) {
+      return;
+    }
 
     if (this.get('model')) {
       this.set('searchText', this.lookupLabelOfItem(this.get('model')));

--- a/addon/components/paper-progress-linear.js
+++ b/addon/components/paper-progress-linear.js
@@ -1,3 +1,4 @@
+import isBrowser from '../utils/is-browser';
 import Ember from 'ember';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 const { inject, computed, Component, isPresent } = Ember;
@@ -23,6 +24,11 @@ export default Component.extend(ColorMixin, {
 
   init() {
     this._super(...arguments);
+
+    if (!isBrowser()) {
+      return;
+    }
+
     this.setupTransforms();
   },
 

--- a/addon/components/paper-sidenav.js
+++ b/addon/components/paper-sidenav.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import PaperNavContainer from './paper-nav-container';
+import isBrowser from '../utils/is-browser';
 
 export default Ember.Component.extend({
   constants: Ember.inject.service(),
@@ -18,8 +19,11 @@ export default Ember.Component.extend({
   tabindex: -1,
 
   _init: Ember.on('init', function() {
-    let _self = this;
+    if (!isBrowser()) {
+      return;
+    }
 
+    let _self = this;
     if (this.get('navContainer')) {
       this.get('navContainer').set('sideBar', this);
     }

--- a/addon/initializers/paper-wormhole.js
+++ b/addon/initializers/paper-wormhole.js
@@ -1,8 +1,8 @@
-const hasDOM = typeof document !== 'undefined';
+import isBrowser from '../utils/is-browser';
 const defaultWormhole = 'paper-wormhole';
 
 export default function initialize() {
-  if (!hasDOM) {
+  if (!isBrowser()) {
     return;
   }
 

--- a/addon/mixins/proxiable-mixin.js
+++ b/addon/mixins/proxiable-mixin.js
@@ -1,9 +1,15 @@
+import isBrowser from '../utils/is-browser';
 import Ember from 'ember';
 import ProxyMixin from './proxy-mixin';
 
 export default Ember.Mixin.create({
   init() {
     this._super(...arguments);
+
+    if (!isBrowser()) {
+      return;
+    }
+
     Ember.run(() => {
       Ember.run.scheduleOnce('afterRender', this, 'registerProxy');
     });

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -1,3 +1,4 @@
+import isBrowser from '../utils/is-browser';
 import Ember from 'ember';
 
 const {
@@ -37,6 +38,11 @@ export default Mixin.create({
 
   init() {
     this._super(...arguments);
+
+    if (!isBrowser()) {
+      return;
+    }
+
     this.TRANSITIONEND = this.get('constants').get('CSS').TRANSITIONEND;
   },
 

--- a/addon/utils/is-browser.js
+++ b/addon/utils/is-browser.js
@@ -1,0 +1,13 @@
+/*
+Ye' ol annoying isBrower function to allow use of this library with fastboot.
+
+Use this within init() within components
+*/
+
+export default function isBrowser() {
+  return typeof window   !== 'undefined' &&
+         typeof document !== 'undefined' &&
+         typeof process  === 'undefined' &&
+         !!window.document               &&
+         !!window.document.createElement;
+}

--- a/app/services/sniffer.js
+++ b/app/services/sniffer.js
@@ -1,3 +1,4 @@
+import isBrowser from '../utils/is-browser';
 import Ember from 'ember';
 
 let isString = function(value) {
@@ -25,6 +26,10 @@ export default Ember.Service.extend({
 
   init() {
     this._super(...arguments);
+
+    if (!isBrowser()) {
+      return;
+    }
 
     let bodyStyle = this.get('document').body && this.get('document').body.style;
     let vendorPrefix;

--- a/app/utils/is-browser.js
+++ b/app/utils/is-browser.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-paper/utils/is-browser';

--- a/tests/unit/utils/is-browser-test.js
+++ b/tests/unit/utils/is-browser-test.js
@@ -1,0 +1,8 @@
+import isBrowser from 'dummy/utils/is-browser';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | is browser');
+
+test('should remain true until we add fastboot tests', function(assert) {
+  assert.strictEqual(isBrowser(), true);
+});


### PR DESCRIPTION
- add `isBrowser()` util
- add guards for fastboot within init calls inside components

I know you guys are doing a major upgrade right now, so no need to merge this, but the following allows the current master branch to work with fastboot. I figured while working on the next version, this would help keep that need in mind.

tl;dr - `init()` within components is called by fastboot. Other component hooks are not. This code wraps each call to init with a `isBrowser()` util. This includes mixins used by components. 

Don't feel obligated to merge this. I will personally use these guards though, so if they break in any way, I'll file a follow up pr with a fix. 