### PR TITLE
fix `included` _super class

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
   name: 'ember-paper',
 
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
       app.import(app.bowerDirectory + '/hammer.js/hammer.js')


### PR DESCRIPTION
This fixes issues with people seeing `regeneratorRuntime` is not defined when ember-concurrency / ember-maybe-import-regenerator are deeply nested dependent addons.

[This new ember app](https://github.com/v3ss0n/ember-paper-menu-error-concurrency) demonstrates the bug and is fixed with this change to ember-paper.

Prior art: https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-88094450