### PR TITLE
fix(paper-autocomplete): content positioning when body is relatively positioned

### DIFF
--- a/addon/utils/calculate-ac-position.js
+++ b/addon/utils/calculate-ac-position.js
@@ -90,6 +90,16 @@ export function calculateWormholedPosition(trigger, content, destination, { hori
 
   // Calculate vertical position
   let triggerTopWithScroll = triggerTop + scroll.top;
+
+  /**
+   * Fixes bug where the dropdown always stays on the same position on the screen when
+   * the <body> is relatively positioned
+   */
+  let isBodyPositionRelative = window.getComputedStyle(document.body).getPropertyValue('position') === 'relative';
+  if (!isBodyPositionRelative) {
+    triggerTopWithScroll += scroll.top;
+  }
+
   if (verticalPosition === 'above') {
     style.top = triggerTopWithScroll - dropdownHeight;
   } else if (verticalPosition === 'below') {


### PR DESCRIPTION
May fix #851 

I had a similar issue with `paper-autocomplete` that simply made it unusable on mobile device because the dropdown menu where hidden behind the keyboard and if you scroll the menu would just continue moving down out of reach.

Looking at the code I saw the following differences in `calculate-ac-position` with the most recent power select.

Since the base styles apply `position:relative;` on the body I gave it a try and it fixed my issue.

