### PR TITLE
add links to hosted v0.2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You can find out more information on the CSP addon page [here](https://github.co
 
 Version 0.2 is a good choice if you need to use `ember-paper` now in your application, and you have tested the components you use and confirmed that they work to your satisfaction. If you encounter bugs, you'll likely need to fix them yourself, as the `ember-paper` team is focused on completing version 1.0. When version 1.0 is released, you will need to adapt to the the API changes as part of your update.
 
+Version 0.2 documentation can be found [here](https://forge512.github.io/ember-paper/).
+
 **1.0** All new development work is focused on the master branch, which will be released as version 1.0.0. This version uses the Angular Material style sheets, which are imported and processed automatically during the build process. This allows `ember-paper` to have excellent fidelity with regard to the Angular version.
 
 The master branch contains significant API changes relative to version 0.2 and earlier. Modern Ember coding style and naming conventions are used. These changes are detailed in the [change log](CHANGELOG.md).

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -51,6 +51,12 @@
     </dd>
   </dl>
 
+  <h2 class="md-headline">Documentation for Previous Versions</h2>
+  <p>Documentation for previous versions can be found here:</p>
+  <ul>
+    <li><a href="https://forge512.github.io/ember-paper/">Version 0.2</a></li>
+  </ul>
+
   <h2 class="md-headline">Contribution</h2>
   <p>This is a very ambitious project. Google's design specs are extensive, and non-trivial to implement. If you can port or fix a component or two, please drop a pull request or issue on GitHub or join us on slack. See README.md for more resources.</p>
   <p>With everyone's help, we can bring this amazing design spec to Ember in a modular and elegant way. The Ember way.</p>


### PR DESCRIPTION
Version 0.2 documentation is being hosted by [Forge 512](https://forge512.com/) via github.io.  See [docs](https://forge512.github.io/ember-paper/).  This PR adds a link to the README and the index page of the dummy app.

A snapshot of the dummy app addition is below.  My thought was this leaves space to add links to other versions as needed.

![screen shot 2017-09-01 at 6 13 43 am](https://user-images.githubusercontent.com/1022582/29967570-de6589b0-8edc-11e7-965a-ce17b6d6aa84.png)

