### PR TITLE
Ember-css-transition upgrade broke sidenav

### DIFF
--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -29,7 +29,7 @@ export default Component.extend(TransitionMixin, {
   }),
 
   addDestroyedElementClone(original, clone) {
-    original.parent().append(clone);
+    original.parentNode.appendChild(clone);
   },
 
   sendClickAction(e) {


### PR DESCRIPTION
The 0.1.11v of ember-css-transitions seems to have removed it dependency on jquery, which also means the code below isn't working anymore (due to `parent()` being a jquery API)

This PR should fix it.