### PR TITLE
pinning the version of ember-css-transistions as v0.1.5 was a breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "broccoli-autoprefixer": "^3.0.0",
     "ember-cli-babel": "^5.1.5",
-    "ember-css-transitions": "^0.1.0",
+    "ember-css-transitions": "0.1.2",
     "ember-wormhole": "^0.3.4"
   },
   "keywords": [


### PR DESCRIPTION
v0.1.2 was the most recent non-breaking version published to npm.

This fixes https://github.com/miguelcobain/ember-paper/issues/512