### PR TITLE
[iOS] "clickOutsideToClose=true" should work correctly in a paper-dialog

### DIFF
--- a/addon/components/paper-dialog-container.js
+++ b/addon/components/paper-dialog-container.js
@@ -10,15 +10,33 @@ import Component from '@ember/component';
 export default Component.extend({
   classNames: ['md-dialog-container'],
 
-  mouseDown(ev) {
-    this._sourceEl = ev.target;
-  },
-
-  mouseUp(ev) {
+  onMouseUp(ev) {
     if (this._sourceEl === this.element && ev.target === this.element) {
       ev.stopPropagation();
       ev.preventDefault();
       this.sendAction('outsideClicked');
     }
+  },
+
+  onMouseDown(ev) {
+    this._sourceEl = ev.target;
+  },
+
+  mouseDown(ev) {
+    this.onMouseDown(ev);
+  },
+
+  mouseUp(ev) {
+    this.onMouseUp(ev);
+  },
+
+  // needed for iOS
+  touchStart(ev) {
+    this.onMouseDown(ev);
+  },
+
+  // needed for iOS
+  touchEnd(ev) {
+    this.onMouseUp(ev);
   }
 });


### PR DESCRIPTION
This is a fix for an iOS-only bug that prevented the paper-dialog from closing due to differences in "touch" event handling.