### PR TITLE
Chips: Pass search and matcher through to autocomplete

### DIFF
--- a/addon/templates/components/paper-chips.hbs
+++ b/addon/templates/components/paper-chips.hbs
@@ -34,6 +34,8 @@
           closeOnSelect=true
           placeholder=placeholder
           searchField=searchField
+          search=search
+          matcher=matcher
           noMatchesMessage=noMatchesMessage
           onBlur=(action "inputBlur")
           onSelectionChange=(action "autocompleteChange")

--- a/addon/templates/components/paper-contact-chips.hbs
+++ b/addon/templates/components/paper-contact-chips.hbs
@@ -23,7 +23,7 @@
     {{/each}}
     {{#unless readOnly}}
       <div class="md-chip-input-container">
-        {{#paper-autocomplete closeOnSelect=true onBlur=(action "inputBlur") onSelectionChange=(action "autocompleteChange") onSearchTextChange=(action "searchTextChange") onFocus=(action "inputFocus") onOpen=(action "inputFocus") placeholder=placeholder options=options searchField=searchField as |item select|}}
+        {{#paper-autocomplete closeOnSelect=true onBlur=(action "inputBlur") onSelectionChange=(action "autocompleteChange") onSearchTextChange=(action "searchTextChange") onFocus=(action "inputFocus") onOpen=(action "inputFocus") placeholder=placeholder options=options searchField=searchField search=search matcher=matcher as |item select|}}
           <div class="md-contact-suggestion">
             <img src={{get item imageField}} alt={{get item nameField}} class="md-contact-avatar">
             <span class="md-contact-name">{{get item nameField}}</span>


### PR DESCRIPTION
This allows for customisable searching in Chips autocomplete (beyond just specifying the `searchField`).  I would have done this sooner, but I've only just hit the need for it and realised that these aren't already being passed through...