### PR TITLE
Make externally provided errors work with paper-autocomplete

### DIFF
--- a/addon/templates/components/paper-autocomplete-trigger.hbs
+++ b/addon/templates/components/paper-autocomplete-trigger.hbs
@@ -3,6 +3,7 @@
     label=extra.label
     value=text
     flex=true
+    isTouched=(readonly isTouched)
     required=(readonly required)
     passThru=(readonly passThru)
     validationErrorMessages=(readonly validationErrorMessages)

--- a/addon/templates/components/paper-autocomplete.hbs
+++ b/addon/templates/components/paper-autocomplete.hbs
@@ -38,6 +38,7 @@
       disabled=disabled
       buildSelection=(readonly buildSelection)
       extra=(readonly extra)
+      isTouched=(readonly isTouched)
       listboxId=(readonly optionsId)
       onFocus=(action "onFocus")
       activate=(action "activate")


### PR DESCRIPTION
Pass isTouched from paper-autocomplete to paper-autocomplete-trigger
and its inner paper-input.

External errors are not otherwise rendered because isTouched is always false on the inner `paper-input` component.