### PR TITLE
[DEMO] width should be height

### DIFF
--- a/tests/dummy/app/templates/layout/layout-containers.hbs
+++ b/tests/dummy/app/templates/layout/layout-containers.hbs
@@ -12,7 +12,7 @@
   {{paper-api
     (p-section
       (p-row "layout-row" "Items arranged horizontally. `max-height = 100%` and `max-width` is the width of the items in the container.")
-      (p-row "layout-column" "Items arranged vertically. `max-width = 100%` and `max-height` is the width of the items in the container.")
+      (p-row "layout-column" "Items arranged vertically. `max-width = 100%` and `max-height` is the height of the items in the container.")
     )
     header=(p-row "Class" "Effect")
   }}


### PR DESCRIPTION
the max-width is set to 100% so max-height is the the height of the items in the container, not the width