### PR TITLE
paper-select focus fix

### DIFF
--- a/addon/components/paper-select-menu-inner.js
+++ b/addon/components/paper-select-menu-inner.js
@@ -30,7 +30,9 @@ export default PaperMenuContentInner.extend({
       } else {
         focusTarget = focusTarget[0];
       }
-      focusTarget.focus();
+      if (focusTarget) {
+        focusTarget.focus();
+      }
     });
   },
 


### PR DESCRIPTION
Should not try to call focusTarget.focus if there is no focusTarget (which is perfectly possible).