### PR TITLE
referencing the correct API

### DIFF
--- a/addon/components/paper-dialog-content.js
+++ b/addon/components/paper-dialog-content.js
@@ -26,6 +26,6 @@ export default Component.extend({
   didInsertElement() {
     // content overflow might change depending on load of images inside dialog.
     let images = this.$().find('img');
-    images.load(run.bind(this, this.imagesLoaded));
+    images.on('load', run.bind(this, this.imagesLoaded));
   }
 });


### PR DESCRIPTION
without this change the browser throws an error when jquery tries to do a .indexOf on an anonymous function instead of a string