### PR TITLE
changed growTextArea algorithm to follow more recent spec

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -183,11 +183,11 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
           this.lineHeight = inputElement.get(0).clientHeight;
           inputElement.get(0).style.minHeight = null;
         }
-        if (minRows && this.lineHeight) {
+        if (this.lineHeight) {
           height = Math.max(height, this.lineHeight * minRows);
         }
         let proposedHeight = Math.round(height / this.lineHeight);
-        let maxRows = this.get('passThru.maxRows') ? this.get('passThru.maxRows') : 99999999;
+        let maxRows = this.get('passThru.maxRows') ? this.get('passThru.maxRows') : Number.MAX_VALUE;
         let rowsToSet = Math.min(proposedHeight, maxRows);
         inputElement
           .css('height', `${this.lineHeight * rowsToSet}px`)
@@ -234,7 +234,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
       run.next(() => {
         this.setValue(this.get('value'));
       });
-      run.debounce(this, this.growTextarea, 10);
+      this.growTextarea();
       let inputElement = this.$('input').get(0);
       this.set('isNativeInvalid', inputElement && inputElement.validity && inputElement.validity.badInput);
       this.notifyValidityChange();

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -176,21 +176,23 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
       inputElement.addClass('md-no-flex').attr('rows', 1);
 
       let minRows = this.get('passThru.rows');
-
+      let height = this.getHeight(inputElement);
       if (minRows) {
         if (!this.lineHeight) {
           inputElement.get(0).style.minHeight = 0;
           this.lineHeight = inputElement.get(0).clientHeight;
           inputElement.get(0).style.minHeight = null;
         }
-
-        let newRows = Math.round(Math.round(this.getHeight(inputElement) / this.lineHeight));
-        let rowsToSet = Math.min(newRows, minRows);
-
+        if (minRows && this.lineHeight) {
+          height = Math.max(height, this.lineHeight * minRows);
+        }
+        let proposedHeight = Math.round(height / this.lineHeight);
+        let maxRows = this.get('passThru.maxRows') ? this.get('passThru.maxRows') : 99999999;
+        let rowsToSet = Math.min(proposedHeight, maxRows);
         inputElement
           .css('height', `${this.lineHeight * rowsToSet}px`)
           .attr('rows', rowsToSet)
-          .toggleClass('md-textarea-scrollable', newRows >= minRows);
+         .toggleClass('md-textarea-scrollable', proposedHeight >= maxRows);
       } else {
         inputElement.css('height', 'auto');
         inputElement.get(0).scrollTop = 0;
@@ -232,7 +234,7 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
       run.next(() => {
         this.setValue(this.get('value'));
       });
-      this.growTextarea();
+      run.debounce(this, this.growTextarea, 10);
       let inputElement = this.$('input').get(0);
       this.set('isNativeInvalid', inputElement && inputElement.validity && inputElement.validity.badInput);
       this.notifyValidityChange();

--- a/tests/dummy/app/templates/demo/input.hbs
+++ b/tests/dummy/app/templates/demo/input.hbs
@@ -12,7 +12,7 @@
     {{paper-input flex=true label="Company (disabled)" type="text" value="Google" disabled=true onChange=(action (mut foo))}}
   </div>
 
-  {{paper-input textarea=true block=true label="Biography" maxlength=150 passThru=(hash rows=5)
+  {{paper-input textarea=true block=true label="Biography" maxlength=150 passThru=(hash rows=5 maxRows=5)
     value=biography onChange=(action (mut biography))}}
   <p>Name: {{name}}</p>
   <p>Email: {{email}}</p>


### PR DESCRIPTION
paper-input used the correct algorithm for determining height from 1.0.6, however they've changed it radically and I think that the newer version was always the intended behaviour. passThru.rows is meant to be the *minimum* number of rows, not the maximum. I've added another property maxRows to allow them to specify that behavior.