### PR TITLE
Update latest version copy as 1.0-alpha is default

### DIFF
--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -13,7 +13,7 @@
   {{/paper-toolbar}}
   {{#card.content}}
     <p>You are viewing the demonstration and documentation for a <strong>pre-production</strong> built of <code>ember-paper</code>. This version is in flux. For version 1.0, all components are being updated to reflect the latest Ember coding practices and Angular Material stylesheets. Components which have not yet been updated are shown with a {{paper-icon "warning"}} and are subject to API changes. Be sure to read CHANGELOG.md when updating.</p>
-    <p><strong>Wrong version?</strong> The currently-released version of ember-paper is version 0.2, currently installed by <br><code>ember install ember-paper</code>. See README.md for advice on which version to use. <a href="/ember-paper/release-0-2">Switch to version 0.2.</a></p>
+    <p><strong>Wrong version?</strong> The latest released stable version of <code>ember-paper</code> is 0.2, installed by <br><code>ember install ember-paper@^0.2</code>. See README.md for advice on which version to use. <a href="/ember-paper/release-0-2">Switch to version 0.2.</a></p>
   {{/card.content}}
   {{/paper-card}}
 
@@ -24,7 +24,7 @@
 
   <p>Install your preferred version of this ember-cli addon in your ember-cli project. To install the latest pre-production 1.0 version:</p>
   {{code-snippet name="install-1.0.sh"}}
-  <p>To install the 0.2 released version:</p>
+  <p>To install the latest stable 0.2 version:</p>
   {{code-snippet name="install-0.2.sh"}}
 
   <p>This should also automatically create an scss file under <code>app/styles/app.scss</code> with <code>@import 'ember-paper';</code> and install <code>ember-cli-sass</code>.</p>


### PR DESCRIPTION
Since `ember install ember-paper` now installs 1.0 by default we need to update the copy to reflect this. It looks like the changes have already been made to the snippets but it hasn't been deployed to github pages yet.