### PR TITLE
search fix

### DIFF
--- a/addon/components/paper-menu-content.js
+++ b/addon/components/paper-menu-content.js
@@ -63,7 +63,7 @@ export default ContentComponent.extend({
       this.mutationObserver = new MutObserver((mutations) => {
         // e-b-d incorrectly counts ripples as a mutation, triggering a problematic repositon
         // convert NodeList to Array
-        let addedNodes = Array.prototype.slice.call(mutations[0].addedNodes).filter((node) => !$(node).hasClass('md-ripple') && (node.nodeName !== '#comment'));
+        let addedNodes = Array.prototype.slice.call(mutations[0].addedNodes).filter((node) => !$(node).hasClass('md-ripple') && (node.nodeName !== '#comment') && !(node.nodeName == "#text" && node.nodeValue == ""));
         let removedNodes = Array.prototype.slice.call(mutations[0].removedNodes).filter((node) => !$(node).hasClass('md-ripple') && (node.nodeName !== '#comment'));
 
         if (addedNodes.length || removedNodes.length) {


### PR DESCRIPTION
When using paper-select with async search and no options specified, the menu will reposition itself when the loading spinner shows. This makes it look janky to do async searches so we should ignore the spinner change.