### PR TITLE
Added isTouched and isInvalid to paper-autocomplete

### DIFF
--- a/addon/templates/components/paper-autocomplete-trigger.hbs
+++ b/addon/templates/components/paper-autocomplete-trigger.hbs
@@ -5,6 +5,8 @@
     flex=true
     required=(readonly required)
     passThru=(readonly passThru)
+    isTouched=(readonly isTouched)
+    isInvalid=(readonly isInvalid)
     validationErrorMessages=(readonly validationErrorMessages)
     disabled=(readonly disabled)
     onChange=(action "handleInputLocal")

--- a/addon/templates/components/paper-autocomplete.hbs
+++ b/addon/templates/components/paper-autocomplete.hbs
@@ -33,6 +33,8 @@
       allowClear=(readonly allowClear)
       required=(readonly required)
       passThru=(readonly passThru)
+      isTouched=(readonly isTouched)
+      isInvalid=(readonly isInvalid)
       class="layout-row"
       flex=(readonly flex)
       disabled=disabled


### PR DESCRIPTION
Realized it wasn´t possible, and I thought it could be useful for some scenarios where you need to manually show validity from inputs, for merely UX purposes.