### PR TITLE
Update Ember, Ember CLI and Ember Data to 2.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log
 
 # editors

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -20,7 +21,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-1.13
 
 before_install:
   - npm config set spin false

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "ember-paper",
   "dependencies": {
-    "ember-cli-shims": "0.1.1",
+    "ember": "~2.10.0",
+    "ember-cli-shims": "0.1.3",
     "hammer.js": "^2.0.8",
     "matchMedia": "0.2.0",
-    "prism": "*",
-    "ember": "^2.9.0"
+    "prism": "*"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,19 +2,24 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-lts-2.4',
       bower: {
-        dependencies: { }
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
       }
     },
     {
-      name: 'ember-1.13',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-8'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/miguelcobain/ember-paper",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "author": "Miguel Andrade <jmandrade0@gmail.com>",
   "license": "MIT",
@@ -21,19 +21,19 @@
     "url": "https://github.com/miguelcobain/ember-paper/issues"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
+    "broccoli-asset-rev": "^2.4.5",
     "broccoli-static-compiler": "~0.2.1",
-    "ember-ajax": "^2.0.1",
-    "ember-cli": "2.8.0",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "^2.10.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-fastboot": "1.0.0-beta.9",
     "ember-cli-github-pages": "^0.1.2",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sass": "^5.2.1",
     "ember-cli-sri": "^2.1.0",
@@ -41,8 +41,8 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.3.0",
     "ember-cp-validations": "3.0.1",
+    "ember-data": "^2.10.0",
     "ember-deferred-content": "0.2.0",
-    "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-inflector": "1.9.4",
@@ -51,7 +51,7 @@
     "ember-suave": "4.0.1",
     "ember-transition-helper": "0.0.6",
     "liquid-fire": "0.26.4",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.10"
   },
   "dependencies": {
     "angular-material-source": "angular/material#v1.0.6",
@@ -60,7 +60,7 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.0",
     "ember-basic-dropdown": "^0.16.0",
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^5.1.7",
     "ember-composability-tools": "0.0.5",
     "ember-css-transitions": "0.1.7",
     "ember-power-select": "1.0.0-beta.23",

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
-const { merge, run } = Ember;
+const { assign, run } = Ember;
 
 export default function startApp(attrs) {
   let application;
 
-  let attributes = merge({}, config.APP);
-  attributes = merge(attributes, attrs); // use defaults, but you can override;
+  // use defaults, but you can override
+  let attributes = assign({}, config.APP, attrs);
 
   run(() => {
     application = Application.create(attributes);

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,7 +19,7 @@
         zoom: 100%
       }
     </style>
-
+    
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
@@ -27,7 +27,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>


### PR DESCRIPTION
Also includes `ember init`, which changed the ember try config slightly. Let me know what you think.

I tested the dummy app using 2.9 and 2.10 and found no differences. 2.10 felt a little faster on pages with a lot of components (like the input demo), but that's subjective.

### File sizes of the app bundle in a production build
|gzipped|size 2.9 | size 2.10 | reduction |
|---|---|---|---|
no |988.15 KB |465.31 KB | 53%
yes |103.81 |64.74 KB | 38%

Probably slightly skewed because the dummy app almost entirely consists of templates.