### PR TITLE
Paper-autocomplete options must only be shown when interacted with

### DIFF
--- a/addon/components/paper-chips.js
+++ b/addon/components/paper-chips.js
@@ -68,7 +68,7 @@ export default Component.extend({
       }
 
       // Keep track of the autocomplete, so we can force it to close when navigating to chips.
-      if (isEmpty(this.get('autocomplete')) && input.is('.ember-power-select-typeahead-input')) {
+      if (isEmpty(this.get('autocomplete')) && input.is('.ember-paper-autocomplete-search-input')) {
         this.set('autocomplete', autocomplete);
       }
 
@@ -194,7 +194,7 @@ export default Component.extend({
     let select = this.get('autocomplete');
     let input = this.getInput();
 
-    if (input.is('.ember-power-select-typeahead-input') && isPresent(select)) {
+    if (input.is('.ember-paper-autocomplete-search-input') && isPresent(select)) {
       // Reset the underlying ember-power-select so that it's ready for another selection.
       input.val('');
       select.actions.search('');

--- a/app/templates/components/paper-autocomplete-trigger.hbs
+++ b/app/templates/components/paper-autocomplete-trigger.hbs
@@ -14,7 +14,7 @@
 {{else}}
   <input type="search"
     value={{text}}
-    class="ember-power-select-typeahead-input ember-power-select-search-input flex"
+    class="flex"
     placeholder={{readonly placeholder}}
     oninput={{action "handleInputLocal"}}
     onchange={{action "handleInputLocal"}}

--- a/app/templates/components/paper-autocomplete-trigger.hbs
+++ b/app/templates/components/paper-autocomplete-trigger.hbs
@@ -14,7 +14,7 @@
 {{else}}
   <input type="search"
     value={{text}}
-    class="flex"
+    class="ember-paper-autocomplete-search-input flex"
     placeholder={{readonly placeholder}}
     oninput={{action "handleInputLocal"}}
     onchange={{action "handleInputLocal"}}

--- a/app/templates/components/paper-chips.hbs
+++ b/app/templates/components/paper-chips.hbs
@@ -1,4 +1,9 @@
-<md-chips-wrap class="md-chips {{if (and (not readOnly) isFocused) 'md-focused'}}" tabindex="-1" onkeydown={{action 'keyDown'}} onfocus={{action 'chipsFocus'}} onblur={{action 'chipsBlur'}}>
+<md-chips-wrap
+  class="md-chips {{if (and (not readOnly) isFocused) 'md-focused'}}"
+  tabindex="-1"
+  onkeydown={{action 'keyDown'}}
+  onfocus={{action 'chipsFocus'}}
+  onblur={{action 'chipsBlur'}}>
   {{#each content as |item index|}}
     <md-chip class="md-chip md-default-theme {{if readOnly 'md-readonly'}} {{if (eq activeChip index) 'md-focused'}}">
       <div class="md-chip-content" tabindex="-1" aria-hidden="true">
@@ -10,7 +15,7 @@
       </div>
       <div class="md-chip-remove-container">
         {{#unless readOnly}}
-          <button class="md-chip-remove" {{action (action removeItem item)}} type="button" aria-hidden="true" tabindex="-1">
+          <button class="md-chip-remove" onclick={{action removeItem item}} type="button" aria-hidden="true" tabindex="-1">
             {{paper-icon icon="clear" size=18}}
             <span class="md-visually-hidden"> Remove </span>
           </button>
@@ -24,7 +29,18 @@
   {{#unless readOnly}}
     <div class="md-chip-input-container">
       {{#if (or requireMatch options)}}
-        {{#paper-autocomplete closeOnSelect=true onBlur=(action 'inputBlur') onSelectionChange=(action 'autocompleteChange') onSearchTextChange=(action 'searchTextChange') onFocus=(action 'inputFocus') onOpen=(action 'inputFocus') onCreate=(action 'addItem') placeholder=placeholder options=options searchField=searchField noMatchesMessage=noMatchesMessage as |item|}}
+        {{#paper-autocomplete
+          options=options
+          closeOnSelect=true
+          placeholder=placeholder
+          searchField=searchField
+          noMatchesMessage=noMatchesMessage
+          onBlur=(action 'inputBlur')
+          onSelectionChange=(action 'autocompleteChange')
+          onSearchTextChange=(action 'searchTextChange')
+          onFocus=(action 'inputFocus')
+          onOpen=(action 'inputFocus')
+          onCreate=(action 'addItem') as |item|}}
           {{#if hasBlock}}
             {{yield item}}
           {{else}}
@@ -32,7 +48,13 @@
           {{/if}}
         {{/paper-autocomplete}}
       {{else}}
-        {{input tabindex="0" placeholder=placeholder aria-label="Add Tag" value=newChipValue focus-in="inputFocus" focus-out="inputBlur" enter=(action 'addItem' newChipValue)}}
+        {{input tabindex="0"
+          placeholder=placeholder
+          aria-label="Add Tag"
+          value=newChipValue
+          focus-in="inputFocus"
+          focus-out="inputBlur"
+          enter=(action 'addItem' newChipValue)}}
       {{/if}}
     </div>
   {{/unless}}

--- a/app/templates/components/paper-select.hbs
+++ b/app/templates/components/paper-select.hbs
@@ -71,16 +71,20 @@
     to=(readonly destination)
     searchEnabled=searchEnabled
     dropdown=publicAPI as |content|}}
-    {{component beforeOptionsComponent
-      extra=(readonly extra)
-      listboxId=(readonly optionsId)
-      onInput=(action "onInput")
-      onKeydown=(action "onKeydown")
-      searchEnabled=(readonly searchEnabled)
-      onFocus=(action "onFocus")
-      onBlur=(action "deactivate")
-      searchPlaceholder=(readonly searchPlaceholder)
-      select=(readonly publicAPI)}}
+    {{#if searchEnabled}}
+      {{component beforeOptionsComponent
+        extra=(readonly extra)
+        listboxId=(readonly optionsId)
+        onInput=(action "onInput")
+        onKeydown=(action "onKeydown")
+        searchEnabled=(readonly searchEnabled)
+        onFocus=(action "onFocus")
+        onBlur=(action "deactivate")
+        searchPlaceholder=(readonly searchPlaceholder)
+        select=(readonly publicAPI)
+      }}
+    {{/if}}
+
     {{#if mustShowSearchMessage}}
       {{component searchMessageComponent
         searchMessage=(readonly searchMessage)


### PR DESCRIPTION
Fixes a bug where clicking on paper-select component would cause paper-autocomplete w/o a label to also display its own dropdown options.