### PR TITLE
Add rel to paper-button attribute bindings

### DIFF
--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -34,7 +34,8 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, Proxiab
     'href',
     'target',
     'title',
-    'download'
+    'download',
+    'rel'
   ],
   classNameBindings: [
     'raised:md-raised',


### PR DESCRIPTION
If using `{{#paper-button href="..." target="_blank"}}` we need to pass through `rel="noopener noreferrer"` too.

https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/