### PR TITLE
Fixes query linear progress to demo switch from query to determinate.

### DIFF
--- a/addon/components/paper-progress-linear.js
+++ b/addon/components/paper-progress-linear.js
@@ -67,8 +67,7 @@ export default Component.extend(ColorMixin, {
     return Ember.String.htmlSafe(`${this.get('constants.CSS.TRANSFORM')}: ${this.transforms[this.get('clampedBufferValue')]}`);
   }),
 
-  bar2Style: computed('clampedValue', function() {
-
+  bar2Style: computed('clampedValue', 'mode', function() {
     if (this.get('mode') === MODE_QUERY) {
       return Ember.String.htmlSafe('');
     }

--- a/app/templates/components/paper-progress-linear.hbs
+++ b/app/templates/components/paper-progress-linear.hbs
@@ -1,5 +1,5 @@
 <div class="md-container {{queryModeClass}}">
-    <div class="md-dashed"></div>
-    <div class="md-bar md-bar1" style={{bar1Style}}></div>
-    <div class="md-bar md-bar2" style={{bar2Style}}></div>
+  <div class="md-dashed"></div>
+  <div class="md-bar md-bar1" style={{bar1Style}}></div>
+  <div class="md-bar md-bar2" style={{bar2Style}}></div>
 </div>

--- a/tests/dummy/app/controllers/demo/progress-linear.js
+++ b/tests/dummy/app/controllers/demo/progress-linear.js
@@ -33,6 +33,7 @@ export default Controller.extend({
   setupTimer2() {
     this.set('timer2', run.later(this, function() {
       this.set('mode', this.get('mode') === 'query' ? 'determinate' : 'query');
+      this.set('determinateValue', 30);
       Ember.run.later(this, this.setupTimer2);
     }, 7200));
   },

--- a/tests/dummy/app/templates/demo/progress-linear.hbs
+++ b/tests/dummy/app/templates/demo/progress-linear.hbs
@@ -1,34 +1,33 @@
 {{page-toolbar pageTitle="Progress Linear" isDemo=true}}
 
 {{#doc-content}}
-    <h2>Basic Usage</h2>
+  <h2>Basic Usage</h2>
 
-    <h3>Determinate mode</h3>
-    <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
-    {{! BEGIN-SNIPPET progress-linear.determinate }}
-    {{paper-progress-linear value=determinateValue}}
-    {{! END-SNIPPET }}
-    {{code-snippet name="progress-linear.determinate.hbs"}}
+  <h3>Determinate mode</h3>
+  <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
+  {{! BEGIN-SNIPPET progress-linear.determinate }}
+  {{paper-progress-linear value=determinateValue}}
+  {{! END-SNIPPET }}
+  {{code-snippet name="progress-linear.determinate.hbs"}}
 
-    <h3>Indeterminate mode</h3>
-    <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator:</p>
-    {{! BEGIN-SNIPPET progress-linear.indeterminate }}
-    {{paper-progress-linear}}
-    {{! END-SNIPPET }}
-    {{code-snippet name="progress-linear.indeterminate.hbs"}}
+  <h3>Indeterminate mode</h3>
+  <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator:</p>
+  {{! BEGIN-SNIPPET progress-linear.indeterminate }}
+  {{paper-progress-linear}}
+  {{! END-SNIPPET }}
+  {{code-snippet name="progress-linear.indeterminate.hbs"}}
 
-    <h3>Buffer mode</h3>
-    <p>For operations where the user wants to indicate some activity or loading from the server, use the buffer indicator:</p>
-    {{! BEGIN-SNIPPET progress-linear.buffer }}
-    {{paper-progress-linear warn=true value=determinateValue bufferValue=determinateValue2}}
-    {{! END-SNIPPET }}
-    {{code-snippet name="progress-linear.buffer.hbs"}}
+  <h3>Buffer mode</h3>
+  <p>For operations where the user wants to indicate some activity or loading from the server, use the buffer indicator:</p>
+  {{! BEGIN-SNIPPET progress-linear.buffer }}
+  {{paper-progress-linear warn=true value=determinateValue bufferValue=determinateValue2}}
+  {{! END-SNIPPET }}
+  {{code-snippet name="progress-linear.buffer.hbs"}}
 
-    <h3>Query mode</h3>
-    <p>For situations where the user wants to indicate pre-loading (until the loading can actually be made), use the query indicator:</p>
-    {{! BEGIN-SNIPPET progress-linear.query }}
-    {{paper-progress-linear accent=true mode=mode value=determinateValue}}
-    {{! END-SNIPPET }}
-    {{code-snippet name="progress-linear.query.hbs"}}
-
+  <h3>Query mode</h3>
+  <p>For situations where the user wants to indicate pre-loading (until the loading can actually be made), use the query indicator:</p>
+  {{! BEGIN-SNIPPET progress-linear.query }}
+  {{paper-progress-linear accent=true mode=mode value=determinateValue}}
+  {{! END-SNIPPET }}
+  {{code-snippet name="progress-linear.query.hbs"}}
 {{/doc-content}}


### PR DESCRIPTION
Before this fix, the determinate progress bar was getting 'stuck'
because the bar style wasn't bound to the mode. So when the mode
changed, the bar style wasn't updated.