### PR TITLE
Makes paper-form an actual html form

### DIFF
--- a/addon/components/paper-form.js
+++ b/addon/components/paper-form.js
@@ -14,11 +14,17 @@ const { Component, computed } = Ember;
  */
 export default Component.extend(ParentMixin, {
   layout,
-  tagName: '',
+  tagName: 'form',
   isValid: computed.not('isInvalid'),
   isInvalid: computed('childComponents.@each.isInvalid', function() {
     return this.get('childComponents').isAny('isInvalid');
   }),
+
+  submit() {
+    this.send('onSubmit');
+    return false;
+  },
+
   actions: {
     onValidityChange() {
       if (this.get('lastIsValid') !== this.get('isValid')) {

--- a/addon/templates/components/paper-form.hbs
+++ b/addon/templates/components/paper-form.hbs
@@ -6,7 +6,6 @@
     onValidityChange=(action "onValidityChange")
   )
   submit-button=(component "paper-button"
-    onClick=(action "onSubmit")
     type="submit"
   )
   select=(component "paper-select"
@@ -19,4 +18,3 @@
   )
   onSubmit=(action "onSubmit")
 )}}
-

--- a/tests/dummy/app/templates/forms.hbs
+++ b/tests/dummy/app/templates/forms.hbs
@@ -12,8 +12,10 @@
     {{#paper-card-content}}
       <p>
         ember-paper provides a <code>paper-form</code> to help you build forms
-        and keep track of the form's global validity state. This component is tagless,
-        so it shouldn't interfere with your styles.
+        and keep track of the form's global validity state. This component uses
+        the html form tag by default, so expected form behavior will occur.
+        (For example, pressing the enter key from within one of the form's
+        inputs will submit the form.)
         <code>paper-form</code> yields <code>{{#link-to "demo.input"}}paper-input{{/link-to}}</code>,
         <code>{{#link-to "demo.select"}}paper-select{{/link-to}}</code>
         and <code>{{#link-to "demo.autocomplete"}}paper-autocomplete{{/link-to}}</code> controls.

--- a/tests/integration/components/paper-form-test.js
+++ b/tests/integration/components/paper-form-test.js
@@ -182,3 +182,23 @@ test('form submit button is of type submit', function(assert) {
 
   assert.equal(this.$('button').attr('type'), 'submit');
 });
+
+test('form `onSubmit` action is invoked when form element is submitted', function(assert) {
+  assert.expect(1);
+
+  this.set('onSubmit', () => {
+    assert.ok(true);
+  });
+
+  this.render(hbs`
+    {{#paper-form onSubmit=(action onSubmit) as |form|}}
+      {{form.input value=foo onChange=(action (mut foo)) label="Foo"}}
+      {{form.input value=bar onChange=(action (mut bar)) label="Bar"}}
+
+      <input type="submit" value="Submit">
+
+    {{/paper-form}}
+  `);
+
+  this.$('input').click();
+});

--- a/tests/integration/components/paper-form-test.js
+++ b/tests/integration/components/paper-form-test.js
@@ -50,12 +50,12 @@ test('form `onSubmit` action is invoked', function(assert) {
       {{form.input value=foo onChange=(action (mut foo)) label="Foo"}}
       {{form.input value=bar onChange=(action (mut bar)) label="Bar"}}
 
-      <button onclick={{action form.onSubmit}}>Submit</button>
+      <a {{action form.onSubmit}}>Submit</a>
 
     {{/paper-form}}
   `);
 
-  this.$('button').click();
+  this.$('a').click();
 });
 
 test('form `onValidityChange` action is invoked', function(assert) {


### PR DESCRIPTION
My second attempt at solving https://github.com/miguelcobain/ember-paper/issues/460, this time by making `paper-form` an html form.

Some things to note:
- Pressing the enter key to select an item in a `paper-autocomplete` (as well as a `paper-select` I assume) will submit the form - probably not ideal behavior. I attempted to find a simple way to prevent the `enter` keypress event from propagating when an item in the dropdown is selected, but I wasn't able to find a solution without hacking into `ember-power-select`. But maybe I missed something.
- I wasn't able to actually write a test for pressing the enter key in a form. From what I can tell this isn't possible with jQuery. Instead, I tested that the `onSubmit` action is called when an input of type submit within the form is clicked. This gives us some test coverage to make sure `paper-form` is in fact a real html form.