### PR TITLE
Demo - Chips: Remove class="flex" from paper-card-content elements

### DIFF
--- a/tests/dummy/app/templates/demo/chips.hbs
+++ b/tests/dummy/app/templates/demo/chips.hbs
@@ -8,7 +8,7 @@
         <h2>Basic Usage</h2>
       {{/paper-toolbar-tools}}
     {{/paper-toolbar}}
-    {{#paper-card-content class="flex"}}
+    {{#paper-card-content}}
       {{! BEGIN-SNIPPET chips.example }}
       <h2>Default Template</h2>
       {{paper-chips
@@ -69,7 +69,7 @@
         <h2>Contact chips</h2>
       {{/paper-toolbar-tools}}
     {{/paper-toolbar}}
-    {{#paper-card-content class="flex"}}
+    {{#paper-card-content}}
 
       {{! BEGIN-SNIPPET chips.contacts-example }}
       <h2>Contact Chips</h2>


### PR DESCRIPTION
This fixes display in IE11 (see #616).  Note that there are other compatibility issues with IE11, but this at least allows you to see the chips demos in order to work on them.