### PR TITLE
Added Form Feature - Show Errors Upon Submit if Not Disabled

### DIFF
--- a/addon/components/paper-form.js
+++ b/addon/components/paper-form.js
@@ -25,8 +25,12 @@ export default Component.extend(ParentMixin, {
       }
     },
     onSubmit() {
-      this.sendAction('onSubmit');
-      this.get('childComponents').setEach('isTouched', false);
+      if (this.get('isInvalid')) {
+        this.get('childComponents').setEach('isTouched', true);
+      } else {
+        this.sendAction('onSubmit');
+        this.get('childComponents').setEach('isTouched', false);
+      }
     }
   }
 });


### PR DESCRIPTION
Added ability for users who don't want to always disable the submit button, to display all the errors in the form upon the user interacting with the submit button prior to all fields being valid.