### PR TITLE
add guard in case focusTarget undefined

### DIFF
--- a/addon/components/paper-menu-content-inner.js
+++ b/addon/components/paper-menu-content-inner.js
@@ -24,7 +24,9 @@ export default Component.extend(ParentMixin, {
       if (!focusTarget.length) {
         focusTarget = this.get('enabledMenuItems.firstObject.element.firstElementChild');
       }
-      focusTarget.focus();
+      if (focusTarget) {
+        focusTarget.focus();
+      }
     });
   },
 


### PR DESCRIPTION
It's possible to generate an error if there is no valid focusTarget in the menu, this should resolve that issue by checking to see if focusTarget is defined before trying `focusTarget.focus()`