### PR TITLE
Fix npm 2.x build failures for angular-material-source dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,10 +106,19 @@ module.exports = {
       'components/dialog/dialog-theme.scss'
     ];
 
-    var pathBase = this.project.nodeModulesPath;
-    var angularMaterialPath =  'angular-material-source/src';
+    /*
+      Find the angular-material-source module in a manner that works for npm 2.x
+      and 3.x in both the addon itself and projects that depend on this addon
 
-    var angularScssFiles = new Funnel(path.join(pathBase,angularMaterialPath), {
+      This is an edge case b/c angular-material-source does not have a main
+      module we can require.resolve through node itself and similarily ember-cli
+      does not have such a hack for the same reason.
+
+      tl;dr - We want the non built scss files, and b/c this dep is only provided via
+      bower, we use this hack. Please change it if you read this and know a better way.
+    */
+    var pathBase = path.resolve(this.nodeModulesPath, 'angular-material-source', 'src')
+    var angularScssFiles = new Funnel(pathBase, {
       files: scssFiles,
       destDir: 'angular-material',
       annotation: 'AngularScssFunnel'


### PR DESCRIPTION
- Angular-material-source does not have a main node module, its only
  built to ./dist and published via bower. The first attempt to make
  this work with npm 3.x broke (some users) npm 2.x env's.

- This aims to allow building a project that includes this addon for
  npme 2.x and 3.x for all versions of node.

fixes #349