### PR TITLE
link directly to `ember-route-action` helper

### DIFF
--- a/tests/dummy/app/templates/sidenav.hbs
+++ b/tests/dummy/app/templates/sidenav.hbs
@@ -26,8 +26,7 @@
     </p>
 
     <p>
-      <strong>Note:</strong> The following Sidenav example contains a <code>transition-to</code> helper that is not installed by default. To use this helper install the following:
-      {{#code-block language='bash'}}ember install ember-route-action{{/code-block}}
+      <strong>Note:</strong> The following Sidenav example contains a <code>transition-to</code> helper via the <a href="https://github.com/peec/ember-route-action">ember-route-action</a> addon, which is not installed by default.
     </p>
 
 


### PR DESCRIPTION
The `ember-route-action` addon isn't easily discoverable at the moment, so explicitly including a link to the repository is arguably more valuable than printing the given `ember install` command.