### PR TITLE
Yield the dropdown public API from paper-menu

### DIFF
--- a/addon/templates/components/paper-menu.hbs
+++ b/addon/templates/components/paper-menu.hbs
@@ -1,4 +1,5 @@
 {{yield (hash
+  dropdown=(readonly publicAPI)
   isOpen=publicAPI.isOpen
   disabled=publicAPI.disabled
   actions=publicAPI.actions


### PR DESCRIPTION
This can be very useful in more advanced scenarios. The yielded actions are practically useless without the dropdown's unique id.