### PR TITLE
Add workaround for Sass syntax error

### DIFF
--- a/app/styles/color-palette.scss
+++ b/app/styles/color-palette.scss
@@ -496,6 +496,10 @@ $default-color: '500' !default;
     $curr_color: $color;
   }
 
+  @if type-of($curr_color) != 'map' {
+    @return $curr_color;
+  }
+
   // if no type was provided:
   //   - use 'default' key if present
   //   - use '500' from $default-color
@@ -519,6 +523,10 @@ $default-color: '500' !default;
   } @else {
     // color is a map
     $curr_color: $color;
+  }
+
+  @if type-of($curr_color) != 'map' {
+    @return $curr_color;
   }
 
   // if no type was provided:


### PR DESCRIPTION
See #918 for context. Note that this PR is a workaround only. I do not know how much breakage it will cause if it is merged. On the other hand, ember-paper doesn't build or run _at all_ without this patch, so we can't get any worse than that, right? 😄