### PR TITLE
paper-autocomplete: don't highlight options by default

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -27,6 +27,9 @@ export default PowerSelect.extend({
   onfocus: computed.alias('onFocus'),
   onblur: computed.alias('onBlur'),
 
+  // Don't automatically highlight any option
+  defaultHighlighted: null,
+
   // Choose highlighted item on key Tab
   _handleKeyTab(e) {
     let publicAPI = this.get('publicAPI');

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-css-transitions": "0.1.5",
     "ember-wormhole": "0.4.1",
     "ember-basic-dropdown": "^0.16.0",
-    "ember-power-select": "1.0.0-beta.21",
+    "ember-power-select": "1.0.0-beta.23",
     "virtual-each": "0.3.1"
   },
   "keywords": [


### PR DESCRIPTION
Use ember-power-select 1.0.0-beta.23's new `defaultHighlighted` option to override its default highlighting (on open and filter/search) to match AM's behaviour - not highlighting anything.  Keyboard or mouse can be used to select an option from the dropdown.