### PR TITLE
Add "autofocus" to autocomplete-trigger input

### DIFF
--- a/addon/templates/components/paper-autocomplete-trigger.hbs
+++ b/addon/templates/components/paper-autocomplete-trigger.hbs
@@ -26,6 +26,7 @@
     disabled={{readonly disabled}}
     onmousedown={{action "stopPropagation"}}
     accept={{passThru.accept}}
+    autofocus={{passThru.autofocus}}
     autocomplete={{passThru.autocomplete}}
     autosave={{passThru.autosave}}
     form={{passThru.form}}


### PR DESCRIPTION
Add autofocus flag to passThru hash to enable autofocus of autocomplete-trigger input