### PR TITLE
validation for autocomplete and change to form

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -28,8 +28,13 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
   onblur: computed.alias('onBlur'),
   onchange: null,
   oninput: null,
-  validationProperty: 'searchText',
-
+  validationProperty: computed('onSearchTextChange', 'onSelectionChange', function() {
+    if (this.get('onSearchTextChange')) {
+      return 'searchText';
+    } else {
+      return 'selected';
+    }
+  }),
   searchText: '',
   _onChangeNop: emberNop,
 

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -3,6 +3,8 @@
  */
 import Ember from 'ember';
 import PowerSelect from 'ember-power-select/components/power-select';
+import ValidationMixin from 'ember-paper/mixins/validation-mixin';
+import ChildMixin from 'ember-paper/mixins/child-mixin';
 import { indexOfOption } from 'ember-power-select/utils/group-utils';
 
 const { assert, computed, inject, isNone, defineProperty, K: emberNop } = Ember;
@@ -11,7 +13,7 @@ const { assert, computed, inject, isNone, defineProperty, K: emberNop } = Ember;
  * @class PaperAutocomplete
  * @extends PowerSelectComponent
  */
-export default PowerSelect.extend({
+export default PowerSelect.extend(ValidationMixin, ChildMixin, {
   util: inject.service(),
   constants: inject.service(),
   triggerComponent: 'paper-autocomplete-trigger',
@@ -26,6 +28,7 @@ export default PowerSelect.extend({
   onblur: computed.alias('onBlur'),
   onchange: null,
   oninput: null,
+  validationProperty: 'searchText',
 
   searchText: '',
   _onChangeNop: emberNop,
@@ -86,6 +89,7 @@ export default PowerSelect.extend({
       if (action) {
         action(this.get('publicAPI'), event);
       }
+      this.notifyValidityChange();
     },
 
     onInput(event) {
@@ -94,6 +98,7 @@ export default PowerSelect.extend({
       if (!publicAPI.isOpen && event.type !== 'change') {
         publicAPI.actions.open(event);
       }
+      this.notifyValidityChange();
       return this._super(...arguments);
     },
 

--- a/app/templates/components/paper-autocomplete-trigger.hbs
+++ b/app/templates/components/paper-autocomplete-trigger.hbs
@@ -3,6 +3,8 @@
     label=extra.label
     value=text
     flex=true
+    required=required
+    customValidations=customValidations
     disabled=(readonly disabled)
     onChange=(action "handleInputLocal")
     onFocus=(action onFocus)

--- a/app/templates/components/paper-autocomplete.hbs
+++ b/app/templates/components/paper-autocomplete.hbs
@@ -41,6 +41,8 @@
       searchEnabled=(readonly searchEnabled)
       searchField=(readonly searchField)
       searchText=(readonly searchText)
+      required=(readonly required)
+      customValidations=(readonly customValidations)
       select=(readonly publicAPI)
       selected=(readonly selected)
       selectedItemComponent=(readonly selectedItemComponent)

--- a/app/templates/components/paper-form.hbs
+++ b/app/templates/components/paper-form.hbs
@@ -5,6 +5,14 @@
     parentComponent=this
     onValidityChange=(action "onValidityChange")
   )
+  select=(component 'paper-select'
+  	parentComponent=this 
+  	onValidityChange=(action 'onValidityChange')
+  )
+  autocomplete=(component 'paper-autocomplete'
+  	parentComponent=this 
+  	onValidityChange=(action 'onValidityChange')
+  )
   onSubmit=(action "onSubmit")
 )}}
 


### PR DESCRIPTION
Added contextual components to paper-form for select and autocomplete. Interesting issue with autocomplete is that there are two properties that we may want to watch for validation over but currently validation-mixin only supports a single validation property. For now I set it to do validation on searchText but that can be changed by the user by passing in validationProperty='selected'.

Validation messages for autocomplete will only show up for the floating label version for obvious reasons.