### PR TITLE
Moved "hide-gt-sm" class in sidenav demo.

### DIFF
--- a/tests/dummy/app/templates/demo/sidenav.hbs
+++ b/tests/dummy/app/templates/demo/sidenav.hbs
@@ -44,8 +44,8 @@
             Left sidenav is {{if leftSideBarOpen "opened" "closed"}}
           </p>
 
-          {{#paper-sidenav-toggle name="left" class="hide-gt-sm" as |toggleAction|}}
-            {{#paper-button raised=true onClick=(action toggleAction)}}
+          {{#paper-sidenav-toggle name="left" as |toggleAction|}}
+            {{#paper-button raised=true classNames="hide-gt-sm" onClick=(action toggleAction)}}
               Toggle
             {{/paper-button}}
           {{/paper-sidenav-toggle}}


### PR DESCRIPTION
The component `paper-sidenav-toggle` now has a `tagName` of `''` so adding a class to it as shown in the demo doesn't work and `Toggle` is visible on all screen sizes.