### PR TITLE
Clean up event handlers in paper dialog

### DIFF
--- a/addon/components/paper-dialog-content.js
+++ b/addon/components/paper-dialog-content.js
@@ -26,6 +26,16 @@ export default Component.extend({
   didInsertElement() {
     // content overflow might change depending on load of images inside dialog.
     let images = this.$().find('img');
-    images.on('load', run.bind(this, this.imagesLoaded));
+    
+    let imageLoadHandler = run.bind(this, this.imagesLoaded);
+    this.set('imageLoadHandler', imageLoadHandler);
+    
+    images.on('load', imageLoadHandler);
+  },
+  
+  willDestroyElement() {
+    this._super(...arguments);
+    let images = this.$().find('img');
+    images.off('load', this.get('imageLoadHandler'));
   }
 });

--- a/addon/components/paper-dialog-content.js
+++ b/addon/components/paper-dialog-content.js
@@ -26,13 +26,13 @@ export default Component.extend({
   didInsertElement() {
     // content overflow might change depending on load of images inside dialog.
     let images = this.$().find('img');
-    
+
     let imageLoadHandler = run.bind(this, this.imagesLoaded);
     this.set('imageLoadHandler', imageLoadHandler);
-    
+
     images.on('load', imageLoadHandler);
   },
-  
+
   willDestroyElement() {
     this._super(...arguments);
     let images = this.$().find('img');


### PR DESCRIPTION
paper-dialog registered event handlers for each image in the dialog, because the size of the content can change when they load. It never cleaned up these handlers, which could cause tests to fail if the dialog in the test contained an image.