### PR TITLE
Modification to the index.js include directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,23 @@ var AngularScssFilter = require('./lib/angular-scss-filter');
 module.exports = {
   name: 'ember-paper',
 
-  included: function(app) {
+  included: function(target) {
     this._super.included.apply(this, arguments);
+
+    var app;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      var current = this;
+      do {
+        app = current.app || app;
+      } while (current.parent.parent && (current = current.parent));
+    }
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
       app.import(app.bowerDirectory + '/hammer.js/hammer.js')

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var AngularScssFilter = require('./lib/angular-scss-filter');
 module.exports = {
   name: 'ember-paper',
 
-  included: function(target) {
+  included: function() {
     this._super.included.apply(this, arguments);
 
     var app;


### PR DESCRIPTION
With this little fix the ember-addon will be able to retrieve the parent application while being used from another addon. 

This also provides compatibility for ember version lower than 2.5 which don't provide the findHost helper