### PR TITLE
use computed.bool instead of directly messages length

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -38,8 +38,7 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
 
   iconComponent: 'paper-icon',
 
-  hasErrorMessages: computed.bool('validationErrorMessages.length'),
-
+  // override validation mixin `isInvalid` to account for the native input validity
   isInvalid: computed.or('hasErrorMessages', 'isNativeInvalid'),
 
   hasValue: computed('value', 'isNativeInvalid', function() {

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -38,7 +38,10 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
 
   iconComponent: 'paper-icon',
 
-  isInvalid: computed.or('validationErrorMessages.length', 'isNativeInvalid'),
+  hasErrorMessages: computed.bool('validationErrorMessages.length'),
+
+  isInvalid: computed.or('hasErrorMessages', 'isNativeInvalid'),
+
   hasValue: computed('value', 'isNativeInvalid', function() {
     let value = this.get('value');
     let isNativeInvalid = this.get('isNativeInvalid');

--- a/addon/mixins/validation-mixin.js
+++ b/addon/mixins/validation-mixin.js
@@ -99,7 +99,7 @@ export default Mixin.create({
    *    false: input is valid (touched or not), or is no longer rendered
    *    true: input has been touched and is invalid.
    */
-  isInvalid: computed.or('hasErrorMessages'),
+  isInvalid: computed.reads('hasErrorMessages'),
   isValid: computed.not('isInvalid'),
 
   /**

--- a/addon/mixins/validation-mixin.js
+++ b/addon/mixins/validation-mixin.js
@@ -86,6 +86,8 @@ export default Mixin.create({
     }
   },
 
+  hasErrorMessages: computed.bool('validationErrorMessages.length'),
+
   /**
    * The result of isInvalid is appropriate for controlling the display of
    * validation error messages. It also may be used to distinguish whether
@@ -97,7 +99,7 @@ export default Mixin.create({
    *    false: input is valid (touched or not), or is no longer rendered
    *    true: input has been touched and is invalid.
    */
-  isInvalid: computed.or('validationErrorMessages.length'),
+  isInvalid: computed.or('hasErrorMessages'),
   isValid: computed.not('isInvalid'),
 
   /**


### PR DESCRIPTION
because `computed.or` does not coalesce to bool, we otherwise end up with the number of errors instead of true in `isInvalid` and `isInvalidAndTouched`

Signed-off-by: Anthony Pessy <anthony.pessy@gmail.com>