### PR TITLE
Fix routable tabs example

### DIFF
--- a/tests/dummy/app/controllers/demo/tabs.js
+++ b/tests/dummy/app/controllers/demo/tabs.js
@@ -15,7 +15,7 @@ export default Controller.extend({
 
   router: inject.service(),
 
-  currentRouteName: computed.reads('router.currentRouteName'),
+  currentRouteName: computed.readOnly('router.currentRouteName'),
 
   chapters: computed(function() {
     let tabs = A();
@@ -60,6 +60,8 @@ export default Controller.extend({
         this.set('selectedChapter', newSelection);
       }
       this.get('chapters').removeObject(t);
-    }
+    },
+
+    noop() {}
   }
 });

--- a/tests/dummy/app/templates/demo/tabs.hbs
+++ b/tests/dummy/app/templates/demo/tabs.hbs
@@ -197,7 +197,7 @@
       <div class="doc-content-example">
         {{#paper-content}}
           {{! BEGIN-SNIPPET routable-usage}}
-          {{#paper-tabs selected=currentRouteName borderBottom=true as |tabs|}}
+          {{#paper-tabs selected=currentRouteName borderBottom=true onChange=(action "noop") as |tabs|}}
             {{#tabs.tab value="demo.tabs.index" href=(href-to "demo.tabs.index")}}
               Index
             {{/tabs.tab}}
@@ -228,8 +228,8 @@
           </em>
         </p>
         <p>
-          <b>Hint:</b> use <code>ember-router-service-polyfill</code> addon to easily retrieve
-          the current route name, and passes it as the selected value to <code>paper-tabs</code>.
+          <b>Hint:</b>for Ember versions less than 2.15, use the <code>ember-router-service-polyfill</code> addon to easily retrieve
+          the current route name and use it as the selected value to <code>paper-tabs</code>.
         </p>
       {{/paper-card-content}}
     {{/paper-card}}


### PR DESCRIPTION
The example for routable tabs is not updating the `selected` property correctly. Steps to reproduce:

1) While on the tabs page, click `Nested Route`
2) Navigate away from the tabs page by clicking one of the other links in the sidebar
3) Navigate back to the tabs page by clicking the tabs link in the sidebar
4) `Nested Route` will still be highlighted even though you are on `demo.tabs.index`

This is happening because the `currentRouteName` on the controller is diverging from the routerService's `currentRouteName`. Making the `currentRouteName` property `readOnly` on the controller fixes the issue.