### PR TITLE
Allow external validations to return array or string

### DIFF
--- a/addon/mixins/validation-mixin.js
+++ b/addon/mixins/validation-mixin.js
@@ -50,12 +50,16 @@ function buildComputedValidationMessages(property) {
       }
     });
 
-    // error messages array
+    // error messages array and string
     let errors = this.get('errors') || [];
-    assert('`errors` must be an array', isArray(errors));
-    messages.pushObjects(errors.map((e) => {
-      return get(e, 'message') ? e : { message: e };
-    }));
+    assert('`errors` must be an array or string', isArray(errors) || typeof errors === 'string' || errors instanceof String);
+    if(isArray(errors)) {
+      messages.pushObjects(errors.map((e) => {
+        return get(e, 'message') ? e : {message: e};
+      }));
+    }else if(typeof errors === 'string' || errors instanceof String){
+      messages.pushObject({ message: errors});
+    }
 
     return messages;
   });


### PR DESCRIPTION
Some external validators just provide a error string.
Allowing them to pass a string doesn’t seem have any side effects.
Therefor I propose to add this option. As it would make my life way easier.

An other option would be to add an 'error' property for strings and not use the 'errors' property.