### PR TITLE
solve null model bug in clear input

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -244,6 +244,10 @@ export default Component.extend({
   }),
 
   lookupLabelOfItem(model) {
+    //model might be null (when user cleared the input for example)
+    if(!model){
+      return '';
+    }
     return this.get('lookupKey') ? get(model, this.get('lookupKey')) : model;
   },
 

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -244,8 +244,8 @@ export default Component.extend({
   }),
 
   lookupLabelOfItem(model) {
-    //model might be null (when user cleared the input for example)
-    if(!model){
+    // model might be null (when user cleared the input for example)
+    if (!model) {
       return '';
     }
     return this.get('lookupKey') ? get(model, this.get('lookupKey')) : model;


### PR DESCRIPTION
When clearing the input of an autocomplete component, the model property is settet to null:

clear() {
      this.set('searchText', '');
      this.set('selectedIndex', -1);
      this.set('model', null); //here
      this.set('hidden', this.get('shouldHide'));
    }

But this will cause the call of "lookupLabelOfItem" in the "modelDidChange" with a model equal to null.
Without the check of the model value equal null, the code crash.