### PR TITLE
Added keyboard support for paper-menu

### DIFF
--- a/addon/components/paper-menu-content-inner.js
+++ b/addon/components/paper-menu-content-inner.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import ParentMixin from 'ember-paper/mixins/parent-mixin';
-const { Component, inject, computed, run: { later } } = Ember;
+const { Component, inject, computed, run } = Ember;
 
 export default Component.extend(ParentMixin, {
   tagName: 'md-menu-content',
@@ -11,7 +11,7 @@ export default Component.extend(ParentMixin, {
   enabledMenuItems: computed.filterBy('childComponents', 'disabled', false),
 
   didInsertElement() {
-    later(() => {
+    run.later(() => {
       let focusTarget = this.$().find('.md-menu-focus-target');
       if (!focusTarget.length) {
         focusTarget = this.get('enabledMenuItems.firstObject.element.firstElementChild');

--- a/addon/components/paper-menu-content-inner.js
+++ b/addon/components/paper-menu-content-inner.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import ParentMixin from 'ember-paper/mixins/parent-mixin';
-const { Component, inject } = Ember;
+const { Component, inject, computed, run: { later } } = Ember;
 
 export default Component.extend(ParentMixin, {
   tagName: 'md-menu-content',
@@ -8,6 +8,17 @@ export default Component.extend(ParentMixin, {
   classNameBindings: ['dense:md-dense'],
 
   constants: inject.service(),
+  enabledMenuItems: computed.filterBy('childComponents', 'disabled', false),
+
+  didInsertElement() {
+    later(() => {
+      let focusTarget = this.$().find('.md-menu-focus-target');
+      if (!focusTarget.length) {
+        focusTarget = this.get('enabledMenuItems.firstObject.element.firstElementChild');
+      }
+      focusTarget.focus();
+    });
+  },
 
   keyDown(ev) {
     switch (ev.which) {
@@ -17,29 +28,43 @@ export default Component.extend(ParentMixin, {
       case this.get('constants.KEYCODE.LEFT_ARROW'):
       case this.get('constants.KEYCODE.UP_ARROW'):
         ev.preventDefault();
-        this.select(-1);
+        this.focusMenuItem(ev, -1);
         break;
       case this.get('constants.KEYCODE.RIGHT_ARROW'):
       case this.get('constants.KEYCODE.DOWN_ARROW'):
         ev.preventDefault();
-        this.select(1);
+        this.focusMenuItem(ev, 1);
         break;
     }
   },
 
-  select(increment) {
-    let groupValue = this.get('groupValue');
-    let index = 0;
+  focusMenuItem(e, direction) {
+    let currentItem = this.$(e.target).closest('md-menu-item');
 
-    if (groupValue) {
-      index = this.get('childValues').indexOf(groupValue);
-      index += increment;
-      let length = this.get('childValues.length');
-      index = ((index % length) + length) % length;
+    let children = this.get('enabledMenuItems');
+    let items = children.map((child) => child.element);
+
+    let currentIndex = items.indexOf(currentItem[0]);
+
+    // Traverse through our elements in the specified direction (+/-1) and try to
+    // focus them until we find one that accepts focus
+    for (let i = currentIndex + direction; i >= 0 && i < items.length; i = i + direction) {
+      let focusTarget = items[i].firstElementChild || items[i];
+      let didFocus = this.attemptFocus(focusTarget);
+      if (didFocus) {
+        break;
+      }
     }
+  },
 
-    let childRadio = this.get('enabledChildRadios').objectAt(index);
-    childRadio.set('focused', true);
-    this.sendAction('onChange', childRadio.get('value'));
+  attemptFocus(el) {
+    if (el && el.getAttribute('tabindex') !== -1) {
+      el.focus();
+      if (document.activeElement === el) {
+        return true;
+      } else {
+        return false;
+      }
+    }
   }
 });

--- a/addon/components/paper-menu-content.js
+++ b/addon/components/paper-menu-content.js
@@ -38,7 +38,6 @@ export default ContentComponent.extend({
     run.next(() => {
       if (!this.get('isDestroyed')) {
         this.set('isActive', false);
-      
         $clone.addClass('md-leave');
         waitForAnimations(clone, function() {
           $clone.removeClass('md-active');

--- a/addon/components/paper-menu-content.js
+++ b/addon/components/paper-menu-content.js
@@ -36,12 +36,15 @@ export default ContentComponent.extend({
     let $clone = $(clone);
     parentElement.appendChild(clone);
     run.next(() => {
-      this.set('isActive', false);
-      $clone.addClass('md-leave');
-      waitForAnimations(clone, function() {
-        $clone.removeClass('md-active');
-        parentElement.removeChild(clone);
-      });
+      if (!this.get('isDestroyed')) {
+        this.set('isActive', false);
+      
+        $clone.addClass('md-leave');
+        waitForAnimations(clone, function() {
+          $clone.removeClass('md-active');
+          parentElement.removeChild(clone);
+        });
+      }
     });
   }
 });

--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
+import ChildMixin from 'ember-paper/mixins/child-mixin';
 
 const { Component } = Ember;
 
-export default Component.extend({
+export default Component.extend(ChildMixin, {
   tagName: 'md-menu-item',
+  disabled: false,
 
   actions: {
     handleClick(event) {

--- a/app/templates/components/paper-menu-content-inner.hbs
+++ b/app/templates/components/paper-menu-content-inner.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/app/templates/components/paper-menu-content-inner.hbs
+++ b/app/templates/components/paper-menu-content-inner.hbs
@@ -1,1 +1,1 @@
-{{yield this}}
+{{yield (hash menu-item=(component 'paper-menu-item' parentComponent=this))}}

--- a/app/templates/components/paper-menu-content.hbs
+++ b/app/templates/components/paper-menu-content.hbs
@@ -5,8 +5,8 @@
       class="ember-basic-dropdown-content {{class}} {{if renderInPlace 'ember-basic-dropdown-content--in-place'}} {{if hPosition (concat 'ember-basic-dropdown-content--' hPosition)}} {{if vPosition (concat 'ember-basic-dropdown-content--' vPosition)}}
       md-open-menu-container md-whiteframe-z2 md-clickable {{if isActive "md-active"}}"
       dir={{dir}}>
-      {{#paper-menu-content-inner width=width dense=dense dropdown=dropdown}}
-        {{yield}}
+      {{#paper-menu-content-inner width=width dense=dense dropdown=dropdown as |content|}}
+        {{yield (hash menu-item=(component 'paper-menu-item' parentComponent=content))}}
       {{/paper-menu-content-inner}}
     </div>
     {{paper-backdrop class="md-menu-backdrop md-click-catcher"}}

--- a/app/templates/components/paper-menu-content.hbs
+++ b/app/templates/components/paper-menu-content.hbs
@@ -5,8 +5,8 @@
       class="ember-basic-dropdown-content {{class}} {{if renderInPlace 'ember-basic-dropdown-content--in-place'}} {{if hPosition (concat 'ember-basic-dropdown-content--' hPosition)}} {{if vPosition (concat 'ember-basic-dropdown-content--' vPosition)}}
       md-open-menu-container md-whiteframe-z2 md-clickable {{if isActive "md-active"}}"
       dir={{dir}}>
-      {{#paper-menu-content-inner width=width dense=dense dropdown=dropdown as |content|}}
-        {{yield (hash menu-item=(component 'paper-menu-item' parentComponent=content))}}
+      {{#paper-menu-content-inner width=width dense=dense dropdown=dropdown as |innerContentHash|}}
+        {{yield innerContentHash}}
       {{/paper-menu-content-inner}}
     </div>
     {{paper-backdrop class="md-menu-backdrop md-click-catcher"}}

--- a/tests/dummy/app/templates/demo/menu.hbs
+++ b/tests/dummy/app/templates/demo/menu.hbs
@@ -25,25 +25,25 @@
         {{paper-icon "local_phone"}}
       {{/paper-button}}
     {{/menu.trigger}}
-    {{#menu.content width=4}}
+    {{#menu.content width=4 as |content|}}
       {{#each items as |item|}}
-        {{#paper-menu-item onClick="openSomething"}}
+        {{#content.menu-item onClick="openSomething"}}
           {{paper-icon item.icon}}
           <span>{{item.title}}</span>
-        {{/paper-menu-item}}
+        {{/content.menu-item}}
       {{/each}}
 
-      {{#paper-menu-item onClick="openSomething" disabled=true}}
+      {{#content.menu-item onClick="openSomething" disabled=true}}
         {{paper-icon "adb"}}
         <span>This is disabled.</span>
-      {{/paper-menu-item}}
+      {{/content.menu-item}}
 
       {{paper-divider}}
 
       {{#each items as |item|}}
-        {{#paper-menu-item onClick="openSomething"}}
+        {{#content.menu-item onClick="openSomething"}}
           {{paper-icon item.icon}} {{item.title}}
-        {{/paper-menu-item}}
+        {{/content.menu-item}}
       {{/each}}
     {{/menu.content}}
   {{/paper-menu}}
@@ -75,12 +75,12 @@
           {{/paper-button}}
         {{/menu.trigger}}
 
-        {{#menu.content}}
+        {{#menu.content as |content|}}
           {{#each items as |item|}}
-            {{#paper-menu-item onClick="openSomething"}}
+            {{#content.menu-item onClick="openSomething"}}
               {{paper-icon item.icon class="md-menu-align-target"}}
               <span>{{item.title}}</span>
-            {{/paper-menu-item}}
+            {{/content.menu-item}}
           {{/each}}
         {{/menu.content}}
 
@@ -95,12 +95,12 @@
           {{/paper-button}}
         {{/menu.trigger}}
 
-        {{#menu.content}}
+        {{#menu.content as |content|}}
           {{#each items as |item|}}
-            {{#paper-menu-item onClick="openSomething"}}
+            {{#content.menu-item onClick="openSomething"}}
               {{paper-icon item.icon class="md-menu-align-target"}}
               <span>{{item.title}}</span>
-            {{/paper-menu-item}}
+            {{/content.menu-item}}
           {{/each}}
         {{/menu.content}}
       {{/paper-menu}}
@@ -114,12 +114,12 @@
           {{/paper-button}}
         {{/menu.trigger}}
 
-        {{#menu.content}}
+        {{#menu.content as |content|}}
           {{#each items as |item|}}
-            {{#paper-menu-item onClick="openSomething"}}
+            {{#content.menu-item onClick="openSomething"}}
               <p style="width: 190px;">{{item.title}}</p>
               {{paper-icon item.icon class="md-menu-align-target"}}
-            {{/paper-menu-item}}
+            {{/content.menu-item}}
           {{/each}}
         {{/menu.content}}
       {{/paper-menu}}
@@ -162,11 +162,11 @@ classes to specify where it should position itself in respect to origin and alig
           {{/paper-button}}
         {{/menu.trigger}}
 
-        {{#menu.content width=6}}
+        {{#menu.content width=6 as |content|}}
           {{#each options as |item|}}
-            {{#paper-menu-item onClick=(action "openSomething")}}
+            {{#content.menu-item onClick=(action "openSomething")}}
               <span class="md-menu-align-target">Option</span> {{item}}
-            {{/paper-menu-item}}
+            {{/content.menu-item}}
           {{/each}}
         {{/menu.content}}
       {{/paper-menu}}
@@ -180,11 +180,11 @@ classes to specify where it should position itself in respect to origin and alig
           {{/paper-button}}
         {{/menu.trigger}}
 
-        {{#menu.content width=4}}
+        {{#menu.content width=4 as |content|}}
           {{#each options as |item|}}
-            {{#paper-menu-item onClick=(action "openSomething")}}
+            {{#content.menu-item onClick=(action "openSomething")}}
               <span class="md-menu-align-target">Option</span> {{item}}
-            {{/paper-menu-item}}
+            {{/content.menu-item}}
           {{/each}}
         {{/menu.content}}
       {{/paper-menu}}
@@ -198,11 +198,11 @@ classes to specify where it should position itself in respect to origin and alig
           {{/paper-button}}
         {{/menu.trigger}}
 
-        {{#menu.content width=2}}
+        {{#menu.content width=2 as |content|}}
           {{#each options as |item|}}
-            {{#paper-menu-item onClick=(action "openSomething")}}
+            {{#content.menu-item onClick=(action "openSomething")}}
               <span class="md-menu-align-target">Option</span> {{item}}
-            {{/paper-menu-item}}
+            {{/content.menu-item}}
           {{/each}}
         {{/menu.content}}
       {{/paper-menu}}

--- a/tests/integration/components/paper-menu-test.js
+++ b/tests/integration/components/paper-menu-test.js
@@ -11,7 +11,7 @@ function focus(el) {
   if (!el) {
     return;
   }
-  let $el = jQuery(el);
+  let $el = $(el);
   if ($el.is(':input, [contenteditable=true]')) {
     let type = $el.prop('type');
     if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
@@ -66,11 +66,10 @@ test('opens on click', function(assert) {
         {{/content.menu-item}}
     {{/menu.content}}
   {{/paper-menu}}`);
-  
-  
+
   return wait().then(() => {
     clickTrigger();
-    
+
     return wait().then(() => {
       let selectors = $('.md-open-menu-container');
       assert.ok(selectors.length, 'opened menu');
@@ -96,11 +95,10 @@ test('backdrop removed if menu closed', function(assert) {
         {{/content.menu-item}}
     {{/menu.content}}
   {{/paper-menu}}`);
-  
-  
+
   return wait().then(() => {
     clickTrigger();
-    
+
     return wait().then(() => {
 
       let selectors = $('.md-open-menu-container');
@@ -108,7 +106,7 @@ test('backdrop removed if menu closed', function(assert) {
       clickTrigger();
       return wait().then(() => {
         let selector = $('.md-backdrop');
-        assert.ok(!selector.length,'backdrop removed');
+        assert.ok(!selector.length, 'backdrop removed');
       });
     });
   });
@@ -129,11 +127,10 @@ test('backdrop removed if backdrop clicked', function(assert) {
         {{/content.menu-item}}
     {{/menu.content}}
   {{/paper-menu}}`);
-  
-  
+
   return wait().then(() => {
     clickTrigger();
-    
+
     return wait().then(() => {
 
       let selectors = $('.md-open-menu-container');
@@ -141,7 +138,7 @@ test('backdrop removed if backdrop clicked', function(assert) {
       $('md-backdrop').click();
       return wait().then(() => {
         let selector = $('.md-backdrop');
-        assert.ok(!selector.length,'backdrop removed');
+        assert.ok(!selector.length, 'backdrop removed');
       });
     });
   });
@@ -165,45 +162,36 @@ test('keydown changes focused element', function(assert) {
         {{/content.menu-item}}
     {{/menu.content}}
   {{/paper-menu}}`);
-  
-  
+
   return wait().then(() => {
     clickTrigger();
-    
+
     return wait().then(() => {
 
       let selectors = $('md-menu-item');
       assert.ok($(selectors[0].firstElementChild).hasClass('md-focused'), 'first menu item given focus');
-      let e = $.Event("keydown");
-      let menu = $('md-menu-content')[0];
+      let e = $.Event('keydown');
+      let menu = $('md-menu-content');
       e.which = 40;
-      e.target = menu.firstElementChild;
-     
-      $(menu.firstElementChild).trigger(e); // down arrow
-      
+      e.target = menu[0].firstElementChild;
+
+      $(menu[0].firstElementChild).trigger(e);
+
       return wait().then(() => {
-        debugger
-        let first = $(selectors[0].firstElementChild)
+        let first = $(selectors[0].firstElementChild);
         let second = $(selectors[1].firstElementChild);
         assert.ok(second.hasClass('md-focused') && !first.hasClass('md-focused'), 'focus has changed to second item');
-        let e = $.Event("keydown");
-        let menu = $('md-menu-content')[0];
+        let e = $.Event('keydown');
         e.which = 38;
         e.target = selectors[1];
-     
-        $(selectors[1]).trigger(e); // down arrow
+        $(selectors[1]).trigger(e);
         return wait().then(() => {
-          let first = $(selectors[0].firstElementChild)
+          let first = $(selectors[0].firstElementChild);
           let second = $(selectors[1].firstElementChild);
           assert.ok(!second.hasClass('md-focused') && first.hasClass('md-focused'), 'focus has changed to first item');
 
-        })
-      })
-      // $('md-backdrop').click();
-      // return wait().then(() => {
-      //   let selector = $('.md-backdrop');
-      //   assert.ok(!selector.length,'backdrop removed');
-      // });
+        });
+      });
     });
   });
 });

--- a/tests/integration/components/paper-menu-test.js
+++ b/tests/integration/components/paper-menu-test.js
@@ -1,0 +1,209 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
+import run from 'ember-runloop';
+
+moduleForComponent('paper-menu', 'Integration | Component | paper menu', {
+  integration: true
+});
+
+function focus(el) {
+  if (!el) {
+    return;
+  }
+  let $el = jQuery(el);
+  if ($el.is(':input, [contenteditable=true]')) {
+    let type = $el.prop('type');
+    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
+      run(null, function() {
+        // Firefox does not trigger the `focusin` event if the window
+        // does not have focus. If the document doesn't have focus just
+        // use trigger('focusin') instead.
+
+        if (!document.hasFocus || document.hasFocus()) {
+          el.focus();
+        } else {
+          $el.trigger('focusin');
+        }
+      });
+    }
+  }
+}
+
+function nativeClick(selector, options = {}) {
+  let mousedown = new window.Event('mousedown', { bubbles: true, cancelable: true, view: window });
+  let mouseup = new window.Event('mouseup', { bubbles: true, cancelable: true, view: window });
+  let click = new window.Event('click', { bubbles: true, cancelable: true, view: window });
+  Object.keys(options).forEach((key) => {
+    mousedown[key] = options[key];
+    mouseup[key] = options[key];
+    click[key] = options[key];
+  });
+  let element = document.querySelector(selector);
+  run(() => element.dispatchEvent(mousedown));
+  focus(element);
+  run(() => element.dispatchEvent(mouseup));
+  run(() => element.dispatchEvent(click));
+}
+
+function clickTrigger(scope, options = {}) {
+  let selector = '.ember-basic-dropdown-trigger';
+  nativeClick(selector, options);
+}
+
+test('opens on click', function(assert) {
+  assert.expect(1);
+  this.appRoot = document.querySelector('#ember-testing');
+  this.render(hbs`{{#paper-menu as |menu|}}
+    {{#menu.trigger}}
+      {{#paper-button iconButton=true}}
+        {{paper-icon "local_phone"}}
+      {{/paper-button}}
+    {{/menu.trigger}}
+    {{#menu.content width=4 as |content|}}
+        {{#content.menu-item onClick="openSomething"}}
+          <span id="menu-item">Test</span>
+        {{/content.menu-item}}
+    {{/menu.content}}
+  {{/paper-menu}}`);
+  
+  
+  return wait().then(() => {
+    clickTrigger();
+    
+    return wait().then(() => {
+      let selectors = $('.md-open-menu-container');
+      assert.ok(selectors.length, 'opened menu');
+      return wait().then(() => {
+
+      });
+    });
+  });
+});
+
+test('backdrop removed if menu closed', function(assert) {
+  assert.expect(2);
+  this.appRoot = document.querySelector('#ember-testing');
+  this.render(hbs`{{#paper-menu as |menu|}}
+    {{#menu.trigger}}
+      {{#paper-button iconButton=true}}
+        {{paper-icon "local_phone"}}
+      {{/paper-button}}
+    {{/menu.trigger}}
+    {{#menu.content width=4 as |content|}}
+        {{#content.menu-item onClick="openSomething"}}
+          <span id="menu-item">Test</span>
+        {{/content.menu-item}}
+    {{/menu.content}}
+  {{/paper-menu}}`);
+  
+  
+  return wait().then(() => {
+    clickTrigger();
+    
+    return wait().then(() => {
+
+      let selectors = $('.md-open-menu-container');
+      assert.ok(selectors.length, 'opened menu');
+      clickTrigger();
+      return wait().then(() => {
+        let selector = $('.md-backdrop');
+        assert.ok(!selector.length,'backdrop removed');
+      });
+    });
+  });
+});
+
+test('backdrop removed if backdrop clicked', function(assert) {
+  assert.expect(2);
+  this.appRoot = document.querySelector('#ember-testing');
+  this.render(hbs`{{#paper-menu as |menu|}}
+    {{#menu.trigger}}
+      {{#paper-button iconButton=true}}
+        {{paper-icon "local_phone"}}
+      {{/paper-button}}
+    {{/menu.trigger}}
+    {{#menu.content width=4 as |content|}}
+        {{#content.menu-item onClick="openSomething"}}
+          <span id="menu-item">Test</span>
+        {{/content.menu-item}}
+    {{/menu.content}}
+  {{/paper-menu}}`);
+  
+  
+  return wait().then(() => {
+    clickTrigger();
+    
+    return wait().then(() => {
+
+      let selectors = $('.md-open-menu-container');
+      assert.ok(selectors.length, 'opened menu');
+      $('md-backdrop').click();
+      return wait().then(() => {
+        let selector = $('.md-backdrop');
+        assert.ok(!selector.length,'backdrop removed');
+      });
+    });
+  });
+});
+
+test('keydown changes focused element', function(assert) {
+  assert.expect(3);
+  this.appRoot = document.querySelector('#ember-testing');
+  this.render(hbs`{{#paper-menu as |menu|}}
+    {{#menu.trigger}}
+      {{#paper-button iconButton=true}}
+        {{paper-icon "local_phone"}}
+      {{/paper-button}}
+    {{/menu.trigger}}
+    {{#menu.content width=4 as |content|}}
+        {{#content.menu-item onClick="openSomething"}}
+          <span id="menu-item">Test</span>
+        {{/content.menu-item}}
+        {{#content.menu-item onClick="openSomething"}}
+          <span id="menu-item2">Test 2</span>
+        {{/content.menu-item}}
+    {{/menu.content}}
+  {{/paper-menu}}`);
+  
+  
+  return wait().then(() => {
+    clickTrigger();
+    
+    return wait().then(() => {
+
+      let selectors = $('md-menu-item');
+      assert.ok($(selectors[0].firstElementChild).hasClass('md-focused'), 'first menu item given focus');
+      let e = $.Event("keydown");
+      let menu = $('md-menu-content')[0];
+      e.which = 40;
+      e.target = menu.firstElementChild;
+     
+      $(menu.firstElementChild).trigger(e); // down arrow
+      
+      return wait().then(() => {
+        debugger
+        let first = $(selectors[0].firstElementChild)
+        let second = $(selectors[1].firstElementChild);
+        assert.ok(second.hasClass('md-focused') && !first.hasClass('md-focused'), 'focus has changed to second item');
+        let e = $.Event("keydown");
+        let menu = $('md-menu-content')[0];
+        e.which = 38;
+        e.target = selectors[1];
+     
+        $(selectors[1]).trigger(e); // down arrow
+        return wait().then(() => {
+          let first = $(selectors[0].firstElementChild)
+          let second = $(selectors[1].firstElementChild);
+          assert.ok(!second.hasClass('md-focused') && first.hasClass('md-focused'), 'focus has changed to first item');
+
+        })
+      })
+      // $('md-backdrop').click();
+      // return wait().then(() => {
+      //   let selector = $('.md-backdrop');
+      //   assert.ok(!selector.length,'backdrop removed');
+      // });
+    });
+  });
+});


### PR DESCRIPTION
I also made the menu-items contextual components in order to use the ParentMixin and ChildMixin. Obviously neither is really necessary but you already had ParentMixin so I assumed that's the direction you wanted to go.