### PR TITLE
automatically set the type of submit-button to submit

### DIFF
--- a/app/templates/components/paper-form.hbs
+++ b/app/templates/components/paper-form.hbs
@@ -7,13 +7,14 @@
   )
   submit-button=(component "paper-button"
     onClick=(action "onSubmit")
+    type="submit"
   )
   select=(component "paper-select"
   	parentComponent=this
   	onValidityChange=(action "onValidityChange")
   )
   autocomplete=(component "paper-autocomplete"
-  	parentComponent=this 
+  	parentComponent=this
   	onValidityChange=(action "onValidityChange")
   )
   onSubmit=(action "onSubmit")

--- a/tests/integration/components/paper-form-test.js
+++ b/tests/integration/components/paper-form-test.js
@@ -169,3 +169,16 @@ test('form submit button calls form onSubmit action', function(assert) {
 
   this.$('button').click();
 });
+
+test('form submit button is of type submit', function(assert) {
+  this.set('onSubmit', () => {
+  });
+
+  this.render(hbs`
+    {{#paper-form onSubmit=(action onSubmit) as |form|}}
+      {{#form.submit-button}}Submit{{/form.submit-button}}
+    {{/paper-form}}
+  `);
+
+  assert.equal(this.$('button').attr('type'), 'submit');
+});


### PR DESCRIPTION
Specify the type of paper-form button as submit so that the form can be submitted using enter key

See #460 