### PR TITLE
Consistent SASS theme colors

### DIFF
--- a/app/styles/color-palette.scss
+++ b/app/styles/color-palette.scss
@@ -7,7 +7,7 @@ $strong-light-contrast-color: rgb(255, 255, 255) !default;
 $foreground-light: (
   '1': rgba(255, 255, 255, 1.0),
   '2': rgba(255, 255, 255, 0.7),
-  '3': rgba(255, 255, 255, 0.3),
+  '3': rgba(255, 255, 255, 0.5),
   '4': rgba(255, 255, 255, 0.12),
   'shadow': '1px 1px 0px rgba(0, 0, 0, 0.4), -1px -1px 0px rgba(0, 0, 0, 0.4)'
 ) !default;
@@ -15,7 +15,7 @@ $foreground-light: (
 $foreground-dark: (
   '1': rgba(0, 0, 0, 0.87),
   '2': rgba(0, 0, 0, 0.54),
-  '3': rgba(0, 0, 0, 0.26),
+  '3': rgba(0, 0, 0, 0.38),
   '4': rgba(0, 0, 0, 0.12),
   'shadow': none
 ) !default;

--- a/app/styles/color-palette.scss
+++ b/app/styles/color-palette.scss
@@ -418,6 +418,9 @@ $shades: (
   'white': #FFFFFF
 ) !default;
 
+$background-light: map-merge($color-grey, (
+  'default': 'A100',
+)) !default;
 
 $colors: () !default;
 
@@ -443,13 +446,23 @@ $colors: map-merge($colors,(
   'grey': $color-grey,
   'shades': $shades,
   'foreground-light': $foreground-light,
-  'foreground-dark': $foreground-dark
+  'foreground-dark': $foreground-dark,
+  'background-light': $background-light,
 ));
 
 $default-color: '500' !default;
-@function color($color, $type: $default-color) {
+@function color($color, $type: null) {
   @if map-has-key($colors, $color) {
     $curr_color: map-get($colors, $color);
+
+    @if ($type == null) {
+      @if map-has-key($curr_color, 'default') {
+        $type: map-get($curr_color, 'default');
+      } @else {
+        $type: $default-color;
+      }
+    }
+
     @if map-has-key($curr_color, $type) {
       @return map-get($curr_color, $type);
     }

--- a/app/styles/default-theme.scss
+++ b/app/styles/default-theme.scss
@@ -11,5 +11,4 @@ $default-color: '500' !default;
 
 $foreground: "foreground-dark" !default;
 
-$base-background-color: white !default;
 $base-color: rgba(0, 0, 0, 0.87) !default;

--- a/app/styles/default-theme.scss
+++ b/app/styles/default-theme.scss
@@ -3,12 +3,11 @@ $theme-name: "default" !default;
 $primary: "indigo" !default;
 $accent: "pink" !default;
 $warn: "red" !default;
-$background: "grey" !default;
 $link: "light-blue" !default;
 
 $dark: false !default;
-$default-color: '500' !default;
 
 $foreground: "foreground-dark" !default;
+$background: "background-light" !default;
 
 $base-color: rgba(0, 0, 0, 0.87) !default;

--- a/lib/angular-scss-filter.js
+++ b/lib/angular-scss-filter.js
@@ -11,9 +11,6 @@ AngularScssFilter.prototype.constructor = AngularScssFilter;
 AngularScssFilter.prototype.extensions = ['scss'];
 AngularScssFilter.prototype.targetExtension = 'scss';
 
-var PALETTES;
-var THEMES;
-
 var DARK_FOREGROUND = {
   name: 'dark',
   '1': 'rgba(0,0,0,0.87)',
@@ -21,24 +18,10 @@ var DARK_FOREGROUND = {
   '3': 'rgba(0,0,0,0.38)',
   '4': 'rgba(0,0,0,0.12)'
 };
-var LIGHT_FOREGROUND = {
-  name: 'light',
-  '1': 'rgba(255,255,255,1.0)',
-  '2': 'rgba(255,255,255,0.7)',
-  '3': 'rgba(255,255,255,0.5)',
-  '4': 'rgba(255,255,255,0.12)'
-};
 
-var DARK_SHADOW = '1px 1px 0px rgba(0,0,0,0.4), -1px -1px 0px rgba(0,0,0,0.4)';
 var LIGHT_SHADOW = 'none';
 
-var DARK_CONTRAST_COLOR = 'rgba(0,0,0,0.87)';
-var LIGHT_CONTRAST_COLOR = 'rgba(255,255,255,0.87)';
-var STRONG_LIGHT_CONTRAST_COLOR = 'rgb(255,255,255)';
-
 var THEME_COLOR_TYPES = ['primary', 'accent', 'warn', 'background'];
-var DEFAULT_COLOR_TYPE = 'primary';
-
 
 // A color in a theme will use these hues by default, if not specified by user.
 var LIGHT_DEFAULT_HUES = {
@@ -80,11 +63,6 @@ THEME_COLOR_TYPES.forEach(function(colorType) {
     DARK_DEFAULT_HUES[colorType] = defaultDefaultHues;
   }
 });
-
-var VALID_HUE_VALUES = [
-  '50', '100', '200', '300', '400', '500', '600',
-  '700', '800', '900', 'A100', 'A200', 'A400', 'A700'
-];
 
 AngularScssFilter.prototype.processString = function(content, relativePath) {
 

--- a/lib/angular-scss-filter.js
+++ b/lib/angular-scss-filter.js
@@ -11,51 +11,16 @@ AngularScssFilter.prototype.constructor = AngularScssFilter;
 AngularScssFilter.prototype.extensions = ['scss'];
 AngularScssFilter.prototype.targetExtension = 'scss';
 
-var THEME_COLOR_TYPES = ['primary', 'accent', 'warn', 'background'];
-
-// A color in a theme will use these hues by default, if not specified by user.
-var LIGHT_DEFAULT_HUES = {
-  'accent': {
-    'default': 'A200',
-    'hue-1': 'A100',
-    'hue-2': 'A400',
-    'hue-3': 'A700'
-  },
-  'background': {
-    'default': '50',
-    'hue-1': 'A100',
-    'hue-2': '100',
-    'hue-3': '300'
+function colorMixinExpression(colorTypeExpression, hueExpression, opacity) {
+  var colorSegments = [colorTypeExpression, hueExpression].filter(function(segment) { return !!segment && segment.length > 0; });
+  var result = 'color(' + colorSegments.join(', ') + ')';
+  if (opacity !== undefined) {
+    result = 'rgba(' + result + ', ' + opacity + ')';
   }
-};
+  return result;
+}
 
-var DARK_DEFAULT_HUES = {
-  'background': {
-    'default': 'A400',
-    'hue-1': '800',
-    'hue-2': '900',
-    'hue-3': 'A200'
-  }
-};
-
-THEME_COLOR_TYPES.forEach(function(colorType) {
-  // Color types with unspecified default hues will use these default hue values
-  var defaultDefaultHues = {
-    'default': '500',
-    'hue-1': '300',
-    'hue-2': '800',
-    'hue-3': 'A100'
-  };
-  if (!LIGHT_DEFAULT_HUES[colorType]) {
-    LIGHT_DEFAULT_HUES[colorType] = defaultDefaultHues;
-  }
-  if (!DARK_DEFAULT_HUES[colorType]) {
-    DARK_DEFAULT_HUES[colorType] = defaultDefaultHues;
-  }
-});
-
-AngularScssFilter.prototype.processString = function(content, relativePath) {
-  // Get theme name from config?
+AngularScssFilter.prototype.processString = function(content, _relativePath) {
   var themeName = 'default';
 
   var newRule = content
@@ -69,31 +34,16 @@ AngularScssFilter.prototype.processString = function(content, relativePath) {
       var hue = params[1];
       var opacity = params[2];
 
-      if (hue === 'color' || hue === 'default') {
-        // Get the default value
-        // TODO: Support for dark themes?
-        hue = LIGHT_DEFAULT_HUES[colorType]['default'];
-      }
+      var colorTypeExpression = '$' + colorType;
 
-      if (hue === 'hue') {
-        hue = params[1] + '-' + params[2];
-        hue = LIGHT_DEFAULT_HUES[colorType][hue]
-      }
-
-      var colorExp = 'color($' + colorType;
-
-      // Find and replace simple variables where we use a specific hue
-      if (hue !== 'color' && hue !== undefined) {
-        colorExp += ', "' + hue + '"' + ')';
+      var hueExpression;
+      if (hue === 'color') {
+        hueExpression = null;
       } else {
-        colorExp += ')';
+        hueExpression = '"' + hue + '"';
       }
 
-      if (opacity !== undefined) {
-        colorExp = 'rgba(' + colorExp + ', ' + opacity + ')';
-      }
-
-      return colorExp;
+      return colorMixinExpression(colorTypeExpression, hueExpression, opacity);
     });
 
   if (themeName === 'default') {
@@ -101,7 +51,6 @@ AngularScssFilter.prototype.processString = function(content, relativePath) {
     newRule = newRule.replace(themeRuleRegex, function(match, prefix, target, suffix) {
       return match + ', ' + prefix + target + suffix;
     });
-
   }
 
   return newRule;

--- a/lib/angular-scss-filter.js
+++ b/lib/angular-scss-filter.js
@@ -37,7 +37,7 @@ AngularScssFilter.prototype.processString = function(content, _relativePath) {
       var colorTypeExpression = '$' + colorType;
 
       var hueExpression;
-      if (hue === 'color') {
+      if (hue === 'color' || hue === 'hue') {
         hueExpression = null;
       } else {
         hueExpression = '"' + hue + '"';

--- a/lib/angular-scss-filter.js
+++ b/lib/angular-scss-filter.js
@@ -11,16 +11,6 @@ AngularScssFilter.prototype.constructor = AngularScssFilter;
 AngularScssFilter.prototype.extensions = ['scss'];
 AngularScssFilter.prototype.targetExtension = 'scss';
 
-var DARK_FOREGROUND = {
-  name: 'dark',
-  '1': 'rgba(0,0,0,0.87)',
-  '2': 'rgba(0,0,0,0.54)',
-  '3': 'rgba(0,0,0,0.38)',
-  '4': 'rgba(0,0,0,0.12)'
-};
-
-var LIGHT_SHADOW = 'none';
-
 var THEME_COLOR_TYPES = ['primary', 'accent', 'warn', 'background'];
 
 // A color in a theme will use these hues by default, if not specified by user.
@@ -96,19 +86,7 @@ AngularScssFilter.prototype.processString = function(content, relativePath) {
 
       // Find and replace simple variables where we use a specific hue
       if (hue !== 'color' && hue !== undefined) {
-
-        // TODO: Support for dark themes?
-        // find and replace simple variables where we use a specific hue
-        if (colorType === 'foreground') {
-          if (hue === 'shadow') {
-            colorExp = LIGHT_SHADOW;
-          } else {
-            colorExp = DARK_FOREGROUND[hue] || DARK_FOREGROUND['1'];
-          }
-        } else {
-          colorExp += ', "' + hue + '"' + ')';
-        }
-
+        colorExp += ', "' + hue + '"' + ')';
       } else {
         colorExp += ')';
       }

--- a/lib/angular-scss-filter.js
+++ b/lib/angular-scss-filter.js
@@ -67,6 +67,7 @@ AngularScssFilter.prototype.processString = function(content, relativePath) {
 
       var colorType = params[0];
       var hue = params[1];
+      var opacity = params[2];
 
       if (hue === 'color' || hue === 'default') {
         // Get the default value
@@ -88,8 +89,8 @@ AngularScssFilter.prototype.processString = function(content, relativePath) {
         colorExp += ')';
       }
 
-      if (params[2] !== undefined) {
-        colorExp = 'rgba(' + colorExp + ', ' + params[2] + ')';
+      if (opacity !== undefined) {
+        colorExp = 'rgba(' + colorExp + ', ' + opacity + ')';
       }
 
       return colorExp;

--- a/lib/angular-scss-filter.js
+++ b/lib/angular-scss-filter.js
@@ -55,15 +55,12 @@ THEME_COLOR_TYPES.forEach(function(colorType) {
 });
 
 AngularScssFilter.prototype.processString = function(content, relativePath) {
-
   // Get theme name from config?
   var themeName = 'default';
 
   var newRule = content
     .replace(/THEME_NAME/g, themeName)
-    .replace(/'{{.*?}}'/g, function(themeExpression) {
-      //remove '{{ and }}'
-      themeExpression = themeExpression.substr(0, themeExpression.length - 3).substr(3);
+    .replace(/'{{(.*?)}}'/g, function(originalExpression, themeExpression) {
       var params = themeExpression.split('-').map(function(p) {
         return p.trim();
       });


### PR DESCRIPTION
For some reason the foreground colors are set during preprocessing to fixed values, making it impossible to alter them using SASS variables. This PR replaces the generated constants with SASS expressions, making it possible to override them, and strips dead code from `lib/angular-scss-filter.js`. 