### PR TITLE
allow touch devices to interact with autocomplete

### DIFF
--- a/addon/components/paper-autocomplete-trigger-container.js
+++ b/addon/components/paper-autocomplete-trigger-container.js
@@ -20,7 +20,18 @@ export default BasicTrigger.extend({
     }
     return tabindex;
   }),
-
+  addMandatoryHandlers() {
+    if (this.get('isTouchDevice')) {
+      this.element.addEventListener('touchstart', () => {
+        self.document.body.addEventListener('touchmove', this._touchMoveHandler);
+      });
+      this.element.addEventListener('touchend', (e) => {
+        this.send('handleTouchEnd', e);
+      });
+    }
+    this.element.addEventListener('mousedown', (e) => this.send('handleMousedown', e));
+    this.element.addEventListener('keydown', (e) => this.send('handleKeydown', e));
+  },
   actions: {
 
     handleMousedown() {


### PR DESCRIPTION
Currently, touch devices are unable to focus on the input in paper-autocomplete because ember-basic-dropdown does a preventDefault on the touch event that prevents the focus event from being called on the input. This corrects that issue.