### PR TITLE
`self.document` to `document` to resolve JSHint issue

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -115,11 +115,11 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     },
 
     scrollTo(option) {
-      if (!self.document || !option) {
+      if (!document || !option) {
         return;
       }
       let publicAPI = this.get('publicAPI');
-      let optionsList = self.document.getElementById(`ember-power-select-options-${publicAPI.uniqueId}`);
+      let optionsList = document.getElementById(`ember-power-select-options-${publicAPI.uniqueId}`);
 
       if (!optionsList) {
         return;


### PR DESCRIPTION
ember-cli ships with these `"predefs"` in `.jshintrc`

```
"predef": [
    "document",
    "window",
    "-Promise",
    "moment"
  ]
```

`self.document` was causing JSHint errors when running tests.  Changed `self.document` to `document` to work with default ember-cli defs.