### PR TITLE
allow SafeString in paper-inputs validation errorMessages

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -110,7 +110,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, {
         if (!validation.validate(currentValue, paramValue)) {
           let message = this.get(`errorMessages.${valParam}`) || get(validation, 'message');
           messages.pushObject({
-            message: Ember.String.loc(message, paramValue, currentValue)
+            message: Ember.String.loc(message.string || message, paramValue, currentValue)
           });
         }
       } catch (error) {

--- a/tests/dummy/app/templates/demo/input.hbs
+++ b/tests/dummy/app/templates/demo/input.hbs
@@ -25,7 +25,7 @@
       onChange=(action (mut address))
       required=true
       errorMessages=(hash
-        reuired="Address is required."
+        required="Address is required."
       )
     }}
     {{paper-input


### PR DESCRIPTION
Issue arose when using the ember-i18n add-on with paper, specifically for providing translation for paper input validator errorMessages
```
 {{paper-input
     value=identification
     label=(t "label.email")
     class="md-block"
     onChange=(action (mut identification))
     required=true
     errorMessages=(hash required=(t "paper.required”)) 
}} 
```  
this returned a console error: `vendor.js:151199Exception with validation:  Object TypeError: str.replace is not a function”  `

temporary work around would involve doing ; 
errorMessages=(hash required=(get (t "paper.required") "string"))

(@miguelcobain further suggest looking into Ember.String.loc and why it doesn't work with safe strings :/ )

 
