### PR TITLE
paper-icon: Set width as well as height / font-size

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -40,7 +40,7 @@ let PaperIconComponent = Component.extend(ColorMixin, {
     let size = this.get('size');
 
     if (size) {
-      return Str.htmlSafe(`height: ${size}px; font-size: ${size}px;`);
+      return Str.htmlSafe(`height: ${size}px; width: ${size}px; font-size: ${size}px;`);
     }
   })
 });


### PR DESCRIPTION
When specifying a size for paper-icon, only the height and font-size were being set - the width was always left at 24px.