### PR TITLE
resolve swipe name conflict

### DIFF
--- a/addon/components/paper-toast.js
+++ b/addon/components/paper-toast.js
@@ -104,7 +104,7 @@ export default Component.extend({
     $(`#${this.get('destinationId')}`).removeClass(`md-toast-open-${y} md-toast-animating`);
   },
 
-  swipe()  {
+  swipeAction()  {
     if (this.get('swipeToClose')) {
       this.sendAction('onClose');
     }

--- a/addon/templates/components/paper-toast.hbs
+++ b/addon/templates/components/paper-toast.hbs
@@ -1,5 +1,5 @@
 {{#ember-wormhole to=destinationId}}
-  {{#paper-toast-inner swipe=swipe swipeToClose=swipeToClose onClose=onClose top=top left=left capsule=capsule class=class}}
+  {{#paper-toast-inner swipe=swipeAction swipeToClose=swipeToClose onClose=onClose top=top left=left capsule=capsule class=class}}
     {{yield (hash
       text=(component "paper-toast-text")
     )}}


### PR DESCRIPTION
Having a function that is named after an event on a tagless component is an error in glimmer. The paper-toast component has a method named `swipe`. Normally this isn't a problem because `swipe` is an official event registered with the event dispatcher. But when using `ember-gestures` there is a `swipe` event, making it impossible to use `paper-toast`. However, here, the tagless component has a method `swipe` out of coincidence. By renaming this method we solve the problem. This fixes issue #853. 