### PR TITLE
Use native passive event listeners for ripple and tooltip

### DIFF
--- a/addon/components/paper-tooltip.js
+++ b/addon/components/paper-tooltip.js
@@ -80,7 +80,9 @@ export default Component.extend({
     };
 
     anchorElement.addEventListener('focus', enterEventHandler);
-    anchorElement.addEventListener('touchstart', enterEventHandler);
+    anchorElement.addEventListener('touchstart', enterEventHandler, {
+      passive: true
+    });
     anchorElement.addEventListener('mouseenter', enterEventHandler);
 
     window.addEventListener('scroll', leaveHandler);

--- a/addon/mixins/ripple-mixin.js
+++ b/addon/mixins/ripple-mixin.js
@@ -126,10 +126,12 @@ export default Mixin.create({
 
   },
   bindEvents() {
-    this.rippleElement.on('mousedown', run.bind(this, this.handleMousedown));
-    this.rippleElement.on('mouseup touchend', run.bind(this, this.handleMouseup));
-    this.rippleElement.on('mouseleave', run.bind(this, this.handleMouseup));
-    this.rippleElement.on('touchmove', run.bind(this, this.handleTouchmove));
+    this.rippleElement[0].addEventListener('mousedown', run.bind(this, this.handleMousedown));
+    this.rippleElement[0].addEventListener('mouseup touchend', run.bind(this, this.handleMouseup));
+    this.rippleElement[0].addEventListener('mouseleave', run.bind(this, this.handleMouseup));
+    this.rippleElement[0].addEventListener('touchmove', run.bind(this, this.handleTouchmove), {
+      passive: true
+    });
   },
   handleMousedown(event) {
     if (this.mousedown) {


### PR DESCRIPTION
To do: 
* Replace remaining jquery `on` / `off` with `addEventListener` / `removeEventListener`.
* Use `passive: true` where possible. (Anywhere where the handler does not call `preventDefault`)
* ~~Ripple mixin needs `unbindEvents`~~
  _Unnecessary as listeners are removed when element is destroyed in browsers newer than ie 7_

These two uses of `passive: true` remove 200 scroll-blocking violations in the test suite.

Related: https://github.com/miguelcobain/ember-paper/issues/843