### PR TITLE
typo in Input example for errorMessages required

### DIFF
--- a/tests/dummy/app/templates/demo/input.hbs
+++ b/tests/dummy/app/templates/demo/input.hbs
@@ -25,7 +25,7 @@
       onChange=(action (mut address))
       required=true
       errorMessages=(hash
-        reuired="Address is required."
+        required="Address is required."
       )
     }}
     {{paper-input


### PR DESCRIPTION
minor typo in the documentation of the example app, but might cause some confusion for new users doing a naive copy and paste, which would still build but would display the default required error msg and not the custom errorMessage specified. 