### PR TITLE
Whitelists google font stylesheets in CSP snippet.

### DIFF
--- a/tests/dummy/snippets/content-security-policy.js
+++ b/tests/dummy/snippets/content-security-policy.js
@@ -1,8 +1,9 @@
 ENV.contentSecurityPolicy = {
   'default-src': "'none'",
-  'script-src': "'self'",
-  'font-src': "'self' http://fonts.gstatic.com",
+  'script-src': "'self' 'unsafe-inline'",
+  'style-src': "'self' 'unsafe-inline' https://fonts.googleapis.com",
+  'font-src': "'self' fonts.gstatic.com",
   'connect-src': "'self'",
   'img-src': "'self' data:",
   'media-src': "'self'"
-}
+};


### PR DESCRIPTION
The readme is updated, but it looks like the docs' snippet was missed.