### PR TITLE
Autocomplete inner text

### DIFF
--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -8,7 +8,7 @@ export default Component.extend({
   tagName: 'md-autocomplete-wrap',
   classNames: ['md-show-clear-button'],
   classNameBindings: ['noLabel:md-whiteframe-z1', 'select.isOpen:md-menu-showing'],
-
+  searchText: computed.oneWay('select.searchText'),
   noLabel: computed.not('extra.label'),
   _innerText: computed.oneWay('searchText'),
 
@@ -23,7 +23,7 @@ export default Component.extend({
       if (selected) {
         return this.getSelectedAsText();
       }
-      return this.get('attrs').searchText !== undefined ? searchText : _innerText;
+      return this.get('searchText') !== undefined ? searchText : _innerText;
     },
     set(_, v) {
       let { selected, searchText } = this.getProperties('selected', 'searchText');

--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -8,7 +8,6 @@ export default Component.extend({
   tagName: 'md-autocomplete-wrap',
   classNames: ['md-show-clear-button'],
   classNameBindings: ['noLabel:md-whiteframe-z1', 'select.isOpen:md-menu-showing'],
-  searchText: computed.oneWay('select.searchText'),
   noLabel: computed.not('extra.label'),
   _innerText: computed.oneWay('searchText'),
 

--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -23,7 +23,7 @@ export default Component.extend({
       if (selected) {
         return this.getSelectedAsText();
       }
-      return attrs.searchText !== undefined ? searchText : _innerText;
+      return this.get('attrs').searchText !== undefined ? searchText : _innerText;
     },
     set(_, v) {
       let { selected, searchText } = this.getProperties('selected', 'searchText');

--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -23,7 +23,7 @@ export default Component.extend({
       if (selected) {
         return this.getSelectedAsText();
       }
-      return searchText ? searchText : _innerText;
+      return attrs.searchText !== undefined ? searchText : _innerText;
     },
     set(_, v) {
       let { selected, searchText } = this.getProperties('selected', 'searchText');

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -37,7 +37,8 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
       return 'selected';
     }
   }),
-  searchText: '',
+  searchText: computed.alias('publicAPI.searchText'),
+  savedSearchText: '',
   _onChangeNop() { },
 
   // Don't automatically highlight any option
@@ -47,7 +48,13 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     this._initComponent();
     this._super(...arguments);
   },
-
+  // Listen for changes in searchText and trigger vanilla power-select's search
+  didUpdateAttrs() {
+    if (this.get('searchText') !== this.get('savedSearchText')) {
+      this.get('publicAPI').actions.search(this.get('searchText'));
+      this.set('savedSearchText', this.get('searchText'));
+    }
+  },
   // Init autocomplete component
   _initComponent() {
     let {

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -70,6 +70,7 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     let aliasOnChangeDepKey = hasSelectionChange ? 'onSelectionChange' : '_onChangeNop';
     defineProperty(this, 'oninput', computed.alias('onSearchTextChange'));
     defineProperty(this, 'onchange', computed.alias(aliasOnChangeDepKey));
+    this.set('publicAPI.searchText', "");
   },
 
   // Choose highlighted item on key tab

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -70,7 +70,6 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     let aliasOnChangeDepKey = hasSelectionChange ? 'onSelectionChange' : '_onChangeNop';
     defineProperty(this, 'oninput', computed.alias('onSearchTextChange'));
     defineProperty(this, 'onchange', computed.alias(aliasOnChangeDepKey));
-    this.set('searchText', '');
   },
 
   // Choose highlighted item on key tab

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -37,7 +37,7 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
       return 'selected';
     }
   }),
-  searchText: computed.alias('publicAPI.searchText'),
+  searchText: '',
   savedSearchText: '',
   _onChangeNop() { },
 

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -70,6 +70,7 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     let aliasOnChangeDepKey = hasSelectionChange ? 'onSelectionChange' : '_onChangeNop';
     defineProperty(this, 'oninput', computed.alias('onSearchTextChange'));
     defineProperty(this, 'onchange', computed.alias(aliasOnChangeDepKey));
+    this.set('searchText', '');
   },
 
   // Choose highlighted item on key tab

--- a/addon/templates/components/paper-autocomplete.hbs
+++ b/addon/templates/components/paper-autocomplete.hbs
@@ -41,6 +41,7 @@
 	  onClear=onClear
       placeholder=(readonly placeholder)
       onKeydown=(action "onKeydown")
+	  attrs=attrs
       searchEnabled=(readonly searchEnabled)
       searchField=(readonly searchField)
       searchText=(readonly searchText)

--- a/addon/templates/components/paper-autocomplete.hbs
+++ b/addon/templates/components/paper-autocomplete.hbs
@@ -41,7 +41,6 @@
 	  onClear=onClear
       placeholder=(readonly placeholder)
       onKeydown=(action "onKeydown")
-	  attrs=attrs
       searchEnabled=(readonly searchEnabled)
       searchField=(readonly searchField)
       validationErrorMessages=(readonly validationErrorMessages)

--- a/addon/templates/components/paper-autocomplete.hbs
+++ b/addon/templates/components/paper-autocomplete.hbs
@@ -44,7 +44,6 @@
 	  attrs=attrs
       searchEnabled=(readonly searchEnabled)
       searchField=(readonly searchField)
-      searchText=(readonly searchText)
       validationErrorMessages=(readonly validationErrorMessages)
       select=(readonly publicAPI)
       selected=(readonly selected)

--- a/addon/templates/components/paper-autocomplete.hbs
+++ b/addon/templates/components/paper-autocomplete.hbs
@@ -39,6 +39,7 @@
       onBlur=(action "onBlur")
       onInput=(action "onInput")
 	  onClear=onClear
+	  searchText=searchText
       placeholder=(readonly placeholder)
       onKeydown=(action "onKeydown")
       searchEnabled=(readonly searchEnabled)


### PR DESCRIPTION
pass the attrs block into the trigger so that if the user ops into tracking searchText manually, the component will have referential transparency.