### PR TITLE
paper-button: Support `<a>` tags with href and optional target attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Contributions and pull requests are always welcome. Contributors may often be fo
 - [#364](https://github.com/miguelcobain/ember-paper/pull/364) Support installation via both npm versions 2 and 3.
 - [#367](https://github.com/miguelcobain/ember-paper/pull/367) You should now use `paper-toolbar-tools` component (or respective contextual component) instead of the `md-toolbar-tools` class.
 - [#370](https://github.com/miguelcobain/ember-paper/pull/370) `paper-icon` now once again supports kebab cased icon names, and a `size` in pixels.
+- [#3XX](https://github.com/miguelcobain/ember-paper/pull/3XX) `paper-button` can generate `a` link elements, with an href and optional target attribute.
 
 #### 1.0.0-alpha.0
 - [1a9b641](https://github.com/miguelcobain/ember-paper/commit/1a9b6411a8ca30f3e9440d8585dc0f1ff4ff7649) paper-progress-circular now uses `diameter` instead of `md-diameter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Contributions and pull requests are always welcome. Contributors may often be fo
 - [#364](https://github.com/miguelcobain/ember-paper/pull/364) Support installation via both npm versions 2 and 3.
 - [#367](https://github.com/miguelcobain/ember-paper/pull/367) You should now use `paper-toolbar-tools` component (or respective contextual component) instead of the `md-toolbar-tools` class.
 - [#370](https://github.com/miguelcobain/ember-paper/pull/370) `paper-icon` now once again supports kebab cased icon names, and a `size` in pixels.
-- [#3XX](https://github.com/miguelcobain/ember-paper/pull/3XX) `paper-button` can generate `a` link elements, with an href and optional target attribute.
+- [#372](https://github.com/miguelcobain/ember-paper/pull/372) `paper-button` can generate `a` link elements, with an href and optional target attribute.
 
 #### 1.0.0-alpha.0
 - [1a9b641](https://github.com/miguelcobain/ember-paper/commit/1a9b6411a8ca30f3e9440d8585dc0f1ff4ff7649) paper-progress-circular now uses `diameter` instead of `md-diameter`

--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -7,14 +7,22 @@ import ColorMixin from 'ember-paper/mixins/color-mixin';
 const { computed } = Ember;
 
 export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
-  attributeBindings: ['type'],
   type: 'button',
-  tagName: 'button',
+  tagName: computed('href', function() {
+    return this.get('href') ? 'a' : 'button';
+  }),
   classNames: ['paper-button', 'md-default-theme', 'md-button'],
   raised: false,
   iconButton: false,
   fab: computed.reads('mini'),  // circular button
   mini: false,
+  href: null,
+  target: null,
+  attributeBindings: [
+    'type',
+    'href',
+    'target'
+  ],
   classNameBindings: [
     'raised:md-raised',
     'iconButton:md-icon-button',

--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -7,15 +7,13 @@ import ColorMixin from 'ember-paper/mixins/color-mixin';
 const { computed } = Ember;
 
 export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
-  type: 'button',
-  tagName: computed('href', function() {
-    return this.get('href') ? 'a' : 'button';
-  }),
+  tagName: 'button',
   classNames: ['paper-button', 'md-default-theme', 'md-button'],
   raised: false,
   iconButton: false,
   fab: computed.reads('mini'),  // circular button
   mini: false,
+  type: 'button',
   href: null,
   target: null,
   attributeBindings: [
@@ -35,6 +33,16 @@ export default BaseFocusable.extend(RippleMixin, ProxiableMixin, ColorMixin, {
   fitRipple: computed.readOnly('iconButton'),
   center: computed.readOnly('iconButton'),
   dimBackground: computed.not('iconButton'),
+
+  init() {
+    this._super(...arguments);
+    if (this.get('href')) {
+      this.setProperties({
+        tagName: 'a',
+        type: null
+      });
+    }
+  },
 
   click(event) {
     this.sendAction('onClick', event);

--- a/tests/dummy/app/templates/button.hbs
+++ b/tests/dummy/app/templates/button.hbs
@@ -8,7 +8,7 @@
 {{/paper-toolbar}}
 {{#paper-content class="md-padding demo-buttons"}}
 <div class="doc-content">
-  <div layout="row" class="flex">
+  <div class="layout-row">
     {{#paper-button onClick=(action "flatButton")}}Button with action{{/paper-button}}
     {{#paper-button noink=true primary=true}}Primary (noink){{/paper-button}}
     {{#paper-button disabled=true}}disabled{{/paper-button}}

--- a/tests/dummy/app/templates/button.hbs
+++ b/tests/dummy/app/templates/button.hbs
@@ -8,7 +8,7 @@
 {{/paper-toolbar}}
 {{#paper-content class="md-padding demo-buttons"}}
 <div class="doc-content">
-  <div layout="row" flex>
+  <div layout="row" class="flex">
     {{#paper-button onClick=(action "flatButton")}}Button with action{{/paper-button}}
     {{#paper-button noink=true primary=true}}Primary (noink){{/paper-button}}
     {{#paper-button disabled=true}}disabled{{/paper-button}}

--- a/tests/dummy/app/templates/button.hbs
+++ b/tests/dummy/app/templates/button.hbs
@@ -8,12 +8,13 @@
 {{/paper-toolbar}}
 {{#paper-content class="md-padding demo-buttons"}}
 <div class="doc-content">
-  <p>
+  <div layout="row" flex>
     {{#paper-button onClick=(action "flatButton")}}Button with action{{/paper-button}}
     {{#paper-button noink=true primary=true}}Primary (noink){{/paper-button}}
     {{#paper-button disabled=true}}disabled{{/paper-button}}
     {{#paper-button warn=true}}warn{{/paper-button}}
-  </p>
+    {{#paper-button href="http://emberjs.com/images/tomsters/original.png" target="_blank"}}href link{{/paper-button}}
+  </div>
   <p>
     {{#paper-button raised=true onClick=(action "raisedButton")}}Button with action{{/paper-button}}
     {{#paper-button raised=true primary=true}}Primary{{/paper-button}}
@@ -37,12 +38,13 @@
   </p>
   <h3>Template</h3>
   {{#code-block language='handlebars'}}
-  &lt;p&gt;
+  &lt;div layout="row" flex&gt;
     \{{#paper-button onClick=(action "flatButton")}}Button with action\{{/paper-button}}
     \{{#paper-button noink=true primary=true}}Primary (noink)\{{/paper-button}}
     \{{#paper-button disabled=true}}disabled\{{/paper-button}}
     \{{#paper-button warn=true}}warn\{{/paper-button}}
-  &lt;/p&gt;
+    \{{#paper-button href="http://emberjs.com/images/tomsters/original.png" target="_blank"}}href link\{{/paper-button}}
+  &lt;/div&gt;
   &lt;p&gt;
     \{{#paper-button raised=true onClick=(action "raisedButton")}}Button with action\{{/paper-button}}
     \{{#paper-button raised=true primary=true}}Primary\{{/paper-button}}
@@ -63,4 +65,94 @@
     \{{paper-button raised=true label="Blockless version"}}
   &lt;/p&gt;{{/code-block}}
 </div>
+
+<h2>Usage</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>API</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>accent</strong></td>
+      <td>boolean</td>
+      <td>Display in the theme's accent color</td>
+    </tr>
+    <tr>
+      <td><strong>bubbles</strong></td>
+      <td>boolean</td>
+      <td>Determines whether the Ember click event handler bubbles. Default is {{#code-inline}}undefined{{/code-inline}}, which bubbles</td>
+    </tr>
+    <tr>
+      <td><strong>disabled</strong></td>
+      <td>boolean</td>
+      <td>Whether the button is displayed as disabled and does not accept clicks</td>
+    </tr>
+    <tr>
+      <td><strong>fab</strong></td>
+      <td>boolean</td>
+      <td>Display as a Floating Action Button</td>
+    </tr>
+    <tr>
+      <td><strong>href</strong></td>
+      <td>string</td>
+      <td>Displays the button as an {{#code-inline}}&lt;a&gt;{{/code-inline}} link to the specified destination URL</td>
+    </tr>
+    <tr>
+      <td><strong>iconButton</strong></td>
+      <td>boolean</td>
+      <td>Set when the contents contains an icon and adjusts CSS appropriately</td>
+    </tr>
+    <tr>
+      <td><strong>label</strong></td>
+      <td>string</td>
+      <td>Set the content of the button when used as a blockless component</td>
+    </tr>
+    <tr>
+      <td><strong>mini</strong></td>
+      <td>boolean</td>
+      <td>Display as a mini-sized button. Implies {{#code-inline}}fab{{/code-inline}}, unless {{#code-inline}}fab{{/code-inline}} is explicity set falsy.</td>
+    </tr>
+    <tr>
+      <td><strong>noInk</strong></td>
+      <td>boolean</td>
+      <td>Suppresses the ripple effect when clicked</td>
+    </tr>
+    <tr>
+      <td><strong>onClick</strong></td>
+      <td>closure</td>
+      <td>Action sent when the button is clicked</td>
+    </tr>
+    <tr>
+      <td><strong>primary</strong></td>
+      <td>boolean</td>
+      <td>Display as the primary button, more prominent that other buttons</td>
+    </tr>
+    <tr>
+      <td><strong>raised</strong></td>
+      <td>boolean</td>
+      <td>Display button with a 3-D effect</td>
+    </tr>
+    <tr>
+      <td><strong>target</strong></td>
+      <td>string</td>
+      <td>Sets the {{#code-inline}}&lt;a&gt;{{/code-inline}} link target attribute, such as {{#code-inline}}"_blank"{{/code-inline}}</td>
+    </tr>
+    <tr>
+      <td><strong>type</strong></td>
+      <td>string</td>
+      <td>Sets the html5 {{#code-inline}}type{{/code-inline}} attribute.</td>
+    </tr>
+    <tr>
+      <td><strong>warn</strong></td>
+      <td>boolean</td>
+      <td>Display in the theme's warn color</td>
+    </tr>
+  </tbody>
+</table>
+
 {{/paper-content}}

--- a/tests/dummy/app/templates/button.hbs
+++ b/tests/dummy/app/templates/button.hbs
@@ -145,7 +145,7 @@
     <tr>
       <td><strong>type</strong></td>
       <td>string</td>
-      <td>Sets the html5 {{#code-inline}}type{{/code-inline}} attribute.</td>
+      <td>Sets the html5 {{#code-inline}}type{{/code-inline}} attribute. Defaults to {{#code-inline}}"button"{{/code-inline}}</td>
     </tr>
     <tr>
       <td><strong>warn</strong></td>

--- a/tests/dummy/app/templates/dialog.hbs
+++ b/tests/dummy/app/templates/dialog.hbs
@@ -14,7 +14,7 @@
       {{#paper-toolbar}}
         <div class="md-toolbar-tools">
           <h2>Basic Usage</h2>
-          <span flex></span>
+          <span class="flex"></span>
           {{#paper-button onClick=(action "toggleSourceCode") iconButton=true}}
             {{paper-icon icon="code"}}
           {{/paper-button}}
@@ -209,7 +209,7 @@
       {{#paper-toolbar}}
         <div class="md-toolbar-tools">
           <h2>Mango (Fruit)</h2>
-          <span flex></span>
+          <span class="flex"></span>
           {{#paper-button iconButton=true onClick=(action "closeDialogWithParent" "cancel")}}{{paper-icon icon="close"}}{{/paper-button}}
         </div>
       {{/paper-toolbar}}
@@ -223,7 +223,7 @@
       {{/paper-dialog-content}}
 
       {{#paper-dialog-actions class="layout-row"}}
-        <span flex></span>
+        <span class="flex"></span>
         {{#paper-button onClick=(action "closeDialogWithParent" "cancel")}}Cancel{{/paper-button}}
         {{#paper-button onClick=(action "closeDialogWithParent" "ok")}}OK{{/paper-button}}
       {{/paper-dialog-actions}}
@@ -236,7 +236,7 @@
     {{#paper-toolbar}}
       <div class="md-toolbar-tools">
         <h2>Mango (Fruit)</h2>
-        <span flex></span>
+        <span class="flex"></span>
         {{#paper-button iconButton=true onClick=(action "closeDialog" "cancel")}}{{paper-icon icon="close"}}{{/paper-button}}
       </div>
     {{/paper-toolbar}}
@@ -251,7 +251,7 @@
     {{/paper-dialog-content}}
 
     {{#paper-dialog-actions class="layout-row"}}
-      <span flex></span>
+      <span class="flex"></span>
       {{#paper-button onClick=(action "closeDialog" "cancel")}}Cancel{{/paper-button}}
       {{#paper-button onClick=(action "closeDialog" "ok")}}OK{{/paper-button}}
     {{/paper-dialog-actions}}
@@ -271,7 +271,7 @@
     {{/paper-dialog-content}}
 
     {{#paper-dialog-actions class="layout-row"}}
-      <span flex></span>
+      <span class="flex"></span>
       {{#paper-button primary=true onClick=(action "closePromptDialog" "cancel")}}I'm a cat person{{/paper-button}}
       {{#paper-button primary=true onClick=(action "closePromptDialog" "ok" dogName)}}Okay!{{/paper-button}}
     {{/paper-dialog-actions}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -11,11 +11,13 @@
   {{#paper-toolbar warn=true}}
     <div class="md-toolbar-tools">
       <h2>Pre-production Version</h2>
+      <span flex></span>
+      {{#paper-button href="/ember-paper/release-0-2"}}Switch to version 0.2{{/paper-button}}
     </div>
   {{/paper-toolbar}}
   {{#paper-content}}
     <p>You are viewing the demonstration and documentation for a <strong>pre-production</strong> built of {{#code-inline}}ember-paper{{/code-inline}}. This version is in flux. For version 1.0, all components are being updated to reflect the latest Ember coding practices and Angular Material stylesheets. Components which have not yet been updated are shown with a {{paper-icon "warning"}} and are subject to API changes. Be sure to read CHANGELOG.md when updating.</p>
-    <p><strong>Wrong version?</strong> The currently-released version of ember-paper is <a href="/ember-paper/release-0-2">Version 0.2</a>, currently installed by <br>{{#code-inline language='bash'}}ember install ember-paper{{/code-inline}}. See README.md for advice on which version to use.</p>
+    <p><strong>Wrong version?</strong> The currently-released version of ember-paper is version 0.2, currently installed by <br>{{#code-inline language='bash'}}ember install ember-paper{{/code-inline}}. See README.md for advice on which version to use. <a href="/ember-paper/release-0-2">Switch to version 0.2.</a></p>
   {{/paper-content}}
 
   <h2 class="md-headline" style="margin-top: 0;">Welcome to Ember Paper.</h2>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -11,7 +11,7 @@
   {{#paper-toolbar warn=true}}
     <div class="md-toolbar-tools">
       <h2>Pre-production Version</h2>
-      <span flex></span>
+      <span class="flex"></span>
       {{#paper-button href="/ember-paper/release-0-2"}}Switch to version 0.2{{/paper-button}}
     </div>
   {{/paper-toolbar}}

--- a/tests/dummy/app/templates/toolbar.hbs
+++ b/tests/dummy/app/templates/toolbar.hbs
@@ -56,7 +56,7 @@
   <br>
 
   {{#paper-toolbar tall=true warn=true}}
-    <span flex></span>
+    <span class="flex"></span>
     {{#paper-toolbar-tools}}
       <h2>Toolbar: tall with actions pin to the bottom (tall=true warn=true)</h2>
     {{/paper-toolbar-tools}}

--- a/tests/integration/components/paper-button-test.js
+++ b/tests/integration/components/paper-button-test.js
@@ -88,3 +88,23 @@ test('uses md-mini and md-fab class when mini=true', function(assert) {
   `);
   assert.ok(this.$('.md-button').is('.md-fab', '.md-mini'));
 });
+
+test('uses a tag when href is specified', function(assert) {
+  this.render(hbs`
+    {{#paper-button href="http://example.com"}}
+      A label
+    {{/paper-button}}
+  `);
+  assert.ok(this.$('.md-button').is('a'));
+  assert.ok(this.$('.md-button').attr('href') === 'http://example.com');
+});
+
+test('renders target', function(assert) {
+  this.render(hbs`
+    {{#paper-button href="http://example.com" target="_blank"}}
+      A label
+    {{/paper-button}}
+  `);
+  assert.ok(this.$('.md-button').is('a'));
+  assert.ok(this.$('.md-button').attr('target') === '_blank');
+});


### PR DESCRIPTION
Also Improve dummy app page with API documentation and button. Use a-link style button to link from 1.0 dummy app to v0.2.