### PR TITLE
paper-chips: decrease rerender amount by introducing keyProp property

### DIFF
--- a/addon/components/paper-chips.js
+++ b/addon/components/paper-chips.js
@@ -48,8 +48,8 @@ export default Component.extend({
           item[this.get('searchField')] = newItem;
         }
 
-        this.sendAction('addItem', item);
         this.set('newChipValue', '');
+        this.sendAction('addItem', item);
 
         if (isPresent(this.get('autocomplete'))) {
           // We have an autocomplete - reset it once it's closed itself.

--- a/addon/components/paper-chips.js
+++ b/addon/components/paper-chips.js
@@ -9,6 +9,7 @@ export default Component.extend({
   classNames: ['md-default-theme'],
   activeChip: -1,
   focusedElement: 'none',
+  keyProp: null,
   isFocused: computed('focusedElement', function() {
     if (this.get('focusedElement') === 'none') {
       return false;

--- a/addon/templates/components/paper-chips.hbs
+++ b/addon/templates/components/paper-chips.hbs
@@ -4,7 +4,7 @@
   onkeydown={{action "keyDown"}}
   onfocus={{action "chipsFocus"}}
   onblur={{action "chipsBlur"}}>
-  {{#each content as |item index|}}
+  {{#each content key=keyProp as |item index|}}
     <md-chip class="md-chip md-default-theme {{if readOnly "md-readonly"}} {{if (eq activeChip index) "md-focused"}}">
       <div class="md-chip-content" tabindex="-1" aria-hidden="true">
         {{#if hasBlock}}


### PR DESCRIPTION
- Adds new prop `keyProp` to improve render performance. (https://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys)
- Prevents possible 'set on destroyed object' error
