### PR TITLE
fix for issue #378

### DIFF
--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -12,7 +12,7 @@ export default Component.extend({
       this.sendAction('onClick', event);
     }
   },
-  mouseEnter: function() {
+  mouseEnter() {
   	this.$('.md-button:not([disabled])').focus();
   }
 

--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -11,6 +11,9 @@ export default Component.extend({
       this.nearestOfType(PaperMenuAbstract).send('toggleMenu');
       this.sendAction('onClick', event);
     }
+  },
+  mouseEnter: function() {
+  	this.$('.md-button:not([disabled])').focus();
   }
 
 });

--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -13,7 +13,9 @@ export default Component.extend({
     }
   },
   mouseEnter() {
-  	this.$('.md-button:not([disabled])').focus();
+    if (!this.get('disabled')) {
+      this.$('button').focus();
+    }
   }
 
 });


### PR DESCRIPTION
problem with #378 was that mouseEnter events on menu items should trigger a focus if there is a non-disabled md-button inside the menu item. Corresponding AM code can be seen here:
https://github.com/angular/material/blob/master/src/components/menu/js/menuController.js
in ```this.handleMenuItemHover()```.

