### PR TITLE
forward primary/warn configuration to the toasts' paper-button

### DIFF
--- a/addon/templates/components/paper-toaster.hbs
+++ b/addon/templates/components/paper-toaster.hbs
@@ -11,7 +11,7 @@
     {{else}}
       {{#toast.text}}{{activeToast.text}}{{/toast.text}}
       {{#if activeToast.action}}
-        {{#paper-button accent=activeToast.action.accent onClick=activeToast.action.onClick}}
+        {{#paper-button primary=activeToast.action.primary accent=activeToast.action.accent warn=activeToast.action.warn onClick=activeToast.action.onClick}}
           {{activeToast.action.label}}
         {{/paper-button}}
       {{/if}}

--- a/tests/dummy/app/templates/demo/toast.hbs
+++ b/tests/dummy/app/templates/demo/toast.hbs
@@ -163,7 +163,9 @@
             (p-row "position" "string" "Possible values are `bottom left` (default), `bottom right`, `top left` and `top right`")
             (p-row "toastClass" "string" "CSS class to be applied to the md-toast element")
             (p-row "action.label" "string" "The label of the action button.")
+            (p-row "action.primary" "boolean" "Wether or not you want the action button to be higlighted with the primary color.")
             (p-row "action.accent" "boolean" "Wether or not you want the action button to be higlighted with the accent color.")
+            (p-row "action.warn" "boolean" "Wether or not you want the action button to be higlighted with the warn color.")
             (p-row "action.onClick" "function" "This function gets called when the button is pressed.")
           )
         }}

--- a/tests/integration/components/paper-toaster-test.js
+++ b/tests/integration/components/paper-toaster-test.js
@@ -1,27 +1,89 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | paper toaster', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  hooks.beforeEach(function() {
+    this.set('paperToaster', {
+      cancelToast() {
+      }
+    });
+  });
 
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it can shows an action', async function(assert) {
+    assert.expect(2);
 
-    await render(hbs`{{paper-toaster}}`);
+    this.set('paperToaster.activeToast', {
+      show: true,
+      position: 'bottom left',
+      duration: 500,
+      action: {
+        label: 'label',
+        primary: true,
+        onClick() {
+          assert.ok(true, 'onClick is called');
+        }
+      }
+    });
 
-    assert.equal(this.$().text().trim(), '');
+    await render(hbs`{{paper-toaster paperToaster=paperToaster}}`);
 
-    // Template block usage:
-    await render(hbs`
-      {{#paper-toaster}}
-        template block text
-      {{/paper-toaster}}
-    `);
+    assert.dom('md-toast .md-button').hasText('label');
 
-    assert.equal(this.$().text().trim(), 'template block text');
+    await click('md-toast .md-button');
+  });
+
+  test('it shows a primary action', async function(assert) {
+    this.set('paperToaster.activeToast', {
+      show: true,
+      position: 'bottom left',
+      duration: 500,
+      action: {
+        label: 'label',
+        primary: true,
+        onClick: () => {}
+      }
+    });
+
+    await render(hbs`{{paper-toaster paperToaster=paperToaster}}`);
+
+    assert.dom('md-toast .md-button').hasClass('md-primary');
+  });
+
+  test('it shows a accent action', async function(assert) {
+    this.set('paperToaster.activeToast', {
+      show: true,
+      position: 'bottom left',
+      duration: 500,
+      action: {
+        label: 'label',
+        accent: true,
+        onClick: () => {}
+      }
+    });
+
+    await render(hbs`{{paper-toaster paperToaster=paperToaster}}`);
+
+    assert.dom('md-toast .md-button').hasClass('md-accent');
+  });
+
+  test('it shows a warn action', async function(assert) {
+    this.set('paperToaster.activeToast', {
+      show: true,
+      position: 'bottom left',
+      duration: 500,
+      action: {
+        label: 'label',
+        warn: true,
+        onClick: () => {}
+      }
+    });
+
+    await render(hbs`{{paper-toaster paperToaster=paperToaster}}`);
+
+    assert.dom('md-toast .md-button').hasClass('md-warn');
   });
 });


### PR DESCRIPTION
In the angular implementation, they allow you to customize the button by using a ["highlightClass"](https://github.com/angular/material/blob/v1.1.4/src/components/toast/toast.js#L174):

> If set, the given class will be applied to the highlighted action button.<br/>
> This allows you to specify the highlight color easily. Highlight classes are `md-primary`, `md-warn`  and `md-accent