### PR TITLE
Set the value before growing the textarea on render

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -155,9 +155,9 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
   },
 
   didRender() {
-    this.growTextarea();
     // setValue below ensures that the input value is the same as this.value
     this.setValue(this.get('value'));
+    this.growTextarea();
   },
 
   willClearRender() {


### PR DESCRIPTION
This fixes an issue with auto-grow when rendering a textarea that already had a `value` passed in (without user input).
