### PR TITLE
Removed null value for defaultHighlighted

### DIFF
--- a/addon/components/paper-autocomplete.js
+++ b/addon/components/paper-autocomplete.js
@@ -33,7 +33,6 @@ export default PowerSelect.extend(ValidationMixin, ChildMixin, {
   onchange: null,
   oninput: null,
   searchText: '',
-  defaultHighlighted: null, // Don't automatically highlight any option
   _onChangeNop() { },
 
   extra: computed('labelPath', 'label', function() {


### PR DESCRIPTION
This property currently prevents the user from allowing a default highlight to occur as it does in power-select. By Removing this declaration a user can now pass in a value for `defaultHighlighted` on the component declaration.