### PR TITLE
Add super calls inside paper-input lifecycle hooks.

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -155,14 +155,12 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
   },
 
   didRender() {
-    this._super(...arguments);
     this.growTextarea();
     // setValue below ensures that the input value is the same as this.value
     this.setValue(this.get('value'));
   },
 
   willClearRender() {
-    this._super(...arguments);
     this.sendAction('onValidityChange', false);
   },
 

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -155,16 +155,19 @@ export default BaseFocusable.extend(ColorMixin, FlexMixin, ChildMixin, {
   },
 
   didRender() {
+    this._super(...arguments);
     this.growTextarea();
     // setValue below ensures that the input value is the same as this.value
     this.setValue(this.get('value'));
   },
 
   willClearRender() {
+    this._super(...arguments);
     this.sendAction('onValidityChange', false);
   },
 
   willDestroyElement() {
+    this._super(...arguments);
     if (this.get('textarea')) {
       $(window).off(`resize.${this.elementId}`);
     }


### PR DESCRIPTION
* ensures hooks higher up in mixinx will fire properly

this was causing an error when we were using the `paper-form` input and dynamically adding/removing its child components in the form based on the current form data. 