### PR TITLE
Added autoprefixer support for Safari >= 6 to use -webkit-flex

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = {
 
   postprocessTree: function(type, tree) {
     if (type === 'all' || type === 'styles') {
-      tree = autoprefixer(tree, { browsers: ['last 2 versions'] });
+      tree = autoprefixer(tree, { browsers: ['last 2 versions', 'Safari >= 6'] });
     }
     return tree;
   },

--- a/index.js
+++ b/index.js
@@ -132,7 +132,8 @@ module.exports = {
 
   postprocessTree: function(type, tree) {
     if (type === 'all' || type === 'styles') {
-      tree = autoprefixer(tree, { browsers: ['last 2 versions', 'Safari >= 6'] });
+      tree = autoprefixer(tree,
+          this.app.options.autoprefixer || { browsers: ['last 2 versions'] });
     }
     return tree;
   },


### PR DESCRIPTION
The "last 2 versions" rule for the autoprefixer was not sufficient to add "display: -webkit-flex" support for Safari v8.0.6 and Safari in iOS Simulator v8.3. All Flexbox based features were broken as a result.