### PR TITLE
fix(autoprefixer): Only autoprefix css tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = {
   },
 
   postprocessTree: function(type, tree) {
-    if (type === 'all' || type === 'styles') {
+    if (type === 'css') {
       tree = autoprefixer(tree,
           this.app.options.autoprefixer || { browsers: ['last 2 versions'] });
     }


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/blob/master/lib/models/addon.js#L834

'styles' doesn't appear to be a called type according to the source code.
There is a comment saying it is a valid type, but no other indication it's used.