### PR TITLE
Close menu on click

### DIFF
--- a/addon/components/paper-menu-content-inner.js
+++ b/addon/components/paper-menu-content-inner.js
@@ -24,7 +24,9 @@ export default Component.extend(ParentMixin, {
       if (!focusTarget.length) {
         focusTarget = this.get('enabledMenuItems.firstObject.element.firstElementChild');
       }
-      focusTarget.focus();
+      if (focusTarget) {
+        focusTarget.focus();
+      }
     });
   },
 

--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -17,6 +17,7 @@ export default Component.extend(ChildMixin, {
 
   actions: {
     handleClick(event) {
+      this.get('dropdown.actions').close();
       this.sendAction('onClick', event);
     }
   },

--- a/app/templates/components/paper-menu-content-inner.hbs
+++ b/app/templates/components/paper-menu-content-inner.hbs
@@ -1,1 +1,1 @@
-{{yield (hash menu-item=(component "paper-menu-item" parentComponent=this))}}
+{{yield (hash menu-item=(component "paper-menu-item" dropdown=dropdown parentComponent=this))}}


### PR DESCRIPTION
The tests that are failing are autocomplete related and should be resolved once you merge my other PR.

This PR closes the dropdown after an item has been clicked, this is the behavior of AM menus.