### PR TITLE
Call power-select's contentFor hook for body-footer

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     }
   },
 
-  contentFor: function(type) {
+  contentFor: function(type, config) {
     if (type === 'head') {
       return '<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">' +
         '<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">';

--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ module.exports = {
     if (type === 'head') {
       return '<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">' +
         '<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">';
+    } else if (type === 'body-footer') {
+      var emberPowerSelect = this.addons.filter(function(addon) {
+        return addon.name === 'ember-power-select';
+      })[0];
+      return emberPowerSelect.contentFor(type, config);
     }
   },
 


### PR DESCRIPTION
Without this, attempting to use paper-autocomplete in an app (or other addon) results in:
ember-wormhole failed to render into '#ember-basic-dropdown-wormhole' because the element is not in the DOM

See https://github.com/cibernox/ember-power-select/issues/145#issuecomment-170012836 for more detail