### PR TITLE
Prevent redundant on invalid

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -202,11 +202,15 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
 
   notifyInvalid() {
     let isInvalid = this.get('isInvalid');
-    if (this.get('lastIsInvalid') !== isInvalid) {
-      this.sendAction('onInvalid', this.get('isInvalid'));
-      this.set('lastIsInvalid', this.get('isInvalid'));
+    let lastIsInvalid = this.get('lastIsInvalid');
+    let isInvalidChanged = (lastIsInvalid !== isInvalid);
+    let isNotRedundant = !((lastIsInvalid === null && isInvalid) || (lastIsInvalid && isInvalid === null));
+    if (isInvalidChanged && isNotRedundant) {
+      this.sendAction('onInvalid', isInvalid);
+      this.set('lastIsInvalid', isInvalid);
     }
   },
+  
   setValue(value) {
     this.$('input, textarea').val(value);
   },

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -46,14 +46,13 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
    *
    * @public
    *
-   * @return {boolean|null} Whether the input is or would be invalid.
-   *    null: input has not yet been touched, but would be invalid if it were
+   * @return {boolean} Whether the input is or would be invalid.
    *    false: input is valid (touched or not), or is no longer rendered
    *    true: input has been touched and is invalid.
    */
-  isInvalid: computed('isTouched', 'validationErrorMessages.length', 'isNativeInvalid', function() {
+  isInvalid: computed('validationErrorMessages.length', 'isNativeInvalid', function() {
     let isInvalid = this.get('validationErrorMessages.length') || this.get('isNativeInvalid');
-    return isInvalid && !this.get('isTouched') ? null : !!isInvalid;
+    return isInvalid;
   }),
 
   renderCharCount: computed('value', function() {
@@ -203,9 +202,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
   notifyInvalid() {
     let isInvalid = this.get('isInvalid');
     let lastIsInvalid = this.get('lastIsInvalid');
-    let isInvalidChanged = (lastIsInvalid !== isInvalid);
-    let isNotRedundant = !((lastIsInvalid === null && isInvalid) || (lastIsInvalid && isInvalid === null));
-    if (isInvalidChanged && isNotRedundant) {
+    if (lastIsInvalid !== isInvalid) {
       this.sendAction('onInvalid', isInvalid);
       this.set('lastIsInvalid', isInvalid);
     }

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -50,10 +50,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
    *    false: input is valid (touched or not), or is no longer rendered
    *    true: input has been touched and is invalid.
    */
-  isInvalid: computed('validationErrorMessages.length', 'isNativeInvalid', function() {
-    let isInvalid = this.get('validationErrorMessages.length') || this.get('isNativeInvalid');
-    return isInvalid;
-  }),
+  isInvalid: computed.or('validationErrorMessages.length', 'isNativeInvalid'),
 
   renderCharCount: computed('value', function() {
     let currentLength = this.get('value') ? this.get('value').length : 0;

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -210,7 +210,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
       this.set('lastIsInvalid', isInvalid);
     }
   },
-  
+
   setValue(value) {
     this.$('input, textarea').val(value);
   },

--- a/app/templates/components/paper-input.hbs
+++ b/app/templates/components/paper-input.hbs
@@ -77,16 +77,18 @@
       <div class="md-char-counter">{{renderCharCount}}</div>
     {{/if}}
   </div>
-  {{#if isInvalid}}
-    <div class="md-input-messages-animation md-auto-hide" ng-messages>
-      {{#each validationErrorMessages as |error index|}}
-        <div
+  {{#if isTouched}}
+    {{#if isInvalid}}
+      <div class="md-input-messages-animation md-auto-hide" ng-messages>
+        {{#each validationErrorMessages as |error index|}}
+          <div
           id="error-{{inputElementId}}-{{index}}"
           class="paper-input-error ng-enter ng-enter-active" ng-message>
-          {{error.message}}
-        </div>
-      {{/each}}
-    </div>
+            {{error.message}}
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
   {{/if}}
 {{/unless}}
 

--- a/tests/integration/components/paper-input-test.js
+++ b/tests/integration/components/paper-input-test.js
@@ -442,3 +442,20 @@ test('displayed input value matches actual input value with no onChange method',
   assert.equal(this.get('value'), 'foo', 'component value should be foo');
 
 });
+
+test('errors only show after input is touched and input is invalid', function(assert) {
+  assert.expect(2);
+
+  let errors = [{
+    message: 'foo should be a number.',
+    attribute: 'foo'
+  }];
+  this.set('errors', errors);
+
+  this.render(hbs`{{paper-input onChange=null errors=errors}}`);
+
+  assert.equal(this.$('.paper-input-error').length, 0, 'renders zero errors');
+  this.$('input, textarea').trigger('blur');
+  assert.equal(this.$('.paper-input-error').length, 1, 'renders one error');
+
+});


### PR DESCRIPTION
There was an issue with onInvalid being sent multiple times when isInvalid goes from TRUE <=> NULL.

Because these essentially both are invalid states, it's unnecessary to send multiple invalid actions.