### PR TITLE
Make autocomplete similar to paper-input (required star & passThru hash)

### DIFF
--- a/app/templates/components/paper-autocomplete-trigger.hbs
+++ b/app/templates/components/paper-autocomplete-trigger.hbs
@@ -3,6 +3,8 @@
     label=extra.label
     value=text
     flex=true
+    required=(readonly required)
+    passThru=(readonly passThru)
     validationErrorMessages=(readonly validationErrorMessages)
     disabled=(readonly disabled)
     onChange=(action "handleInputLocal")
@@ -20,7 +22,23 @@
     onblur={{action onBlur}}
     onkeydown={{action "handleKeydown"}}
     disabled={{readonly disabled}}
-    onmousedown={{action "stopPropagation"}}>
+    onmousedown={{action "stopPropagation"}}
+
+    accept={{passThru.accept}}
+    autocomplete={{passThru.autocomplete}}
+    autosave={{passThru.autosave}}
+    form={{passThru.form}}
+    formaction={{passThru.formaction}}
+    formenctype={{passThru.formenctype}}
+    formmethod={{passThru.formmethod}}
+    formnovalidate={{passThru.formnovalidate}}
+    formtarget={{passThru.formtarget}}
+    inputmode={{passThru.inputmode}}
+    pattern={{passThru.pattern}}
+    readonly={{passThru.readonly}}
+    selectionDirection={{passThru.selectionDirection}}
+    spellcheck={{passThru.spellcheck}}
+    step={{passThru.step}}>
 {{/if}}
 {{#if (and select.loading select.isActive)}}
   {{paper-progress-linear classNameBindings="extra.label:md-inline"}}

--- a/app/templates/components/paper-autocomplete.hbs
+++ b/app/templates/components/paper-autocomplete.hbs
@@ -26,6 +26,8 @@
     label=label}}
     {{#component triggerComponent
       allowClear=(readonly allowClear)
+      required=(readonly required)
+      passThru=(readonly passThru)
       class="layout-row"
       flex=(readonly flex)
       disabled=disabled

--- a/tests/dummy/app/templates/demo/autocomplete.hbs
+++ b/tests/dummy/app/templates/demo/autocomplete.hbs
@@ -97,6 +97,7 @@
       {{paper-input label="Name" value=name onChange=(action (mut name)) class="flex"}}
         {{#paper-autocomplete
           disabled=(readonly disabled2)
+          required=(readonly isRequired)
           triggerClass="flex"
           options=items
           selected=selectedCountry2
@@ -112,6 +113,7 @@
             searchText=select.searchText
             flags="i"}}
       {{/paper-autocomplete}}
+
       {{! END-SNIPPET }}
     </div>
     <p>
@@ -130,6 +132,11 @@
       value=simulateQuery2
       onChange=(action (mut simulateQuery2))}}
       Simulate query
+    {{/paper-checkbox}}
+    {{#paper-checkbox
+      value=isRequired
+      onChange=(action (mut isRequired))}}
+      Is required
     {{/paper-checkbox}}
 
     <h3>Template</h3>


### PR DESCRIPTION
1. Support required attribute on autocomplete similar to paper-input (shown
with a start (*))
2. Allow passThru hash to passed in.