### PR TITLE
Upgrade paper-menu branch to ember-power-select 1.0.0-beta.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-css-transitions": "miguelcobain/ember-css-transitions#19baa1de8025abac0cf91206f9ef32210cb411ce",
     "ember-wormhole": "^0.4.0",
-    "ember-basic-dropdown": "^0.15.0-beta.5",
+    "ember-basic-dropdown": "^0.16.0-beta.4",
     "ember-power-select": "1.0.0-beta.19",
     "virtual-each": "0.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-css-transitions": "miguelcobain/ember-css-transitions#19baa1de8025abac0cf91206f9ef32210cb411ce",
     "ember-wormhole": "^0.4.0",
     "ember-basic-dropdown": "^0.15.0-beta.5",
-    "ember-power-select": "1.0.0-beta.14",
+    "ember-power-select": "1.0.0-beta.19",
     "virtual-each": "0.2.2"
   },
   "keywords": [


### PR DESCRIPTION
This fixes a memory leak, as well as fixing and improving a few other things.  Also bump minimum version of ember-basic-dropdown in core requirements to match that in e-p-s beta.19, to get some of the same fixes when using e-b-d directly.