### PR TITLE
Add NAME_KEY property to components and mixins.

### DIFF
--- a/addon/components/paper-autocomplete-content.js
+++ b/addon/components/paper-autocomplete-content.js
@@ -1,6 +1,13 @@
+import Ember from 'ember';
 import ContentComponent from 'ember-basic-dropdown/components/basic-dropdown/content';
 import layout from '../templates/components/paper-autocomplete-content';
 
-export default ContentComponent.extend({
+const { NAME_KEY } = Ember;
+
+const PaperComponent = ContentComponent.extend({
   layout
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete-content';
+
+export default PaperComponent;

--- a/addon/components/paper-autocomplete-dropdown.js
+++ b/addon/components/paper-autocomplete-dropdown.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 import BasicDropdown from 'ember-basic-dropdown/components/basic-dropdown';
 import layout from '../templates/components/paper-autocomplete-dropdown';
 
-const { $ } = Ember;
+const { NAME_KEY, $ } = Ember;
 
-export default BasicDropdown.extend({
+const PaperComponent = BasicDropdown.extend({
   layout,
   triggerComponent: 'paper-autocomplete-trigger-container',
 
@@ -91,3 +91,7 @@ export default BasicDropdown.extend({
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete-dropdown';
+
+export default PaperComponent;

--- a/addon/components/paper-autocomplete-highlight.js
+++ b/addon/components/paper-autocomplete-highlight.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-autocomplete-highlight';
 
-const { Component, computed, String: { htmlSafe } } = Ember;
+const { NAME_KEY, Component, computed, String: { htmlSafe } } = Ember;
 
 /**
  * @class PaperAutocompleteHighlight
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'span',
 
@@ -45,3 +45,7 @@ export default Component.extend({
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete-highlight';
+
+export default PaperComponent;

--- a/addon/components/paper-autocomplete-options.js
+++ b/addon/components/paper-autocomplete-options.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 import PowerOptions from 'ember-power-select/components/power-select/options';
 import layout from '../templates/components/paper-autocomplete-options';
 
-const { get } = Ember;
+const { NAME_KEY, get } = Ember;
 
-export default PowerOptions.extend({
+const PaperComponent = PowerOptions.extend({
   layout,
 
   _optionFromIndex(index) {
@@ -17,3 +17,7 @@ export default PowerOptions.extend({
     return option !== undefined ? get(option, 'raw') : option;
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete-options';
+
+export default PaperComponent;

--- a/addon/components/paper-autocomplete-trigger-container.js
+++ b/addon/components/paper-autocomplete-trigger-container.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import BasicTrigger from 'ember-basic-dropdown/components/basic-dropdown/trigger';
-const { computed } = Ember;
+const { NAME_KEY, computed } = Ember;
 
-export default BasicTrigger.extend({
+const PaperComponent = BasicTrigger.extend({
   tagName: 'md-autocomplete',
   attributeBindings: ['label:md-floating-label', 'disabled:disabled'],
   disabled: computed('disabledProxy', function() {
@@ -45,3 +45,7 @@ export default BasicTrigger.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete-trigger-container';
+
+export default PaperComponent;

--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-autocomplete-trigger';
 
-const { Component, isPresent, isBlank, run, get, computed } = Ember;
+const { NAME_KEY, Component, isPresent, isBlank, run, get, computed } = Ember;
 
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-autocomplete-wrap',
   classNames: ['md-show-clear-button'],
@@ -109,3 +109,7 @@ export default Component.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete-trigger';
+
+export default PaperComponent;

--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -8,13 +8,13 @@ import ValidationMixin from 'ember-paper/mixins/validation-mixin';
 import ChildMixin from 'ember-paper/mixins/child-mixin';
 import { indexOfOption } from 'ember-power-select/utils/group-utils';
 
-const { assert, computed, inject, isNone, defineProperty } = Ember;
+const { NAME_KEY, assert, computed, inject, isNone, defineProperty } = Ember;
 
 /**
  * @class PaperAutocomplete
  * @extends PowerSelectComponent
  */
-export default PowerSelect.extend(ValidationMixin, ChildMixin, {
+const PaperComponent = PowerSelect.extend(ValidationMixin, ChildMixin, {
   layout,
   util: inject.service(),
   constants: inject.service(),
@@ -139,3 +139,7 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-autocomplete';
+
+export default PaperComponent;

--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -4,14 +4,14 @@
 import Ember from 'ember';
 import TransitionMixin from 'ember-css-transitions/mixins/transition-mixin';
 
-const { Component, computed, String: { htmlSafe } } = Ember;
+const { NAME_KEY, Component, computed, String: { htmlSafe } } = Ember;
 
 /**
  * @class PaperBackdrop
  * @extends Ember.Component
  * @uses TransitionMixin
  */
-export default Component.extend(TransitionMixin, {
+const PaperComponent = Component.extend(TransitionMixin, {
 
   tagName: 'md-backdrop',
   classNames: ['md-default-theme'],
@@ -46,3 +46,7 @@ export default Component.extend(TransitionMixin, {
     this.sendClickAction(e);
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-backdrop';
+
+export default PaperComponent;

--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -8,7 +8,7 @@ import RippleMixin from 'ember-paper/mixins/ripple-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
 
-const { Component, computed } = Ember;
+const { NAME_KEY, Component, computed } = Ember;
 
 /**
  * @class PaperButton
@@ -18,7 +18,7 @@ const { Component, computed } = Ember;
  * @uses ColorMixin
  * @uses ProxiableMixin
  */
-export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
+const PaperComponent = Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
   layout,
   tagName: 'button',
   classNames: ['md-default-theme', 'md-button'],
@@ -64,3 +64,7 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, Proxiab
     return this.get('bubbles');
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-button';
+
+export default PaperComponent;

--- a/addon/components/paper-card-actions.js
+++ b/addon/components/paper-card-actions.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-actions';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardActions
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card-actions',
   classNameBindings: ['defaultClasses'],
@@ -27,3 +27,7 @@ export default Component.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-actions';
+
+export default PaperComponent;

--- a/addon/components/paper-card-avatar.js
+++ b/addon/components/paper-card-avatar.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardAvatar
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-card-avatar'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-avatar';
+
+export default PaperComponent;

--- a/addon/components/paper-card-content.js
+++ b/addon/components/paper-card-content.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardContent
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-card-content'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-content';
+
+export default PaperComponent;

--- a/addon/components/paper-card-header-headline.js
+++ b/addon/components/paper-card-header-headline.js
@@ -3,13 +3,17 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardHeaderHeadline
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'span',
   classNames: ['md-headline']
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-header-headline';
+
+export default PaperComponent;

--- a/addon/components/paper-card-header-subhead.js
+++ b/addon/components/paper-card-header-subhead.js
@@ -3,13 +3,17 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardHeaderSubhead
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'span',
   classNames: ['md-subhead']
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-header-subhead';
+
+export default PaperComponent;

--- a/addon/components/paper-card-header-text.js
+++ b/addon/components/paper-card-header-text.js
@@ -4,13 +4,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-header-text';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardheaderText
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card-header-text'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-header-text';
+
+export default PaperComponent;

--- a/addon/components/paper-card-header-title.js
+++ b/addon/components/paper-card-header-title.js
@@ -3,13 +3,17 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardHeaderTitle
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'span',
   classNames: ['md-title']
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-header-title';
+
+export default PaperComponent;

--- a/addon/components/paper-card-header.js
+++ b/addon/components/paper-card-header.js
@@ -4,13 +4,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-header';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardHeader
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card-header'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-header';
+
+export default PaperComponent;

--- a/addon/components/paper-card-icon-actions.js
+++ b/addon/components/paper-card-icon-actions.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardIconActions
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-card-icon-actions'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-icon-actions';
+
+export default PaperComponent;

--- a/addon/components/paper-card-image.js
+++ b/addon/components/paper-card-image.js
@@ -3,14 +3,18 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardImage
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'img',
   classNames: ['md-card-image'],
   attributeBindings: ['src', 'title', 'alt']
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-image';
+
+export default PaperComponent;

--- a/addon/components/paper-card-media.js
+++ b/addon/components/paper-card-media.js
@@ -4,14 +4,18 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-media';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardMedia
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: '',
   size: 'md'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-media';
+
+export default PaperComponent;

--- a/addon/components/paper-card-title-media.js
+++ b/addon/components/paper-card-title-media.js
@@ -4,14 +4,18 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-title-media';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardTitleMedia
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card-title-media',
   size: 'md'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-title-media';
+
+export default PaperComponent;

--- a/addon/components/paper-card-title-text.js
+++ b/addon/components/paper-card-title-text.js
@@ -4,13 +4,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-title-text';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardTitleText
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card-title-text'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-title-text';
+
+export default PaperComponent;

--- a/addon/components/paper-card-title.js
+++ b/addon/components/paper-card-title.js
@@ -4,13 +4,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card-title';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCardTitle
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card-title'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card-title';
+
+export default PaperComponent;

--- a/addon/components/paper-card.js
+++ b/addon/components/paper-card.js
@@ -4,13 +4,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-card';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperCard
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-card'
 });
+
+PaperComponent[NAME_KEY] = 'paper-card';
+
+export default PaperComponent;

--- a/addon/components/paper-checkbox.js
+++ b/addon/components/paper-checkbox.js
@@ -8,7 +8,7 @@ import RippleMixin from 'ember-paper/mixins/ripple-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
 
-const { Component, inject, assert, computed } = Ember;
+const { NAME_KEY, Component, inject, assert, computed } = Ember;
 
 /**
  * @class PaperCheckbox
@@ -18,7 +18,7 @@ const { Component, inject, assert, computed } = Ember;
  * @uses ColorMixin
  * @uses ProxiableMixin
  */
-export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
+const PaperComponent = Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
   layout,
   tagName: 'md-checkbox',
   classNames: ['md-checkbox', 'md-default-theme'],
@@ -64,3 +64,7 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, Proxiab
     this.sendAction('onChange', !this.get('value'));
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-checkbox';
+
+export default PaperComponent;

--- a/addon/components/paper-chips.js
+++ b/addon/components/paper-chips.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-chips';
 
-const { Component, isEmpty, isPresent, computed, observer, run } = Ember;
+const { NAME_KEY, Component, isEmpty, isPresent, computed, observer, run } = Ember;
 
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-chips',
   classNames: ['md-default-theme'],
@@ -238,3 +238,7 @@ export default Component.extend({
     return false;
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-chips';
+
+export default PaperComponent;

--- a/addon/components/paper-contact-chips.js
+++ b/addon/components/paper-contact-chips.js
@@ -1,7 +1,10 @@
+import Ember from 'ember';
 import PaperChips from 'ember-paper/components/paper-chips';
 import layout from '../templates/components/paper-contact-chips';
 
-export default PaperChips.extend({
+const { NAME_KEY } = Ember;
+
+const PaperComponent = PaperChips.extend({
   layout,
   tagName: 'md-contact-chips',
   classNames: ['md-default-theme'],
@@ -11,3 +14,7 @@ export default PaperChips.extend({
   nameField: 'name',
   imageField: 'image'
 });
+
+PaperComponent[NAME_KEY] = 'paper-contact-chips';
+
+export default PaperComponent;

--- a/addon/components/paper-content.js
+++ b/addon/components/paper-content.js
@@ -3,15 +3,19 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperContent
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-content',
   classNames: ['md-default-theme'],
   attributeBindings: ['layout-padding', 'scroll-y:md-scroll-y'],
   classNameBindings: ['padding:md-padding']
 });
+
+PaperComponent[NAME_KEY] = 'paper-content';
+
+export default PaperComponent;

--- a/addon/components/paper-dialog-actions.js
+++ b/addon/components/paper-dialog-actions.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperDialogActions
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-dialog-actions'
 });
+
+PaperComponent[NAME_KEY] = 'paper-dialog-actions';
+
+export default PaperComponent;

--- a/addon/components/paper-dialog-container.js
+++ b/addon/components/paper-dialog-container.js
@@ -3,13 +3,13 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperDialogContainer
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   classNames: ['md-dialog-container'],
 
   mouseDown(ev) {
@@ -24,3 +24,7 @@ export default Component.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-dialog-container';
+
+export default PaperComponent;

--- a/addon/components/paper-dialog-content.js
+++ b/addon/components/paper-dialog-content.js
@@ -2,13 +2,17 @@
  * @module ember-paper
  */
 import Ember from 'ember';
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperDialogComponent
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-dialog-content',
   classNames: ['md-dialog-content']
 });
+
+PaperComponent[NAME_KEY] = 'paper-dialog-content';
+
+export default PaperComponent;

--- a/addon/components/paper-dialog-inner.js
+++ b/addon/components/paper-dialog-inner.js
@@ -4,14 +4,14 @@
 import Ember from 'ember';
 import Translate3dMixin from '../mixins/translate3d-mixin';
 
-const { Component, run } = Ember;
+const { NAME_KEY, Component, run } = Ember;
 
 /**
  * @class PaperDialogInner
  * @extends Ember.Component
  * @uses Translate3dMixin
  */
-export default Component.extend(Translate3dMixin, {
+const PaperComponent = Component.extend(Translate3dMixin, {
   tagName: 'md-dialog',
   classNames: ['md-default-theme'],
   classNameBindings: ['contentOverflow:md-content-overflow', 'fullscreen:md-dialog-fullscreen'],
@@ -50,3 +50,7 @@ export default Component.extend(Translate3dMixin, {
     images.off(`load.${this.elementId}`);
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-dialog-inner';
+
+export default PaperComponent;

--- a/addon/components/paper-dialog.js
+++ b/addon/components/paper-dialog.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-dialog';
 
-const { $, Component, computed, inject, testing } = Ember;
+const { NAME_KEY, $, Component, computed, inject, testing } = Ember;
 
 /**
  * @class PaperDialog
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: '',
 
@@ -79,3 +79,7 @@ export default Component.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-dialog';
+
+export default PaperComponent;

--- a/addon/components/paper-divider.js
+++ b/addon/components/paper-divider.js
@@ -3,13 +3,13 @@
  */
 import Ember from 'ember';
 
-const { Component, computed } = Ember;
+const { NAME_KEY, Component, computed } = Ember;
 
 /**
  * @class PaperDivider
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-divider',
   attributeBindings: ['insetAttr:md-inset'],
   inset: false,
@@ -23,3 +23,7 @@ export default Component.extend({
     return this.get('inset') ? 'md-inset' : null;
   })
 });
+
+PaperComponent[NAME_KEY] = 'paper-divider';
+
+export default PaperComponent;

--- a/addon/components/paper-form.js
+++ b/addon/components/paper-form.js
@@ -5,14 +5,14 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-form';
 import ParentMixin from 'ember-paper/mixins/parent-mixin';
 
-const { Component, computed } = Ember;
+const { NAME_KEY, Component, computed } = Ember;
 
 /**
  * @class PaperForm
  * @extends Ember.Component
  * @uses ParentMixin
  */
-export default Component.extend(ParentMixin, {
+const PaperComponent = Component.extend(ParentMixin, {
   layout,
   tagName: 'form',
 
@@ -55,3 +55,7 @@ export default Component.extend(ParentMixin, {
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-form';
+
+export default PaperComponent;

--- a/addon/components/paper-grid-list.js
+++ b/addon/components/paper-grid-list.js
@@ -4,7 +4,7 @@
 import Ember from 'ember';
 import gridLayout from '../utils/grid-layout';
 
-const { Component, inject, computed, A, run, get, isEqual } = Ember;
+const { NAME_KEY, Component, inject, computed, A, run, get, isEqual } = Ember;
 
 const unitCSS = (units) => {
   return `${units.share}% - (${units.gutter} * ${units.gutterShare})`;
@@ -26,7 +26,7 @@ const media = (mediaName) => {
  * @class PaperGridList
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-grid-list',
 
   constants: inject.service(),
@@ -350,3 +350,7 @@ export default Component.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-grid-list';
+
+export default PaperComponent;

--- a/addon/components/paper-grid-tile-footer.js
+++ b/addon/components/paper-grid-tile-footer.js
@@ -4,13 +4,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-grid-tile-footer';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperGridTileFooter
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-grid-tile-footer'
 });
+
+PaperComponent[NAME_KEY] = 'paper-grid-tile-footer';
+
+export default PaperComponent;

--- a/addon/components/paper-grid-tile.js
+++ b/addon/components/paper-grid-tile.js
@@ -5,13 +5,13 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-grid-tile';
 import PaperGridList from './paper-grid-list';
 
-const { Component, computed, inject, get } = Ember;
+const { NAME_KEY, Component, computed, inject, get } = Ember;
 
 /**
  * @class PaperGridTile
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-grid-tile',
 
@@ -69,3 +69,7 @@ export default Component.extend({
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-grid-tile';
+
+export default PaperComponent;

--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-icon';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 
-const { Component, computed, String: Str } = Ember;
+const { NAME_KEY, Component, computed, String: Str } = Ember;
 
 /**
  * @class PaperIcon
@@ -50,5 +50,7 @@ let PaperIconComponent = Component.extend(ColorMixin, {
 PaperIconComponent.reopenClass({
   positionalParams: ['positionalIcon']
 });
+
+PaperIconComponent[NAME_KEY] = 'paper-icon';
 
 export default PaperIconComponent;

--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -8,7 +8,7 @@ import ColorMixin from 'ember-paper/mixins/color-mixin';
 import ChildMixin from 'ember-paper/mixins/child-mixin';
 import ValidationMixin from 'ember-paper/mixins/validation-mixin';
 
-const { Component, $, computed, isEmpty, run, assert } = Ember;
+const { NAME_KEY, Component, $, computed, isEmpty, run, assert } = Ember;
 
 /**
  * @class PaperInput
@@ -18,7 +18,7 @@ const { Component, $, computed, isEmpty, run, assert } = Ember;
  * @uses ColorMixin
  * @uses ValidationMixin
  */
-export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, ValidationMixin, {
+const PaperComponent = Component.extend(FocusableMixin, ColorMixin, ChildMixin, ValidationMixin, {
   layout,
   tagName: 'md-input-container',
   classNames: ['md-default-theme'],
@@ -161,3 +161,7 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-input';
+
+export default PaperComponent;

--- a/addon/components/paper-item.js
+++ b/addon/components/paper-item.js
@@ -6,7 +6,7 @@ import layout from '../templates/components/paper-item';
 import RippleMixin from '../mixins/ripple-mixin';
 import { ParentMixin } from 'ember-composability-tools';
 
-const { Component, computed } = Ember;
+const { NAME_KEY, Component, computed } = Ember;
 
 /**
  * @class PaperItem
@@ -14,7 +14,7 @@ const { Component, computed } = Ember;
  * @uses ParentMixin
  * @uses RippleMixin
  */
-export default Component.extend(RippleMixin, ParentMixin, {
+const PaperComponent = Component.extend(RippleMixin, ParentMixin, {
   layout,
   tagName: 'md-list-item',
 
@@ -71,3 +71,7 @@ export default Component.extend(RippleMixin, ParentMixin, {
     this.sendAction('onMouseLeave', ev);
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-item';
+
+export default PaperComponent;

--- a/addon/components/paper-list.js
+++ b/addon/components/paper-list.js
@@ -3,13 +3,17 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperList
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-list',
   classNames: ['md-default-theme']
 });
+
+PaperComponent[NAME_KEY] = 'paper-list';
+
+export default PaperComponent;

--- a/addon/components/paper-menu-content-inner.js
+++ b/addon/components/paper-menu-content-inner.js
@@ -4,14 +4,14 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-menu-content-inner';
 import ParentMixin from 'ember-paper/mixins/parent-mixin';
-const { Component, inject, computed, run } = Ember;
+const { NAME_KEY, Component, inject, computed, run } = Ember;
 
 /**
  * @class PaperMenuContentInner
  * @extends Ember.Component
  * @uses ParentMixin
  */
-export default Component.extend(ParentMixin, {
+const PaperComponent = Component.extend(ParentMixin, {
   layout,
   tagName: 'md-menu-content',
   attributeBindings: ['width'],
@@ -80,3 +80,7 @@ export default Component.extend(ParentMixin, {
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-menu-content-inner';
+
+export default PaperComponent;

--- a/addon/components/paper-menu-content.js
+++ b/addon/components/paper-menu-content.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-menu-content';
 import ContentComponent from 'ember-basic-dropdown/components/basic-dropdown/content';
 import { nextTick } from 'ember-css-transitions/mixins/transition-mixin';
-const { $, computed, String: { htmlSafe } } = Ember;
+const { NAME_KEY, $, computed, String: { htmlSafe } } = Ember;
 const MutObserver = window.MutationObserver || window.WebKitMutationObserver;
 
 function waitForAnimations(element, callback) {
@@ -31,7 +31,7 @@ function waitForAnimations(element, callback) {
  * @class PaperMenuContent
  * @extends ContentComponent
  */
-export default ContentComponent.extend({
+const PaperComponent = ContentComponent.extend({
   layout,
 
   // We need to overwrite this CP because:
@@ -107,3 +107,7 @@ export default ContentComponent.extend({
     });
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-menu-content';
+
+export default PaperComponent;

--- a/addon/components/paper-menu-item.js
+++ b/addon/components/paper-menu-item.js
@@ -5,14 +5,14 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-menu-item';
 import ChildMixin from 'ember-paper/mixins/child-mixin';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperMenuItem
  * @extends Ember.Component
  * @uses ChildMixin
  */
-export default Component.extend(ChildMixin, {
+const PaperComponent = Component.extend(ChildMixin, {
   layout,
   tagName: 'md-menu-item',
   disabled: false,
@@ -30,3 +30,7 @@ export default Component.extend(ChildMixin, {
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-menu-item';
+
+export default PaperComponent;

--- a/addon/components/paper-menu.js
+++ b/addon/components/paper-menu.js
@@ -4,7 +4,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-menu';
 import BasicDropdownComponent from 'ember-basic-dropdown/components/basic-dropdown';
-const { assert, computed } = Ember;
+const { NAME_KEY, assert, computed } = Ember;
 
 const MENU_EDGE_MARGIN = 8;
 
@@ -25,7 +25,7 @@ function firstVisibleChild(node) {
  * @class PaperMenu
  * @extends BasicDropdownComponent
  */
-export default BasicDropdownComponent.extend({
+const PaperComponent = BasicDropdownComponent.extend({
   layout,
 
   close() {
@@ -181,3 +181,7 @@ export default BasicDropdownComponent.extend({
     return { style, horizontalPosition: '', verticalPosition: '' };
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-menu';
+
+export default PaperComponent;

--- a/addon/components/paper-optgroup.js
+++ b/addon/components/paper-optgroup.js
@@ -4,14 +4,18 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-optgroup';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperOptgroup
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'md-optgroup',
   attributeBindings: ['label']
 });
+
+PaperComponent[NAME_KEY] = 'paper-optgroup';
+
+export default PaperComponent;

--- a/addon/components/paper-option.js
+++ b/addon/components/paper-option.js
@@ -6,14 +6,14 @@ import layout from '../templates/components/paper-option';
 import PaperMenuItem from './paper-menu-item';
 import RippleMixin from '../mixins/ripple-mixin';
 
-const { computed } = Ember;
+const { NAME_KEY, computed } = Ember;
 
 /**
  * @class PaperOption
  * @extends PaperMenuItem
  * @uses RippleMixin
  */
-export default PaperMenuItem.extend(RippleMixin, {
+const PaperComponent = PaperMenuItem.extend(RippleMixin, {
   layout,
   tagName: 'md-option',
   attributeBindings: ['aria-selected', 'aria-disabled', 'aria-current', 'data-option-index', 'role', 'selected', 'tabindex'],
@@ -23,3 +23,7 @@ export default PaperMenuItem.extend(RippleMixin, {
   center: computed.readOnly('isIconButton'),
   dimBackground: computed.not('isIconButton')
 });
+
+PaperComponent[NAME_KEY] = 'paper-option';
+
+export default PaperComponent;

--- a/addon/components/paper-progress-circular.js
+++ b/addon/components/paper-progress-circular.js
@@ -7,7 +7,7 @@ import ColorMixin from 'ember-paper/mixins/color-mixin';
 import clamp from 'ember-paper/utils/clamp';
 import { rAF, cAF } from 'ember-css-transitions/mixins/transition-mixin';
 
-const { Component, computed, isPresent, String: { htmlSafe } } = Ember;
+const { NAME_KEY, Component, computed, isPresent, String: { htmlSafe } } = Ember;
 
 const MODE_DETERMINATE = 'determinate';
 const MODE_INDETERMINATE = 'indeterminate';
@@ -31,7 +31,7 @@ function materialEase(t, b, c, d) {
  * @extends Ember.Component
  * @uses ColorMixin
  */
-export default Component.extend(ColorMixin, {
+const PaperComponent = Component.extend(ColorMixin, {
   layout,
   tagName: 'md-progress-circular',
   classNames: ['md-default-theme'],
@@ -229,3 +229,7 @@ export default Component.extend(ColorMixin, {
     return (diameter - strokeWidth) * Math.PI * ((3 * (limit || 100) / 100) - (value / 100));
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-progress-circular';
+
+export default PaperComponent;

--- a/addon/components/paper-progress-linear.js
+++ b/addon/components/paper-progress-linear.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-progress-linear';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 
-const { inject, computed, Component, isPresent, String: { htmlSafe } } = Ember;
+const { NAME_KEY, inject, computed, Component, isPresent, String: { htmlSafe } } = Ember;
 
 function makeTransform(value) {
   let scale = value / 100;
@@ -23,7 +23,7 @@ const MODE_QUERY = 'query';
  * @extends Ember.Component
  * @uses ColorMixin
  */
-export default Component.extend(ColorMixin, {
+const PaperComponent = Component.extend(ColorMixin, {
   layout,
   tagName: 'md-progress-linear',
 
@@ -97,3 +97,7 @@ export default Component.extend(ColorMixin, {
   })
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-progress-linear';
+
+export default PaperComponent;

--- a/addon/components/paper-radio-base.js
+++ b/addon/components/paper-radio-base.js
@@ -7,7 +7,7 @@ import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import RippleMixin from 'ember-paper/mixins/ripple-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 
-const { Component, computed, assert } = Ember;
+const { NAME_KEY, Component, computed, assert } = Ember;
 
 /**
  * @class PaperRadio
@@ -16,7 +16,7 @@ const { Component, computed, assert } = Ember;
  * @uses ColorMixin
  * @uses RippleMixin
  */
-export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
+const PaperComponent = Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
   layout,
   tagName: 'md-radio-button',
   classNames: ['md-default-theme'],
@@ -57,3 +57,7 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
     return this.get('bubbles');
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-radio-base';
+
+export default PaperComponent;

--- a/addon/components/paper-radio-group.js
+++ b/addon/components/paper-radio-group.js
@@ -6,7 +6,7 @@ import layout from '../templates/components/paper-radio-group';
 import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import { ParentMixin } from 'ember-composability-tools';
 
-const { Component, computed, inject, assert } = Ember;
+const { NAME_KEY, Component, computed, inject, assert } = Ember;
 
 /**
  * @class PaperRadioGroup
@@ -14,7 +14,7 @@ const { Component, computed, inject, assert } = Ember;
  * @uses FocusableMixin
  * @uses ParentMixin
  */
-export default Component.extend(FocusableMixin, ParentMixin, {
+const PaperComponent = Component.extend(FocusableMixin, ParentMixin, {
   layout,
   tagName: 'md-radio-group',
   tabindex: 0,
@@ -73,3 +73,7 @@ export default Component.extend(FocusableMixin, ParentMixin, {
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-radio-group';
+
+export default PaperComponent;

--- a/addon/components/paper-radio-proxiable.js
+++ b/addon/components/paper-radio-proxiable.js
@@ -1,16 +1,23 @@
 /**
  * @module ember-paper
  */
+import Ember from 'ember';
 import PaperRadioBaseComponent from './paper-radio-base';
 import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
+
+const { NAME_KEY } = Ember;
 
 /**
  * @class PaperRadio
  * @extends PaperRadioBaseComponent
  * @uses ProxiableMixin
  */
-export default PaperRadioBaseComponent.extend(ProxiableMixin, {
+const PaperComponent = PaperRadioBaseComponent.extend(ProxiableMixin, {
   processProxy() {
     this.click();
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-radio-proxiable';
+
+export default PaperComponent;

--- a/addon/components/paper-radio.js
+++ b/addon/components/paper-radio.js
@@ -1,14 +1,21 @@
 /**
  * @module ember-paper
  */
+import Ember from 'ember';
 import PaperRadioBaseComponent from './paper-radio-base';
 import { ChildMixin } from 'ember-composability-tools';
+
+const { NAME_KEY } = Ember;
 
 /**
  * @class PaperRadio
  * @extends PaperRadioBaseComponent
  * @uses ChildMixin
  */
-export default PaperRadioBaseComponent.extend(ChildMixin, {
+const PaperComponent = PaperRadioBaseComponent.extend(ChildMixin, {
   shouldRegister: false
 });
+
+PaperComponent[NAME_KEY] = 'paper-radio';
+
+export default PaperComponent;

--- a/addon/components/paper-reset-button.js
+++ b/addon/components/paper-reset-button.js
@@ -1,7 +1,10 @@
+import Ember from 'ember';
 import Component from 'ember-component';
 import TransitionMixin from 'ember-css-transitions/mixins/transition-mixin';
 
-export default Component.extend(TransitionMixin, {
+const { NAME_KEY } = Ember;
+
+const PaperComponent = Component.extend(TransitionMixin, {
   tagName: 'button',
   attributeBindings: ['tabindex'],
   transitionClass: 'ng',
@@ -16,3 +19,7 @@ export default Component.extend(TransitionMixin, {
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-reset-button';
+
+export default PaperComponent;

--- a/addon/components/paper-select-content.js
+++ b/addon/components/paper-select-content.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import PaperMenuContent from './paper-menu-content';
 import layout from '../templates/components/paper-select-content';
 
-const { run, $ } = Ember;
+const { NAME_KEY, run, $ } = Ember;
 
 function waitForAnimations(element, callback) {
   let computedStyle = window.getComputedStyle(element);
@@ -30,7 +30,7 @@ function waitForAnimations(element, callback) {
  * @class PaperSelectContent
  * @extends PaperMenuContent
  */
-export default PaperMenuContent.extend({
+const PaperComponent = PaperMenuContent.extend({
   layout,
 
   animateIn() {
@@ -62,3 +62,7 @@ export default PaperMenuContent.extend({
     });
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-content';
+
+export default PaperComponent;

--- a/addon/components/paper-select-header.js
+++ b/addon/components/paper-select-header.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperSelectHeader
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   tagName: 'md-select-header'
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-header';
+
+export default PaperComponent;

--- a/addon/components/paper-select-menu-inner.js
+++ b/addon/components/paper-select-menu-inner.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-select-menu-inner';
 import PaperMenuContentInner from './paper-menu-content-inner';
 import { indexOfOption, optionAtIndex, countOptions } from 'ember-power-select/utils/group-utils';
-const { computed, run } = Ember;
+const { NAME_KEY, computed, run } = Ember;
 
 function advanceSelectableOption(options, currentOption, step) {
   let resultsLength = countOptions(options);
@@ -16,7 +16,7 @@ function advanceSelectableOption(options, currentOption, step) {
   return option;
 }
 
-export default PaperMenuContentInner.extend({
+const PaperComponent = PaperMenuContentInner.extend({
   layout,
   tagName: 'md-select-menu',
   classNames: ['md-default-theme'],
@@ -100,3 +100,7 @@ export default PaperMenuContentInner.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-menu-inner';
+
+export default PaperComponent;

--- a/addon/components/paper-select-menu-trigger.js
+++ b/addon/components/paper-select-menu-trigger.js
@@ -1,12 +1,16 @@
 import Ember from 'ember';
 import BasicTrigger from 'ember-basic-dropdown/components/basic-dropdown/trigger';
 
-const { computed } = Ember;
+const { NAME_KEY, computed } = Ember;
 
-export default BasicTrigger.extend({
+const PaperComponent = BasicTrigger.extend({
   tagName: 'md-select',
   attributeBindings: ['disabledAttr:disabled', 'required'],
   disabledAttr: computed('disabled', function() {
     return this.get('disabled') ? 'disabled' : null;
   })
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-menu-trigger';
+
+export default PaperComponent;

--- a/addon/components/paper-select-menu.js
+++ b/addon/components/paper-select-menu.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import PaperMenu from './paper-menu';
 import layout from '../templates/components/paper-select-menu';
 
-const { $ } = Ember;
+const { NAME_KEY, $ } = Ember;
 
 const SELECT_EDGE_MARGIN = 8;
 
@@ -26,7 +26,7 @@ function clamp(min, n, max) {
  * @class PaperSelectMenu
  * @extends Ember.Component
  */
-export default PaperMenu.extend({
+const PaperComponent = PaperMenu.extend({
   layout,
 
   triggerComponent: 'paper-select-menu-trigger',
@@ -167,3 +167,7 @@ export default PaperMenu.extend({
     return { style, horizontalPosition: '', verticalPosition: '' };
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-menu';
+
+export default PaperComponent;

--- a/addon/components/paper-select-options.js
+++ b/addon/components/paper-select-options.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 import PowerOptions from 'ember-power-select/components/power-select/options';
 import layout from '../templates/components/paper-select-options';
 
-const { $ } = Ember;
+const { NAME_KEY, $ } = Ember;
 
-export default PowerOptions.extend({
+const PaperComponent = PowerOptions.extend({
   layout,
   tagName: 'md-content',
   init() {
@@ -42,3 +42,7 @@ export default PowerOptions.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-options';
+
+export default PaperComponent;

--- a/addon/components/paper-select-search.js
+++ b/addon/components/paper-select-search.js
@@ -1,6 +1,13 @@
+import Ember from 'ember';
 import PowerBeforeOptions from 'ember-power-select/components/power-select/before-options';
 import layout from '../templates/components/paper-select-search';
 
-export default PowerBeforeOptions.extend({
+const { NAME_KEY } = Ember;
+
+const PaperComponent = PowerBeforeOptions.extend({
   layout
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-search';
+
+export default PaperComponent;

--- a/addon/components/paper-select-trigger.js
+++ b/addon/components/paper-select-trigger.js
@@ -5,13 +5,13 @@ import Ember from 'ember';
 import TriggerComponent from 'ember-power-select/components/power-select/trigger';
 import layout from '../templates/components/paper-select-trigger';
 
-const { computed } = Ember;
+const { NAME_KEY, computed } = Ember;
 
 /**
  * @class PaperSelectTrigger
  * @extends Ember.Component
  */
-export default TriggerComponent.extend({
+const PaperComponent = TriggerComponent.extend({
   layout,
   tagName: 'md-select-value',
   classNames: ['md-select-value'],
@@ -20,3 +20,7 @@ export default TriggerComponent.extend({
     return (this.get('placeholder') || this.get('label')) && !this.get('select.selected');
   })
 });
+
+PaperComponent[NAME_KEY] = 'paper-select-trigger';
+
+export default PaperComponent;

--- a/addon/components/paper-select.js
+++ b/addon/components/paper-select.js
@@ -8,7 +8,7 @@ import ValidationMixin from 'ember-paper/mixins/validation-mixin';
 import ChildMixin from 'ember-paper/mixins/child-mixin';
 import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 
-const { computed } = Ember;
+const { NAME_KEY, computed } = Ember;
 
 function concatWithProperty(strings, property) {
   if (property) {
@@ -21,7 +21,7 @@ function concatWithProperty(strings, property) {
  * @class PaperSelect
  * @extends PaperInput
  */
-export default PowerSelect.extend(ValidationMixin, ChildMixin, FocusableMixin, {
+const PaperComponent = PowerSelect.extend(ValidationMixin, ChildMixin, FocusableMixin, {
   layout,
   tagName: 'md-input-container',
   onchange: computed.alias('onChange'),
@@ -67,3 +67,7 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, FocusableMixin, {
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-select';
+
+export default PaperComponent;

--- a/addon/components/paper-sidenav-container.js
+++ b/addon/components/paper-sidenav-container.js
@@ -3,14 +3,18 @@
  */
 import Ember from 'ember';
 
-const { Component, String: { htmlSafe } } = Ember;
+const { NAME_KEY, Component, String: { htmlSafe } } = Ember;
 
 /**
  * @class PaperSidenavContainer
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   classNames: ['flex', 'layout-row'],
   attributeBindings: ['style'],
   style: htmlSafe('overflow: hidden')
 });
+
+PaperComponent[NAME_KEY] = 'paper-sidenav-container';
+
+export default PaperComponent;

--- a/addon/components/paper-sidenav-inner.js
+++ b/addon/components/paper-sidenav-inner.js
@@ -5,14 +5,14 @@
 import Ember from 'ember';
 import TransitionMixin from 'ember-css-transitions/mixins/transition-mixin';
 
-const { Component, inject, computed, $, run } = Ember;
+const { NAME_KEY, Component, inject, computed, $, run } = Ember;
 
 /**
  * @class PaperSidenavInner
  * @extends Ember.Component
  * @uses TransitionMixin
  */
-export default Component.extend(TransitionMixin, {
+const PaperComponent = Component.extend(TransitionMixin, {
   tagName: 'md-sidenav',
   attributeBindings: ['tabindex'],
   classNameBindings: ['positionClass'],
@@ -111,3 +111,7 @@ export default Component.extend(TransitionMixin, {
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-sidenav-inner';
+
+export default PaperComponent;

--- a/addon/components/paper-sidenav-toggle.js
+++ b/addon/components/paper-sidenav-toggle.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-sidenav-toggle';
 
-const { Component, inject } = Ember;
+const { NAME_KEY, Component, inject } = Ember;
 
 /**
  * @class PaperSidenavToggle
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: '',
 
@@ -23,3 +23,7 @@ export default Component.extend({
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-sidenav-toggle';
+
+export default PaperComponent;

--- a/addon/components/paper-sidenav.js
+++ b/addon/components/paper-sidenav.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-sidenav';
 
-const { Component, computed } = Ember;
+const { NAME_KEY, Component, computed } = Ember;
 
 /**
  * @class
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: '',
 
@@ -30,3 +30,7 @@ export default Component.extend({
     }
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-sidenav';
+
+export default PaperComponent;

--- a/addon/components/paper-slider.js
+++ b/addon/components/paper-slider.js
@@ -6,7 +6,7 @@ import layout from '../templates/components/paper-slider';
 import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import clamp from 'ember-paper/utils/clamp';
-const { Component, computed, inject, run, String: { htmlSafe } } = Ember;
+const { NAME_KEY, Component, computed, inject, run, String: { htmlSafe } } = Ember;
 /* global Hammer */
 
 /**
@@ -15,7 +15,7 @@ const { Component, computed, inject, run, String: { htmlSafe } } = Ember;
  * @uses FocusableMixin
  * @uses ColorMixin
  */
-export default Component.extend(FocusableMixin, ColorMixin, {
+const PaperComponent = Component.extend(FocusableMixin, ColorMixin, {
   layout,
   tagName: 'md-slider',
 
@@ -203,3 +203,7 @@ export default Component.extend(FocusableMixin, ColorMixin, {
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-slider';
+
+export default PaperComponent;

--- a/addon/components/paper-subheader.js
+++ b/addon/components/paper-subheader.js
@@ -4,14 +4,18 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-subheader';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperSubheader
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   tagName: 'h2',
   classNames: ['md-subheader']
 });
+
+PaperComponent[NAME_KEY] = 'paper-subheader';
+
+export default PaperComponent;

--- a/addon/components/paper-switch.js
+++ b/addon/components/paper-switch.js
@@ -9,7 +9,7 @@ import ColorMixin from 'ember-paper/mixins/color-mixin';
 import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
 
 const {
-  Component, assert, computed, get, run, String: { htmlSafe }, inject
+  NAME_KEY, Component, assert, computed, get, run, String: { htmlSafe }, inject
 } = Ember;
 /* global Hammer */
 
@@ -21,7 +21,7 @@ const {
  * @uses ColorMixin
  * @uses ProxiableMixin
  */
-export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
+const PaperComponent = Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
   layout,
   tagName: 'md-switch',
   classNames: ['paper-switch', 'md-default-theme'],
@@ -154,3 +154,7 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, Proxiab
   }
 
 });
+
+PaperComponent[NAME_KEY] = 'paper-switch';
+
+export default PaperComponent;

--- a/addon/components/paper-toolbar-tools.js
+++ b/addon/components/paper-toolbar-tools.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperToolbarTools
  * @extends Ember.Component
  */
-export default Component.extend({
+const PaperComponent = Component.extend({
   classNames: ['md-toolbar-tools']
 });
+
+PaperComponent[NAME_KEY] = 'paper-toolbar-tools';
+
+export default PaperComponent;

--- a/addon/components/paper-toolbar.js
+++ b/addon/components/paper-toolbar.js
@@ -5,17 +5,21 @@ import Ember from 'ember';
 import layout from '../templates/components/paper-toolbar';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
 /**
  * @class PaperToolbar
  * @extends Ember.Component
  * @uses ColorMixin
  */
-export default Component.extend(ColorMixin, {
+const PaperComponent = Component.extend(ColorMixin, {
   layout,
   tagName: 'md-toolbar',
   classNames: ['md-default-theme'],
   tall: false,
   classNameBindings: ['tall:md-tall']
 });
+
+PaperComponent[NAME_KEY] = 'paper-toolbar';
+
+export default PaperComponent;

--- a/addon/components/paper-virtual-repeat-scroller.js
+++ b/addon/components/paper-virtual-repeat-scroller.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-virtual-repeat-scroller';
 
-const { Component } = Ember;
+const { NAME_KEY, Component } = Ember;
 
-export default Component.extend({
+const PaperComponent = Component.extend({
   layout,
   classNames: ['md-virtual-repeat-scroller'],
 
@@ -19,3 +19,7 @@ export default Component.extend({
     this.$().off('scroll');
   }
 });
+
+PaperComponent[NAME_KEY] = 'paper-virtual-repeat-scroller';
+
+export default PaperComponent;

--- a/addon/components/paper-virtual-repeat.js
+++ b/addon/components/paper-virtual-repeat.js
@@ -3,6 +3,7 @@ import VirtualEachComponent from 'virtual-each/components/virtual-each/component
 import layout from '../templates/components/paper-virtual-repeat';
 
 const {
+  NAME_KEY,
   computed,
   run,
   get,
@@ -263,5 +264,7 @@ const VirtualRepeatComponent = VirtualEachComponent.extend({
 VirtualRepeatComponent.reopenClass({
   positionalParams: ['items']
 });
+
+VirtualRepeatComponent[NAME_KEY] = 'paper-virtual-repeat';
 
 export default VirtualRepeatComponent;

--- a/addon/mixins/child-mixin.js
+++ b/addon/mixins/child-mixin.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import ParentMixin from 'ember-paper/mixins/parent-mixin';
 
-const { Mixin, computed } = Ember;
+const { Mixin, NAME_KEY, computed } = Ember;
 
 /**
  * @class ChildMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
 
   // override to look for a specific parent class
   parentClass: ParentMixin,
@@ -34,3 +34,7 @@ export default Mixin.create({
     }
   }
 });
+
+PaperMixin[NAME_KEY] = 'paper-child-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/color-mixin.js
+++ b/addon/mixins/color-mixin.js
@@ -3,12 +3,16 @@
  */
 import Ember from 'ember';
 
-const { Mixin } = Ember;
+const { Mixin, NAME_KEY } = Ember;
 
 /**
  * @class ColorMixin
  * @extends Ember.Mixin;
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
   classNameBindings: ['warn:md-warn', 'accent:md-accent', 'primary:md-primary']
 });
+
+PaperMixin[NAME_KEY] = 'paper-color-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/events-mixin.js
+++ b/addon/mixins/events-mixin.js
@@ -3,13 +3,13 @@
  */
 import Ember from 'ember';
 
-const { Mixin } = Ember;
+const { Mixin, NAME_KEY } = Ember;
 
 /**
  * @class EventsMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
   touchStart(e) {
     return this.down(e);
   },
@@ -50,3 +50,7 @@ export default Mixin.create({
 
   move() {}
 });
+
+PaperMixin[NAME_KEY] = 'paper-events-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/focusable-mixin.js
+++ b/addon/mixins/focusable-mixin.js
@@ -4,14 +4,14 @@
 import Ember from 'ember';
 import EventsMixin from './events-mixin';
 
-const { Mixin, computed } = Ember;
+const { Mixin, NAME_KEY, computed } = Ember;
 
 /**
  * @class FocusableMixin
  * @extends Ember.Mixin
  * @uses EventsMixin
  */
-export default Mixin.create(EventsMixin, {
+const PaperMixin = Mixin.create(EventsMixin, {
 
   disabled: false,
   pressed: false,
@@ -80,3 +80,7 @@ export default Mixin.create(EventsMixin, {
     }
   }
 });
+
+PaperMixin[NAME_KEY] = 'paper-focusable-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/parent-mixin.js
+++ b/addon/mixins/parent-mixin.js
@@ -3,13 +3,13 @@
  */
 import Ember from 'ember';
 
-const { Mixin, computed, A } = Ember;
+const { Mixin, NAME_KEY, computed, A } = Ember;
 
 /**
  * @class ParentMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
   childComponents: computed(function() {
     return A();
   }),
@@ -22,3 +22,7 @@ export default Mixin.create({
     this.get('childComponents').removeObject(child);
   }
 });
+
+PaperMixin[NAME_KEY] = 'paper-parent-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/proxiable-mixin.js
+++ b/addon/mixins/proxiable-mixin.js
@@ -4,14 +4,14 @@
 import Ember from 'ember';
 import { ChildMixin } from 'ember-composability-tools';
 
-const { Mixin, run } = Ember;
+const { Mixin, NAME_KEY, run } = Ember;
 
 /**
  * @class ProxiableMixin
  * @uses ChildMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create(ChildMixin, {
+const PaperMixin = Mixin.create(ChildMixin, {
 
   classNameBindings: ['secondary:md-secondary'],
 
@@ -51,3 +51,7 @@ export default Mixin.create(ChildMixin, {
     }
   }
 });
+
+PaperMixin[NAME_KEY] = 'paper-proxiable-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/ripple-mixin.js
+++ b/addon/mixins/ripple-mixin.js
@@ -3,7 +3,7 @@
  */
 import Ember from 'ember';
 
-const { inject, computed, Mixin, run, $ } = Ember;
+const { inject, computed, Mixin, NAME_KEY, run, $ } = Ember;
 /* global window */
 
 const DURATION = 400;
@@ -12,7 +12,7 @@ const DURATION = 400;
  * @class RippleMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
   util: inject.service(),
   rippleContainerSelector: '.md-container',
 
@@ -294,3 +294,7 @@ export default Mixin.create({
     this.lastRipple = null;
   }
 });
+
+PaperMixin[NAME_KEY] = 'paper-ripple-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -4,13 +4,13 @@
 import Ember from 'ember';
 import { nextTick, computeTimeout } from 'ember-css-transitions/mixins/transition-mixin';
 
-const { $, Mixin, String: { htmlSafe }, computed, inject, run } = Ember;
+const { $, Mixin, NAME_KEY, String: { htmlSafe }, computed, inject, run } = Ember;
 
 /**
  * @class Translate3dMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
   constants: inject.service(),
 
   attributeBindings: ['translateStyle:style'],
@@ -188,3 +188,7 @@ export default Mixin.create({
   }
 
 });
+
+PaperMixin[NAME_KEY] = 'paper-translate3d-mixin';
+
+export default PaperMixin;

--- a/addon/mixins/validation-mixin.js
+++ b/addon/mixins/validation-mixin.js
@@ -3,7 +3,7 @@
  */
 import Ember from 'ember';
 
-const { Mixin, computed, A, assert, isArray, Logger, get, String: { loc }, isBlank } = Ember;
+const { Mixin, NAME_KEY, computed, A, assert, isArray, Logger, get, String: { loc }, isBlank } = Ember;
 
 import requiredValidator from 'ember-paper/validators/required';
 import minValidator from 'ember-paper/validators/min';
@@ -68,7 +68,7 @@ function buildComputedValidationMessages(property, validations = [], customValid
  * @class ValidationMixin
  * @extends Ember.Mixin
  */
-export default Mixin.create({
+const PaperMixin = Mixin.create({
   validationErrorMessages: null,
   lastIsInvalid: undefined,
   validationProperty: null, // property that validation should be based on
@@ -134,3 +134,7 @@ export default Mixin.create({
   customValidations: [],
   errors: []
 });
+
+PaperMixin[NAME_KEY] = 'paper-validation-mixin';
+
+export default PaperMixin;


### PR DESCRIPTION
This will fix most of the '(unknown_mixin)' labels shown currently in Ember Inspector.