### PR TITLE
Fix typo in speed-dial demo

### DIFF
--- a/tests/dummy/app/templates/demo/speed-dial.hbs
+++ b/tests/dummy/app/templates/demo/speed-dial.hbs
@@ -93,7 +93,7 @@
           <code>right</code> through the <code>direction</code> attribute. Default value is <code>down</code>.
         </p>
         <p>
-          There are also two available animations. Specify <code>sling</code> or <code>scale</code> strings
+          There are also two available animations. Specify <code>fling</code> or <code>scale</code> strings
           through the <code>animation</code> attribute. Default value is <code>fling</code>.
         </p>
         <p>


### PR DESCRIPTION
`sling` should read `fling`