### PR TITLE
add option to keep chips dropdown open

### DIFF
--- a/addon/components/paper-chips.js
+++ b/addon/components/paper-chips.js
@@ -18,6 +18,7 @@ export default Component.extend({
   }),
   resetTimer: null,
   lastItemChosen: false,
+  keepDropdownClosed: true,
 
   handleFocusChange: observer('focusedElement', 'activeChip', function() {
     let element = this.get('focusedElement');
@@ -75,7 +76,7 @@ export default Component.extend({
       }
 
       // We don't want the autocomplete to open on focus - it'll open when the user starts typing.
-      if (isPresent(autocomplete)) {
+      if (isPresent(autocomplete) && this.get('keepDropdownClosed')) {
         autocomplete.actions.close();
       }
     },
@@ -91,8 +92,6 @@ export default Component.extend({
         this.set('lastItemChosen', false);
         return true;
       }
-
-      this.closeAutocomplete();
 
       if (!this.focusMovingTo('md-chips-wrap')) {
         this.set('focusedElement', 'none');
@@ -128,7 +127,7 @@ export default Component.extend({
 
     searchTextChange(searchText, select) {
       // Close dropdown if search text is cleared by the user.
-      if (isEmpty(searchText)) {
+      if (isEmpty(searchText) && this.get('keepDropdownClosed')) {
         select.actions.close();
       }
     },
@@ -203,7 +202,9 @@ export default Component.extend({
 
       // Close the dropdown after focusing the field.
       input.focus();
-      select.actions.close();
+      if (this.get('keepDropdownClosed')) {
+        select.actions.close();
+      }
     } else {
       input.focus();
     }

--- a/addon/templates/components/paper-chips.hbs
+++ b/addon/templates/components/paper-chips.hbs
@@ -31,7 +31,7 @@
       {{#if (or requireMatch options)}}
         {{#paper-autocomplete
           options=options
-          closeOnSelect=true
+          closeOnSelect=keepDropdownClosed
           placeholder=placeholder
           searchField=searchField
           noMatchesMessage=noMatchesMessage

--- a/tests/dummy/app/templates/demo/chips.hbs
+++ b/tests/dummy/app/templates/demo/chips.hbs
@@ -54,6 +54,17 @@
         content=vegeNames
         options=remainingVegeNames
         requireMatch=true}}
+
+      <h2>Chips with Autocomplete and open dropdown</h2>
+      {{paper-chips
+        readOnly=readOnly
+        removeItem=(action "removeVegeName")
+        addItem=(action "addVegeName")
+        placeholder="Add a vegetable"
+        content=vegeNames
+        options=remainingVegeNames
+        keepDropdownClosed=false
+        noMatchesMessage="Not found. Click to add."}}
       {{! END-SNIPPET }}
 
       <h3>Template</h3>


### PR DESCRIPTION
Adds the option `keepDropdownClosed` to `paper-chips` which is `true` by default.

Passing `keepDropdownClosed=false` makes the dropdown open on focus and keeps it open after items are added.  Intended for use cases where the options are unknown to the user as mentioned in #612.

![untitled](https://cloud.githubusercontent.com/assets/3893505/22490323/6ead2c9c-e881-11e6-8ff2-c1d35239d8eb.gif)
