### PR TITLE
Fixed paper-select issue

### DIFF
--- a/addon/components/paper-menu-container-abstract.js
+++ b/addon/components/paper-menu-container-abstract.js
@@ -55,8 +55,11 @@ export default Ember.Component.extend({
   hideWrapper() {
     let _self = this;
     return new Ember.RSVP.Promise(function(resolve/*, reject*/) {
-      _self.get('transitionEvents').addEndEventListener(_self.get('element'), resolve);
-      _self.$().removeClass('md-active').addClass('md-leave');
+      _self.get('transitionEvents').addEndEventListener(_self.get('element'), function() {
+        _self.$().removeClass('md-active');
+        resolve();
+      });
+      _self.$().addClass('md-leave');
     });
   },
 


### PR DESCRIPTION
Problem was that the md-active class (which mandated that the display be block) was being removed before the transition started, causing the 'display:none' from paper-select-container to interrupt the transition. The reason it worked in dummy app was that dummy app forces all ember-views to have display flex.

Looked at AM code and it appears the correct solution was to remove md-active after the transition ended.