### PR TITLE
VR: ignore offsetter parameter

### DIFF
--- a/app/templates/components/paper-virtual-repeat.hbs
+++ b/app/templates/components/paper-virtual-repeat.hbs
@@ -1,6 +1,14 @@
 {{#paper-virtual-repeat-scroller onScroll=(action 'onScroll')}}
   <div class="md-virtual-repeat-sizer" style={{contentStyle}}></div>
-  <div class="md-virtual-repeat-offsetter" style={{offsetterStyle}}>
-    {{yield rawVisibleItems visibleItems}}
-  </div>
+  {{#if ignoreOffsetter}}
+  	<div class="md-virtual-repeat-offsetter"></div>
+
+  {{else}}
+  	<div class="md-virtual-repeat-offsetter" style={{offsetterStyle}}>
+    	{{yield rawVisibleItems visibleItems}}
+  	</div>
+  {{/if}}
 {{/paper-virtual-repeat-scroller}}
+{{#if ignoreOffsetter}}
+	{{yield rawVisibleItems visibleItems}}
+{{/if}}


### PR DESCRIPTION
sometimes it is desirable to have the list items render outside of the virtual repeats offsetter. In particular, using VR in conjunction with tables (such as paper-data-table) requires the table to be rendered as a sibling of the offsetter to work correctly.

I'd also like to remove the virtual-each class from the paper-virtual-repeat, I'm not sure how to do that though since it's being added by the parent class and doesn't appear to be overridden by the paper-virtual-repeat implementation. 