### PR TITLE
Fix ripple behaviour for touch devices

### DIFF
--- a/addon/mixins/ripple-mixin.js
+++ b/addon/mixins/ripple-mixin.js
@@ -126,9 +126,8 @@ export default Mixin.create({
 
   },
   bindEvents() {
-    this.rippleElement.on('mousedown', run.bind(this, this.handleMousedown));
-    this.rippleElement.on('mouseup touchend', run.bind(this, this.handleMouseup));
-    this.rippleElement.on('mouseleave', run.bind(this, this.handleMouseup));
+    this.rippleElement.on('mousedown touchstart pointerdown', run.bind(this, this.handleMousedown));
+    this.rippleElement.on('mouseup mouseleave touchend touchcancel pointerup pointercancel', run.bind(this, this.handleMouseup));
     this.rippleElement.on('touchmove', run.bind(this, this.handleTouchmove));
   },
   handleMousedown(event) {


### PR DESCRIPTION
The animation didn't start which made everything feel more slow and static.

Next: To make it more high fidelity and get it closer to the "Google Inbox App" we need a faster animation as the one which is used right now is too slow. But I'll put that into a separate pull request as it seems like we can't change the md-angular stylesheets (?) so I had to make the animation faster by increasing the ripple size 👯  Maybe you don't want such a hack in your app :)
