### PR TITLE
can add CSS classes to paper dialog container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Contributions and pull requests are always welcome. Contributors may often be fo
 - [a4acae4](https://github.com/miguelcobain/ember-paper/commit/a4acae4bb014a476506603e2e82e5d6467f30efe) Remove usage of `Ember.K`
 - [#560](https://github.com/miguelcobain/ember-paper/pull/560) `paper-autocomplete` works with `allowClear` + floating label
 - [#567](https://github.com/miguelcobain/ember-paper/pull/567) `paper-autocomplete-highlight` now highlights non-string labels
+- [#571](https://github.com/miguelcobain/ember-paper/pull/571) Allow css class on paper dialog and its container
 
 ### 1.0.0-alpha.7 (November 2, 2016)
 - [#531](https://github.com/miguelcobain/ember-paper/pull/531) paper-select focus fix - doesn't call focusTarget.focus if there is no focusTarget (which is perfectly possible)

--- a/app/templates/components/paper-dialog.hbs
+++ b/app/templates/components/paper-dialog.hbs
@@ -5,8 +5,9 @@
     fixed=(unless parent true)
     class="md-dialog-backdrop"
     onClick=(action "outsideClicked")}}
-  {{#paper-dialog-container outsideClicked=(action "outsideClicked")}}
+  {{#paper-dialog-container class=(readonly dialogContainerClass) outsideClicked=(action "outsideClicked")}}
     {{#paper-dialog-inner
+      class=(readonly class)
       origin=origin
       defaultedParent=defaultedParent
       defaultedOpenFrom=defaultedOpenFrom

--- a/tests/dummy/app/templates/demo/dialog.hbs
+++ b/tests/dummy/app/templates/demo/dialog.hbs
@@ -63,7 +63,7 @@
 
 {{! BEGIN-SNIPPET dialog }}
 {{#if showDialogWithParent}}
-  {{#paper-dialog onClose=(action "closeDialogWithParent" "cancel") parent="#paper-dialog-demo" origin=dialogOrigin clickOutsideToClose=true}}
+  {{#paper-dialog class="flex-50" onClose=(action "closeDialogWithParent" "cancel") parent="#paper-dialog-demo" origin=dialogOrigin clickOutsideToClose=true}}
     <form>
       {{#paper-toolbar}}
         {{#paper-toolbar-tools}}
@@ -74,11 +74,9 @@
       {{/paper-toolbar}}
 
       {{#paper-dialog-content}}
-        <div style="max-width:800px;max-height:810px;">
           <p>
             This is a dialog rendered into a specific element. Clicking outside the dialog will close it.
           </p>
-        </div>
       {{/paper-dialog-content}}
 
       {{#paper-dialog-actions class="layout-row"}}
@@ -91,7 +89,7 @@
 {{/if}}
 
 {{#if showDialog}}
-  {{#paper-dialog onClose=(action "closeDialog" "cancel") origin=dialogOrigin clickOutsideToClose=true}}
+  {{#paper-dialog class="flex-77" onClose=(action "closeDialog" "cancel") origin=dialogOrigin clickOutsideToClose=true}}
     {{#paper-toolbar}}
       {{#paper-toolbar-tools}}
         <h2>Mango (Fruit)</h2>
@@ -101,12 +99,10 @@
     {{/paper-toolbar}}
 
     {{#paper-dialog-content}}
-      <div style="max-width:800px;max-height:810px;">
         <p>
           The mango is a juicy stone fruit belonging to the genus Mangifera, consisting of numerous tropical fruiting trees, cultivated mostly for edible fruit. The majority of these species are found in nature as wild mangoes. They all belong to the flowering plant family Anacardiaceae. The mango is native to South and Southeast Asia, from where it has been distributed worldwide to become one of the most cultivated fruits in the tropics.
         </p>
         <img style="margin: auto; max-width: 100%;" alt="Lush mango tree" src="http://weknowyourdreamz.com/images/mango/mango-01.jpg">
-      </div>
     {{/paper-dialog-content}}
 
     {{#paper-dialog-actions class="layout-row"}}

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -252,3 +252,23 @@ test('opening gives focus', function(assert) {
   });
 
 });
+
+test('can specify dialog container classes', function(assert) {
+  this.render(hbs`
+    <div id="paper-wormhole"></div>
+    {{paper-dialog dialogContainerClass="flex-50 my-dialog-container"}}
+  `);
+
+  assert.ok(this.$('.md-dialog-container').hasClass('flex-50'), 'has flex-50 css class');
+  assert.ok(this.$('.md-dialog-container').hasClass('my-dialog-container'), 'has my-dialog-container css class');
+});
+
+test('can specify dialog css classes', function(assert) {
+  this.render(hbs`
+    <div id="paper-wormhole"></div>
+    {{paper-dialog class="flex-50 my-dialog-inner"}}
+  `);
+
+  assert.ok(this.$('md-dialog').hasClass('flex-50'), 'has flex-50 css class');
+  assert.ok(this.$('md-dialog').hasClass('my-dialog-inner'), 'has my-dialog-inner css class');
+});


### PR DESCRIPTION
Add the capability for the user to specify CSS classes to the paper dialog container if necessary.