### PR TITLE
Install ember-cli-yuidoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ testem.log
 
 # editors
 /.idea
+
+# rendered API docs
+/tests/dummy/public/api-docs

--- a/addon/components/paper-sidenav.js
+++ b/addon/components/paper-sidenav.js
@@ -6,7 +6,7 @@ import Ember from 'ember';
 const { Component, computed } = Ember;
 
 /**
- * @class
+ * @class PaperSidenav
  * @extends Ember.Component
  */
 export default Component.extend({

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli-sass": "^5.2.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-yuidoc": "0.8.6",
     "ember-code-snippet": "1.3.0",
     "ember-cp-validations": "2.6.1",
     "ember-data": "^2.6.0",

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,0 +1,16 @@
+{
+  "name": "ember-paper",
+  "description": "The Ember approach to Material Design.",
+  "options": {
+    "paths": [
+      "addon"
+    ],
+    "exclude": "vendor",
+    "outdir": "docs",
+    "linkNatives": true,
+    "quiet": true,
+    "parseOnly": false,
+    "lint": false,
+    "enabledEnvironments": ["development", "production"]
+  }
+}

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -6,11 +6,10 @@
       "addon"
     ],
     "exclude": "vendor",
-    "outdir": "docs",
+    "outdir": "tests/dummy/public/api-docs",
     "linkNatives": true,
     "quiet": true,
     "parseOnly": false,
-    "lint": false,
-    "enabledEnvironments": ["development", "production"]
+    "lint": false
   }
 }


### PR DESCRIPTION
This allows API docs to be served via:

```
ember s --docs
```

Then navigate to /docs in the browser to see the rendered API docs.  This can be merged as is, but will need followup to figure out how to integrate with gh-pages.

Refs #444 
