### PR TITLE
can disable paper-dialog's backdrop opaqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Contributions and pull requests are always welcome. Contributors may often be fo
   - no more backporting styles needed!
 - [#707](https://github.com/miguelcobain/ember-paper/pull/707) paper-dialog-inner's image load events are now properly cleaned up
 - [51a6250](https://github.com/miguelcobain/ember-paper/commit/51a6250bebf1200e2b38d21c5655333540543bb8) icons are now absolutely sized (line-height, min-height, font-size, etc), from the `size` property
+- [#720](https://github.com/miguelcobain/ember-paper/issues/720) add `opaque` option to `paper-dialog` component (defaults to `true`).
 
 ### 1.0.0-alpha.19 (March 20, 2017)
 - [56b84cf](https://github.com/miguelcobain/ember-paper/commit/56b84cf6b30e01dcf64961c4f75e101d0899593c) fix sliders on android browsers

--- a/addon/components/paper-dialog.js
+++ b/addon/components/paper-dialog.js
@@ -16,6 +16,7 @@ export default Component.extend({
 
   escapeToClose: true,
   focusOnOpen: true,
+  opaque: true,
 
   // Calculate a default that is always valid for the parent of the backdrop.
   wormholeSelector: '#paper-wormhole',

--- a/addon/templates/components/paper-dialog.hbs
+++ b/addon/templates/components/paper-dialog.hbs
@@ -1,7 +1,7 @@
 {{#ember-wormhole to=destinationId}}
   {{paper-backdrop
     locked-open=isLockedOpen
-    opaque=true
+    opaque=opaque
     fixed=(unless parent true)
     class="md-dialog-backdrop"
     onClick=(action "outsideClicked")}}

--- a/tests/dummy/app/templates/demo/dialog.hbs
+++ b/tests/dummy/app/templates/demo/dialog.hbs
@@ -48,6 +48,7 @@
               (p-row "closeTo" "jQuery object, element or selector" "Target for closing the dialog with a transition.")
               (p-row "openFrom" "jQuery object, element or selector" "Source for opening the dialog with a transition.")
               (p-row "fullscreen" "boolean" "Causes the dialog to become fullscreen at smaller breakpoints.")
+              (p-row "opaque" "boolean" "Causes the backdrop to become opaque. Defaults to `true`.")
               (p-row "clickOutsideToClose" "boolean" "Causes clicking on the backdrop to trigger the `onClose` handler. Defaults to `false`.")
               (p-row "focusOnOpen" "boolean" "Causes the initial focus to be on an inner element with the autofocus attribute, rather than the last button inside `{{paper-dialog-actions}}`. Defaults to `true`.")
               (p-row "escapeToClose" "boolean" "Causes pressing escape to close the dialog. Defaults to `true`.")

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -71,6 +71,24 @@ test('should only prevent scrolling behind scoped modal', function(assert) {
   assert.equal($('md-backdrop').css('position'), 'absolute', 'backdrop is absolute');
 });
 
+test('backdrop is opaque by default', function(assert) {
+  this.render(hbs`
+    <div id="paper-wormhole"></div>
+    {{paper-dialog}}
+  `);
+
+  assert.ok($('md-backdrop').hasClass('md-opaque'), 'backdrop is opaque');
+});
+
+test('backdrop opaqueness can be disabled ', function(assert) {
+  this.render(hbs`
+    <div id="paper-wormhole"></div>
+    {{paper-dialog opaque=false}}
+  `);
+
+  assert.notOk($('md-backdrop').hasClass('md-opaque'), 'backdrop is not opaque');
+});
+
 test('should prevent scrolling entirely behind fixed modal', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Add a way to disable the opaqueness of the paper-dialog.

Combined with `origin` and little css on `md-dialog` you can do nice "popover panels" next to clicked buttons, etc.
