### PR TITLE
Close autocomplete drop-down on tabKey

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -63,12 +63,14 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     defineProperty(this, 'onchange', computed.alias(aliasOnChangeDepKey));
   },
 
-  // Choose highlighted item on key Tab
+  // Choose highlighted item on key tab
   _handleKeyTab(e) {
     let publicAPI = this.get('publicAPI');
     if (publicAPI.isOpen && !isNone(publicAPI.highlighted)) {
       publicAPI.actions.choose(publicAPI.highlighted, e);
     }
+    // e-p-s will close
+    this._super(...arguments);
   },
 
   actions: {


### PR DESCRIPTION
To reproduce:
1. In e-p current demo (v1.0.0-alpha.8), click on any autocomplete, then hit 'tab' key w/o selecting/highlighting any items
2. The autocomplete drop-down stays open

Fix:
- When tab is invoked, just delegate to e-p-s component, which closes the drop-down by default.