### PR TITLE
fixed async search behavior for autocomplete

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -6,8 +6,14 @@ import PowerSelect from 'ember-power-select/components/power-select';
 import ValidationMixin from 'ember-paper/mixins/validation-mixin';
 import ChildMixin from 'ember-paper/mixins/child-mixin';
 import { indexOfOption } from 'ember-power-select/utils/group-utils';
+import { task } from 'ember-concurrency';
+import { countOptions } from 'ember-power-select/utils/group-utils';
 
 const { assert, computed, inject, isNone, defineProperty } = Ember;
+
+function toPlainArray(collection) {
+  return collection.toArray ? collection.toArray() : collection;
+}
 
 /**
  * @class PaperAutocomplete
@@ -79,7 +85,7 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
       this.send('activate');
       let publicAPI = this.get('publicAPI');
 
-      if (isNone(publicAPI.selected)) {
+      if (isNone(publicAPI.selected) && (!this.get('search') || !this.get('label'))) {
         publicAPI.actions.open(event);
       }
 
@@ -104,6 +110,10 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
 
       if (!publicAPI.isOpen && event.type !== 'change') {
         publicAPI.actions.open(event);
+      }
+
+      if (this.get('search') && this.get('label') && event.target.value === '') {
+        publicAPI.actions.close(event);
       }
 
       this.notifyValidityChange();
@@ -135,5 +145,29 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
       // Update the scroll index
       this.updateState({ scrollIndex: index });
     }
-  }
+  },
+  handleAsyncSearchTask: task(function*(term, searchThenable) {
+    try {
+      if (this.get('label')) {
+        this.get('publicAPI').actions.close();
+      }
+      this.updateState({ loading: true });
+      let results = yield searchThenable;
+      this.get('publicAPI').actions.open();
+      let resultsArray = toPlainArray(results);
+      this.updateState({
+        results: resultsArray,
+        lastSearchedText: term,
+        resultsCount: countOptions(results),
+        loading: false
+      });
+      this.resetHighlighted();
+    } catch(e) {
+      this.updateState({ lastSearchedText: term, loading: false });
+    } finally {
+      if (typeof searchThenable.cancel === 'function') {
+        searchThenable.cancel();
+      }
+    }
+  }).restartable()
 });

--- a/tests/dummy/app/templates/demo/autocomplete.hbs
+++ b/tests/dummy/app/templates/demo/autocomplete.hbs
@@ -99,7 +99,7 @@
           disabled=(readonly disabled2)
           required=(readonly isRequired)
           triggerClass="flex"
-          options=items
+          options=(if simulateQuery2 null items)
           selected=selectedCountry2
           search=(if simulateQuery2 (action "searchCountries"))
           searchField="name"


### PR DESCRIPTION
Behavior of async searches more closely matches AM now. I had to override either the `handleAsyncSearchTask` or the `search` action and I opted to overriding the task. I don't anticipate either of them changing substantially in the future and I would have had to add a task to make it work the other way. I can switch it if you want though.

Wait for Travis to finish though because my phantomjs was throwing undefined symbol errors at me but I think it's a local problem, we'll see if Travis breaks.