### PR TITLE
Fix ripple artifact in Chrome 51

### DIFF
--- a/addon/mixins/ripple-mixin.js
+++ b/addon/mixins/ripple-mixin.js
@@ -279,6 +279,7 @@ export default Mixin.create({
     }
     this.ripples.splice(this.ripples.indexOf(ripple), 1);
     ripple.removeClass('md-ripple-active');
+    ripple.addClass('md-ripple-remove');
     if (this.ripples.length === 0) {
       this._container.css({ backgroundColor: '' });
     }

--- a/app/styles/backports/ripple.scss
+++ b/app/styles/backports/ripple.scss
@@ -1,0 +1,32 @@
+//Fixed in angular-material#v1.1.0
+.md-ripple {
+  $sizeDuration: 0.45s * 2;
+  position: absolute;
+  transform: translate(-50%, -50%) scale(0);
+  transform-origin: 50% 50%;
+  opacity: 0;
+  border-radius: 50%;
+  &.md-ripple-placed {
+    transition: margin $sizeDuration $swift-ease-out-timing-function,
+                border $sizeDuration $swift-ease-out-timing-function,
+                width $sizeDuration $swift-ease-out-timing-function,
+                height $sizeDuration $swift-ease-out-timing-function,
+                opacity $sizeDuration $swift-ease-out-timing-function,
+                transform $sizeDuration $swift-ease-out-timing-function;
+  }
+  &.md-ripple-scaled {
+    transform: translate(-50%, -50%) scale(1);
+  }
+  &.md-ripple-active, &.md-ripple-full, &.md-ripple-visible {
+    opacity: 0.20;
+  }
+  &.md-ripple-remove {
+    animation: md-remove-ripple $sizeDuration $swift-ease-out-timing-function;
+  }
+}
+
+// Fix issue causing ripple disappear suddenly in Chrome version 51, opacity .15 is close to the opacity when a normal click mouseup
+@keyframes md-remove-ripple {
+  0% { opacity: .15; }
+  100% { opacity: 0; }
+}

--- a/app/styles/ember-paper.scss
+++ b/app/styles/ember-paper.scss
@@ -120,3 +120,4 @@
 
 // Backports of features from future versions of angular-material-source to this version
 @import './backports/paper-input';
+@import './backports/ripple';


### PR DESCRIPTION
Once we move to angular-material >= 1.1.0 we can remove those backported styles