### PR TITLE
remove overflow:hidden directive on body tag that breaks test app

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -10,7 +10,6 @@ $accent: 'pink';
  */
 
 body {
-  overflow: hidden;
   max-width: 100%;
   max-height: 100%;
 }


### PR DESCRIPTION
Because the test app share its css with the dummy app. It had the 'overflow:hidden' css property which prevent the user from scrolling.

This property seems unnecessary as it does not appear* to affect the dummy app in anyway.

* tested on chrome only 