### PR TITLE
Chips: Don't explicitly close autocomplete on inputBlur - fixes #587

### DIFF
--- a/addon/components/paper-chips.js
+++ b/addon/components/paper-chips.js
@@ -92,8 +92,6 @@ export default Component.extend({
         return true;
       }
 
-      this.closeAutocomplete();
-
       if (!this.focusMovingTo('md-chips-wrap', event)) {
         this.set('focusedElement', 'none');
       }


### PR DESCRIPTION
Explicitly closing the autocomplete component on inputBlur broke the ability to add custom items to the chips element (assuming requireMatch is not true).  It doesn't appear to be necessary for any other purpose.