### PR TITLE
fixed https://github.com/miguelcobain/ember-paper/issues/642 by clear…

### DIFF
--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -64,6 +64,10 @@ export default Component.extend({
 
     if (oldSelect && oldSelect.isOpen && !select.isOpen && !loading && searchText) {
       this.set('text', this.getSelectedAsText());
+    } else if (oldSelect && select && oldSelect.selected && !select.selected) {
+
+      // the selection has been cleared.  We need clear the text property, unsets cached key press values in _innerText
+      this.set('text', '');
     }
 
     if (lastSearchedText !== oldLastSearchedText) {

--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -66,7 +66,7 @@ export default Component.extend({
       this.set('text', this.getSelectedAsText());
     } else if (oldSelect && select && oldSelect.selected && !select.selected) {
 
-      // the selection has been cleared.  We need clear the text property, unsets cached key press values in _innerText
+      // the selection has been cleared.  We need to clear the text property and unset cached key press values in _innerText
       this.set('text', '');
     }
 

--- a/tests/integration/components/paper-autocomplete-test.js
+++ b/tests/integration/components/paper-autocomplete-test.js
@@ -271,3 +271,38 @@ test('we can highlight search results for properties that aren\'t text', functio
     assert.equal(this.get('selectedItem'), undefined, 'selectedItem is undefined');
   });
 });
+
+test('clears when selected and searchText are falsey', function(assert) {
+  assert.expect(2);
+  this.appRoot = document.querySelector('#ember-testing');
+  this.set('items', ['Ember', 'Paper', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten', 'Eleven', 'Twelve']);
+  this.set('selectedItem', 'One');
+  this.set('searchText', 'One');
+  this.render(hbs`{{#paper-autocomplete
+    placeholder="Item"
+    options=items
+    searchText=searchText
+    onSearchTextChange=(action (mut searchText))
+    selected=selectedItem
+    onSelectionChange=(action (mut selectedItem))
+    as |item|
+  }}
+    {{item}}
+  {{/paper-autocomplete}}`);
+
+  return wait().then(() => {
+    $('md-autocomplete-wrap input').val('One');
+    $('md-autocomplete-wrap input').change();
+
+    let $initialSelector = $($('.ember-paper-autocomplete-search-input').get(0));
+    assert.equal($initialSelector.val(), 'One');
+
+    this.set('selectedItem', null);
+    this.set('searchText', null);
+
+    return wait().then(() => {
+      let $selector = $($('.ember-paper-autocomplete-search-input').get(0));
+      assert.equal($selector.val(), '');
+    });
+  });
+});


### PR DESCRIPTION
I wrote a test to reproduce https://github.com/miguelcobain/ember-paper/issues/642, then fixed it.

What was happening was: each time a key is pressed, it provides the value of the select to "v" in the setter of text (which will set _innerText) within paper-autocomplete-trigger.  When selected and searchText are set to something falsey, it still returns _innerText, the result of the key-presses:

```
text: computed('selected', 'searchText', '_innerText', {
    get() {
      let {
        selected,
        searchText,
        _innerText
      } = this.getProperties('selected', 'searchText', '_innerText');

      if (selected) {
        return this.getSelectedAsText();
      }
      return searchText ? searchText : _innerText;
    },
    set(_, v) {
      let { selected, searchText } = this.getProperties('selected', 'searchText');
      this.set('_innerText', v);

      // searchText should always win
      if (!selected && isPresent(searchText)) {
        return searchText;
      }

      return v;
    }
  }),
```