### PR TITLE
Only call `setValueFromEvent` if the event has a center

### DIFF
--- a/addon/components/paper-slider.js
+++ b/addon/components/paper-slider.js
@@ -141,7 +141,9 @@ export default Component.extend(FocusableMixin, ColorMixin, {
       return;
     }
 
-    this.setValueFromEvent(event.center.x);
+    if (event && event.center) {
+      this.setValueFromEvent(event.center.x);
+    }
   },
 
   dragStart(event) {
@@ -153,7 +155,9 @@ export default Component.extend(FocusableMixin, ColorMixin, {
     this.set('dragging', true);
     this.element.focus();
 
-    this.setValueFromEvent(event.center.x);
+    if (event && event.center) {
+      this.setValueFromEvent(event.center.x);
+    }
   },
 
   drag(event) {
@@ -161,7 +165,9 @@ export default Component.extend(FocusableMixin, ColorMixin, {
       return;
     }
 
-    this.setValueFromEvent(event.center.x);
+    if (event && event.center) {
+      this.setValueFromEvent(event.center.x);
+    }
   },
 
   dragEnd() {


### PR DESCRIPTION
This is because sometimes we can "coerce" the slider to receive events
that don't have this value at all, and it causes errors and is
generally not a good time