### PR TITLE
paper-icon: Set md-font-icon attribute

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -15,7 +15,7 @@ let PaperIconComponent = Component.extend(ColorMixin, {
   tagName: 'md-icon',
   classNames: ['paper-icon', 'md-font', 'material-icons', 'md-default-theme'],
   classNameBindings: ['spinClass'],
-  attributeBindings: ['aria-label', 'title', 'sizeStyle:style'],
+  attributeBindings: ['aria-label', 'title', 'sizeStyle:style', 'iconClass:md-font-icon'],
 
   icon: '',
   spin: false,

--- a/tests/integration/components/paper-icon-test.js
+++ b/tests/integration/components/paper-icon-test.js
@@ -129,3 +129,14 @@ test('it renders the correct ligature when given a dashed or underscored icon na
 
   assert.equal($component.text().trim(), 'aspect_ratio');
 });
+
+test('it renders with md-font-icon attribute', function(assert) {
+  assert.expect(1);
+
+  this.set('iconName', 'check');
+  this.render(hbs`{{paper-icon iconName}}`);
+
+  let $component = this.$('md-icon');
+
+  assert.equal($component.attr('md-font-icon'), 'check');
+});


### PR DESCRIPTION
Following discussion in #514, set md-font-icon attribute on paper-icon so that the icon doesn't end up with a fixed width of 24px no matter what size is specified.