### PR TITLE
Fix Glimmer 2 scroll for paper-select

### DIFF
--- a/addon/components/paper-select-content.js
+++ b/addon/components/paper-select-content.js
@@ -66,7 +66,7 @@ export default PaperMenuContent.extend({
     if (MutObserver) {
       this.mutationObserver = new MutObserver((mutations) => {
         // e-b-d incorrectly counts ripples as a mutation, triggering a problematic repositon
-        let addedNodes = Array.from(mutations[0].addedNodes).filter((node) => !$(node).hasClass('md-ripple'));
+        let addedNodes = Array.from(mutations[0].addedNodes).filter((node) => !$(node).hasClass('md-ripple') && (node.nodeName !== '#comment'));
         if (addedNodes.length || mutations[0].removedNodes.length) {
           this.runloopAwareReposition();
         }


### PR DESCRIPTION
under Glimmer 2 there is a new DOM mutation that wasn't there before. It's the addition of a `comment` node that happens under a number of circumstances, such as hovering over one of the options or the window losing focus. The reposition for paper-select includes changing the scrollTop value to center around selected values when the menu initially renders but that should only happen on initial render.

I'm asking the ember team about the nature of this node but regardless it likely is never desirable to trigger a reposition after adding it so I filtered it out of the DOM mutations that should rightfully trigger reposition.