### PR TITLE
[paper-input] preventing exception when typing with mobile keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Contributions and pull requests are always welcome. Contributors may often be fo
 ### master
 - [#542](https://github.com/miguelcobain/ember-paper/pull/542) paper-form now yields a submit button
 - [#549](https://github.com/miguelcobain/ember-paper/pull/549) Allow `title` attribute in paper-button
+- [#551](https://github.com/miguelcobain/ember-paper/pull/551) avoids calling setValue when the component is destroyed
 
 ### 1.0.0-alpha.7 (November 2, 2016)
 - [#531](https://github.com/miguelcobain/ember-paper/pull/531) paper-select focus fix - doesn't call focusTarget.focus if there is no focusTarget (which is perfectly possible)

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -142,7 +142,9 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
       this.sendAction('onChange', e.target.value);
       // setValue below ensures that the input value is the same as this.value
       run.next(() => {
-        if (this.isDestroyed) { return; }
+        if (this.isDestroyed) {
+          return;
+        }
         this.setValue(this.get('value'));
       });
       this.growTextarea();

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -132,7 +132,7 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
   },
 
   setValue(value) {
-    if (this.$('input, textarea').val() !== value) {
+    if (this.$('input, textarea') && this.$('input, textarea').val() !== value) {
       this.$('input, textarea').val(value);
     }
   },

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -132,7 +132,7 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
   },
 
   setValue(value) {
-    if (this.$('input, textarea') && this.$('input, textarea').val() !== value) {
+    if (this.$('input, textarea').val() !== value) {
       this.$('input, textarea').val(value);
     }
   },
@@ -142,6 +142,7 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
       this.sendAction('onChange', e.target.value);
       // setValue below ensures that the input value is the same as this.value
       run.next(() => {
+        if (this.isDestroyed) { return; }
         this.setValue(this.get('value'));
       });
       this.growTextarea();


### PR DESCRIPTION
I got the following exception on paper-input when typing with the Android keyboard:

 [paper-input error](https://drive.google.com/file/d/0B_CrumEitcQDREFQaVRLc1UtczA/view?usp=sharing)
Cannot read property 'val' of undefined.

Steps to reproduce:

requirements:
Android smartphone with google chrome


1. Open Chrome dev tools and setup it for [remote debugging](https://developers.google.com/web/tools/chrome-devtools/remote-debugging/)
2. On the phone open this page [dialog example](http://miguelcobain.github.io/ember-paper/release-1/#/components/dialog)
3. In the prompt dialog example type some text with the phone keyboard (has to be with the phone keyboard)
4. Click on confirm action on the dialogue 

Expected:  Dialog closes
Actual: Dialog remains opened  with the error linked above
 
The fix in the pull request prevents this exception while maintaining the current behavior. 