### PR TITLE
text-input: add an exemple for helper text

### DIFF
--- a/tests/dummy/app/styles/demo.scss
+++ b/tests/dummy/app/styles/demo.scss
@@ -1465,6 +1465,18 @@ md-sidenav.site-sidenav {
 
 }
 
+/* Inputs demo */
+md-input-container .hint {
+  position: absolute;
+  left: 2px;
+  right: auto;
+  bottom: 7px;
+  font-size: 12px;
+  line-height: 14px;
+  transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+  color: grey;
+}
+
 /* CHIPS demo */
 .chipsdemoContactChips .ember-power-select-trigger {
     min-width: 400px;

--- a/tests/dummy/app/templates/demo/input.hbs
+++ b/tests/dummy/app/templates/demo/input.hbs
@@ -188,6 +188,37 @@
     {{code-snippet name="input.actions.hbs"}}
   </p>
 
+  {{#paper-api
+    (p-section
+      (p-row "charCount" "integer" "Length of the current input's value.")
+      (p-row "isInvalid" "boolean" "`true` if input is in error.")
+      (p-row "isTouched" "boolean" "`true` is the user interacted with it.")
+      (p-row "isInvalidAndTouched" "boolean" "`true` if input is in error and the user interacted with it.")
+      (p-row "hasValue" "boolean" "`true` if the input is filled.")
+      (p-row "validationErrorMessages" "array" "List of input's errors.")
+
+    )
+      title="Input Text Helpers"
+  }}
+    <p>You can pass in a helper text to the paper-input's block. Some useful properties are yieled to the block to help you
+    conditionally render the text.</p>
+    <div>
+    {{! BEGIN-SNIPPET input.textHelper }}
+    {{#paper-input
+      value=emailValue
+      onChange=(action (mut emailValue))
+      label="Email"
+      type="email"
+      as |textHelper|}}
+        {{#unless textHelper.hasValue}}
+          <div class="hint">How can we reach you?</div>
+        {{/unless}}
+      {{/paper-input}}
+      {{! END-SNIPPET }}
+      {{code-snippet name="input.textHelper.hbs"}}
+    </div>
+    {{/paper-api}}
+
   {{#paper-api validationApi title="Custom Validations"}}
     <p>
       In addition to <code>required</code>,


### PR DESCRIPTION
Simply add some documentations for text-input.

Closes #668 