### PR TITLE
render md-select-header outside of md-content

### DIFF
--- a/addon/components/paper-select-options.js
+++ b/addon/components/paper-select-options.js
@@ -9,8 +9,6 @@ export default PowerOptions.extend({
     if (this.get('role') === 'group') {
       this.set('tagName', '');
       this.set('attributeBindings', undefined);
-    } else if (this.get('searchEnabled')) {
-      this.set('tagName', 'md-optgroup');
     }
     this._super(...arguments);
   },

--- a/addon/templates/components/paper-select-menu-inner.hbs
+++ b/addon/templates/components/paper-select-menu-inner.hbs
@@ -1,7 +1,1 @@
-{{#if searchEnabled}}
-	<md-content>
-		{{yield (hash menu=this)}}
-	</md-content>
-{{else}}
-	{{yield (hash menu=this)}}
-{{/if}}
+{{yield (hash menu=this)}}

--- a/tests/integration/components/paper-select-test.js
+++ b/tests/integration/components/paper-select-test.js
@@ -110,3 +110,53 @@ test('backdrop removed if select closed', function(assert) {
     });
   });
 });
+
+test('header is rendered above content', async function(assert) {
+  this.set('sizes', ['small (12-inch)', 'medium (14-inch)', 'large (16-inch)', 'insane (42-inch)']);
+
+  this.render(hbs`{{#paper-select
+    disabled=disableSelect
+    placeholder="Size"
+    options=sizes
+    searchEnabled=true
+    selected=selectedSize
+    onChange=(action (mut selectedSize))
+    as |size|
+  }}
+    {{size}}
+  {{/paper-select}}`);
+
+  await wait();
+
+  await clickTrigger();
+
+  assert.ok(!!$('md-select-menu > md-select-header'), 'header is a direct child of menu');
+  assert.ok(!!$('md-select-menu > md-content'), 'content is a direct child of menu');
+});
+
+test('it can search a value', async function(assert) {
+  this.set('sizes', ['small (12-inch)', 'medium (14-inch)', 'large (16-inch)', 'insane (42-inch)']);
+
+  this.render(hbs`{{#paper-select
+    disabled=disableSelect
+    placeholder="Size"
+    options=sizes
+    searchEnabled=true
+    selected=selectedSize
+    onChange=(action (mut selectedSize))
+    as |size|
+  }}
+    {{size}}
+  {{/paper-select}}`);
+
+  await clickTrigger();
+
+  await wait();
+
+  assert.equal($('md-select-menu md-option').length, 4);
+
+  $('md-select-header input').val('small').trigger('input');
+
+  assert.equal($('md-select-menu md-option').length, 1);
+  assert.equal($('md-select-menu md-option').text().trim(), 'small (12-inch)');
+});

--- a/tests/integration/components/paper-select-test.js
+++ b/tests/integration/components/paper-select-test.js
@@ -157,6 +157,8 @@ test('it can search a value', async function(assert) {
 
   $('md-select-header input').val('small').trigger('input');
 
+  await wait();
+
   assert.equal($('md-select-menu md-option').length, 1);
   assert.equal($('md-select-menu md-option').text().trim(), 'small (12-inch)');
 });


### PR DESCRIPTION
Not sure why it was done this way to begin with, but rendering `md-select-header` outside of `md-content` make it sticky to the top which is a huge usability improvement.

Closes #938 
