### PR TITLE
paper-content: arrow keys scroll main content, add tabindex attribute binding

### DIFF
--- a/addon/components/paper-content.js
+++ b/addon/components/paper-content.js
@@ -4,6 +4,6 @@ import FlexMixin from '../mixins/flex-mixin';
 export default Ember.Component.extend(FlexMixin, {
   tagName: 'md-content',
   classNames: ['md-default-theme'],
-  attributeBindings: ['layout-padding', 'scroll-y:md-scroll-y'],
+  attributeBindings: ['layout-padding', 'scroll-y:md-scroll-y', 'tabindex'],
   classNameBindings: ['padding:md-padding']
 });

--- a/app/services/constants.js
+++ b/app/services/constants.js
@@ -55,7 +55,7 @@ export default Ember.Service.extend({
     'xl': '(min-width: 1920px)',
     'print': 'print'
   },
-  
+
   MEDIA_PRIORITY: [
     'xl',
     'gt-lg',

--- a/tests/dummy/app/templates/components/doc-content.hbs
+++ b/tests/dummy/app/templates/components/doc-content.hbs
@@ -1,4 +1,4 @@
-{{#paper-content class="md-padding"}}
+{{#paper-content class="md-padding" tabindex="0"}}
   <div class="doc-content {{class}}">
     {{yield}}
   </div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,6 +1,6 @@
 {{page-toolbar pageTitle="Introduction" isDemo=false}}
 
-{{#paper-content flex=true scroll-y=true layout-padding=true}}
+{{#paper-content flex=true scroll-y=true layout-padding=true tabindex="1"}}
 <div class="doc-content">
 
   {{#paper-card as |card|}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,6 +1,6 @@
 {{page-toolbar pageTitle="Introduction" isDemo=false}}
 
-{{#paper-content flex=true scroll-y=true layout-padding=true tabindex="1"}}
+{{#paper-content flex=true scroll-y=true layout-padding=true tabindex="0"}}
 <div class="doc-content">
 
   {{#paper-card as |card|}}

--- a/tests/dummy/app/templates/typography.hbs
+++ b/tests/dummy/app/templates/typography.hbs
@@ -1,6 +1,6 @@
 {{page-toolbar pageTitle="Typography" isDemo=false}}
 
-{{#paper-content class="md-padding"}}
+{{#paper-content class="md-padding" tabindex="0"}}
 <div class="doc-content">
   <h3>Headings</h3>
   <div class="preview-block">

--- a/tests/integration/components/paper-content-test.js
+++ b/tests/integration/components/paper-content-test.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('paper-content', 'Integration | Component | paper content', {
+  integration: true
+});
+
+test('renders md-content with tabindex attribute', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{paper-content tabindex="1138"}}`);
+  let $mdContent = this.$('md-content');
+  let actual = $mdContent.attr('tabindex');
+  let expected = '1138';
+  assert.equal(actual, expected);
+});


### PR DESCRIPTION
Presently it's not possible to scroll http://miguelcobain.github.io/ember-paper/release-1/#/typography from the keyboard.

This pull request adds tabindex binding to the paper-content component, so that a tabindex may be set on the main paper-content for a page, allowing keyboard scrolling.

```
{{#paper-content class="md-padding" tabindex="0"}}
    long content which you can now click, tab into or otherwise focus to scroll
    from the keyboard
{{/paper-content}}
```