### PR TITLE
clone still needs to be removed if the component has been destroyed

### DIFF
--- a/addon/components/paper-menu-content.js
+++ b/addon/components/paper-menu-content.js
@@ -51,6 +51,8 @@ export default ContentComponent.extend({
           $clone.removeClass('md-active');
           parentElement.removeChild(clone);
         });
+      } else {
+        parentElement.removeChild(clone);
       }
     });
   }


### PR DESCRIPTION
Had a problem where the component was destroyed before the animations were finished and the menu stayed behind. This should remove the clone regardless of whether the component has been destroyed to prevent visual glitches.