### PR TITLE
Add checks to prevent calling methods on destroyed objects

### DIFF
--- a/addon/components/paper-input.js
+++ b/addon/components/paper-input.js
@@ -153,6 +153,9 @@ export default Component.extend(FocusableMixin, ColorMixin, ChildMixin, Validati
         }
         this.setValue(this.get('value'));
       });
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
       this.growTextarea();
       let inputElement = this.$('input').get(0);
       this.set('isNativeInvalid', inputElement && inputElement.validity && inputElement.validity.badInput);

--- a/addon/components/paper-menu-content-inner.js
+++ b/addon/components/paper-menu-content-inner.js
@@ -25,6 +25,9 @@ export default Component.extend(ParentMixin, {
 
   didInsertElement() {
     run.later(() => {
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
       let focusTarget = this.$().find('.md-menu-focus-target');
       if (!focusTarget.length) {
         focusTarget = this.get('enabledMenuItems.firstObject.element.firstElementChild');

--- a/addon/components/paper-select-content.js
+++ b/addon/components/paper-select-content.js
@@ -36,6 +36,9 @@ export default PaperMenuContent.extend({
   animateIn() {
     run.next(() => {
       run.scheduleOnce('afterRender', this, () => {
+        if (this.isDestroyed || this.isDestroying) {
+          return;
+        }
         let dropdown = this.get('dropdown');
         dropdown.actions.reposition();
         this.set('isActive', true);

--- a/addon/components/paper-slider.js
+++ b/addon/components/paper-slider.js
@@ -162,7 +162,7 @@ export default Component.extend(FocusableMixin, ColorMixin, {
   },
 
   drag(event) {
-    if (this.get('disabled') || !this.get('dragging')) {
+    if (this.get('disabled') || !this.get('dragging') || !event.center) {
       return;
     }
 

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -109,6 +109,9 @@ export default Mixin.create({
 
     if (originator) {
       originator = $(originator).get(0);
+    }
+
+    if (originator) {
       let originBnds = this.copyRect(originator.getBoundingClientRect());
       let dialogRect = this.copyRect(element.getBoundingClientRect());
       let dialogCenterPt = this.centerPointFor(dialogRect);


### PR DESCRIPTION
They are unfortunately no tests provided because this is kind of hard to test :/

They all come from errors reported into my app's [sentry](https://sentry.io).

- `Cannot read property 'style' of null`
> this.dropdownElement.style.transform = '';

- `undefined is not an object (evaluating 't.getBoundingClientRect')`
> var originBnds = this.copyRect(originator.getBoundingClientRect());

- `Cannot read property 'x' of undefined`
> this.setValueFromEvent(event.center.x);

- `Cannot read property 'get' of undefined`
> var inputElement = this.$('input').get(0);

This one since it comes from Hammer I don't know if it's a bug upstream or not I'm not familiar with Hammer at all.

- `Cannot read property 'find' of undefined`
> var focusTarget = this.$().find('.md-menu-focus-target');

