### PR TITLE
Fix #448: Sidebar not closable by tapping away on mobile devices

### DIFF
--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -34,6 +34,10 @@ export default Component.extend(TransitionMixin, {
   click(e) {
     e.preventDefault();
     this.sendAction('onClick', e);
+  },
+
+  touchEnd(e) {
+    this.click(e);
   }
 
 });


### PR DESCRIPTION
Backdrop component now listens to `touchEnd` event and calls `this.click()` when fired.
