### PR TITLE
replace flex attribute by flex class

### DIFF
--- a/tests/dummy/app/templates/demo/input.hbs
+++ b/tests/dummy/app/templates/demo/input.hbs
@@ -3,13 +3,13 @@
 {{#doc-content}}
   {{! BEGIN-SNIPPET input.basic-usage}}
   <div class="layout layout-sm-column">
-    {{paper-input flex=30 label="Name" value=name onChange=(action (mut name))}}
-    {{paper-input flex=30 label="E-mail" type="email" value=email onChange=(action (mut email))}}
-    {{paper-input flex=40 label="Password" type="password" value=password onChange=(action (mut password))}}
+    {{paper-input class="flex-30" label="Name" value=name onChange=(action (mut name))}}
+    {{paper-input class="flex-30" label="E-mail" type="email" value=email onChange=(action (mut email))}}
+    {{paper-input class="flex-40" label="Password" type="password" value=password onChange=(action (mut password))}}
   </div>
   <div class="layout layout-sm-column">
-    {{paper-input flex=true label="Submission date" type="date" value=date onChange=(action (mut date))}}
-    {{paper-input flex=true label="Company (disabled)" type="text" value="Google" disabled=true onChange=(action (mut foo))}}
+    {{paper-input class="flex" label="Submission date" type="date" value=date onChange=(action (mut date))}}
+    {{paper-input class="flex" label="Company (disabled)" type="text" value="Google" disabled=true onChange=(action (mut foo))}}
   </div>
 
   {{paper-input textarea=true block=true label="Biography" maxlength=150 passThru=(hash rows=5 maxRows=5)
@@ -241,7 +241,7 @@
     {{#card.content}}
       <div class="layout layout-sm-row">
         {{paper-input
-          flex=50
+          class="flex-50"
           label="User name"
           value=model.username
           onChange=(action (mut model.username))
@@ -251,7 +251,7 @@
       <div class="layout layout-sm-row">
         {{paper-input
           label="Password"
-          flex=34
+          class="flex-34"
           type="password"
           value=model.password
           onChange=(action (mut model.password))
@@ -259,7 +259,7 @@
         }}
         {{paper-input
           label="E-mail"
-          flex=33
+          class="flex-33"
           type="email"
           value=model.email
           onChange=(action (mut model.email))
@@ -267,7 +267,7 @@
         }}
         {{paper-input
           label="Retype your e-mail"
-          flex=33
+          class="flex-33"
           type="email"
           value=model.emailConfirmation
           onChange=(action (mut model.emailConfirmation))

--- a/tests/dummy/app/templates/demo/slider.hbs
+++ b/tests/dummy/app/templates/demo/slider.hbs
@@ -33,19 +33,19 @@
 
       <h2>Rating: {{rating}}/5 - demo of theming classes</h2>
       <div class="layout layout-align-center-center slider-container">
-        <div flex=10 class="layout flex-10 layout-align-center-center">
+        <div class="layout flex-10 layout-align-center-center">
           <span>default</span>
         </div>
         {{paper-slider class="flex" discrete=true value=rating1 step=1 min=1 max=5 onChange=(action (mut rating1))}}
       </div>
       <div class="layout layout-align-center-center slider-container">
-        <div flex=10 class="layout flex-10 layout-align-center-center">
+        <div class="layout flex-10 layout-align-center-center">
           <span>md-warn</span>
         </div>
         {{paper-slider class="flex" warn=true discrete=true value=rating2 step=1 min=1 max=5 onChange=(action (mut rating2))}}
       </div>
       <div class="layout layout-align-center-center slider-container">
-        <div flex=10 class="layout flex-10 layout-align-center-center">
+        <div class="layout flex-10 layout-align-center-center">
           <span>md-primary</span>
         </div>
         {{paper-slider class="flex" primary=true discrete=true value=rating3 step=1 min=1 max=5 onChange=(action (mut rating3))}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,6 +1,6 @@
 {{page-toolbar pageTitle="Introduction" isDemo=false}}
 
-{{#paper-content flex=true scroll-y=true class="layout-padding"}}
+{{#paper-content scroll-y=true class="layout-padding flex"}}
 <div class="doc-content">
 
   {{#paper-card as |card|}}


### PR DESCRIPTION
The `flex` attribute was replaced in favor of `flex-X` classes.

Closes #673 