### PR TITLE
fix(ac): remove md-show-clear-button style when disabled

### DIFF
--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -13,8 +13,10 @@ const { Component, isPresent, isBlank, run, get, computed } = Ember;
 export default Component.extend({
   layout,
   tagName: 'md-autocomplete-wrap',
-  classNames: ['md-show-clear-button'],
-  classNameBindings: ['noLabel:md-whiteframe-z1', 'select.isOpen:md-menu-showing'],
+  classNameBindings: ['showClearButton:md-show-clear-button', 'noLabel:md-whiteframe-z1', 'select.isOpen:md-menu-showing'],
+
+  isEnabled: computed.not('disabled').readOnly(),
+  showClearButton: computed.and('allowClear', 'isEnabled').readOnly(),
 
   noLabel: computed.not('extra.label'),
   _innerText: computed.oneWay('searchText'),

--- a/addon/templates/components/paper-autocomplete-trigger.hbs
+++ b/addon/templates/components/paper-autocomplete-trigger.hbs
@@ -43,7 +43,7 @@
   {{paper-progress-linear classNameBindings="extra.label:md-inline"}}
 {{/if}}
 {{#if (and (or selected text) allowClear (not select.disabled))}}
-  {{#paper-reset-button onReset=(action "clear") tabindex="-1"}}
+  {{#paper-reset-button class="reset-button" onReset=(action "clear") tabindex="-1"}}
     {{paper-icon "close"}}
   {{/paper-reset-button}}
 {{/if}}

--- a/app/styles/overrides/paper-autocomplete.scss
+++ b/app/styles/overrides/paper-autocomplete.scss
@@ -3,3 +3,12 @@
   height: 225.5px;
   max-height: 225.5px;
 }
+
+md-autocomplete {
+  button.reset-button {
+    display: none;
+  }
+  &[disabled] input {
+    text-overflow: ellipsis;
+  }
+}


### PR DESCRIPTION
Currently ```paper-autocomplete-trigger``` component has ```md-show-clear-button``` class always set regardless of the state of the ```paper-autocompelete```  component (allowClear). This class sets padding on the inner input element to make sure that the text does not over-run the clear-button. This PR address 2 things:
1. If the ```paper-autocomplete``` is disabled, remove that class so more of the selected content is visible
2. If only apply ```md-show-clear-button``` class if allowClear is truthy.