### PR TITLE
Don't show progress-circular when it's value is 0

### DIFF
--- a/addon/components/paper-progress-circular.js
+++ b/addon/components/paper-progress-circular.js
@@ -69,6 +69,10 @@ export default Component.extend(ColorMixin, {
     return isPresent(value) ? MODE_DETERMINATE : MODE_INDETERMINATE;
   }),
 
+  isHidden: computed('value', function() {
+    return this.get('value') == 0 ? 'hidden' : 'visible';
+  }),
+
   spinnerClass: computed('mode', function() {
     let mode = this.get('mode');
     return mode === MODE_DETERMINATE || mode === MODE_INDETERMINATE ? `md-mode-${mode}` : 'ng-hide';

--- a/addon/templates/components/paper-progress-circular.hbs
+++ b/addon/templates/components/paper-progress-circular.hbs
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {{diameter}} {{diameter}}" style={{svgStyle}}>
-  <path fill="none" style={{pathStyle}} stroke-dasharray={{strokeDasharray}} d={{d}}></path>
+  <path fill="none" style={{pathStyle}} stroke-dasharray={{strokeDasharray}} d={{d}} visibility={{isHidden}}></path>
 </svg>

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "matchmedia-polyfill": "^0.3.0",
     "propagating-hammerjs": "^1.4.6",
     "resolve": "^1.3.3",
-    "virtual-each": "~0.6.0"
+    "virtual-each": "https://github.com/BobrImperator/virtual-each"
   },
   "keywords": [
     "ember-addon",

--- a/tests/integration/components/paper-progress-circular-test.js
+++ b/tests/integration/components/paper-progress-circular-test.js
@@ -43,4 +43,15 @@ module('Integration | Component | paper progress circular', function(hooks) {
     assert.ok(parseFloat($svgPath.attr('stroke-dashoffset')), 'stroke-dashoffset has a number');
     assert.ok(parseFloat($svgPath.attr('stroke-dasharray')), 'stroke-dasharray has a number');
   });
+
+  test('is hidden when value is 0', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{paper-progress-circular value=0 diameter=25}}`);
+    await settled();
+
+    let $svgPath = this.$('md-progress-circular path');
+
+    assert.equal($svgPath.attr('visibility'), 'hidden', 'is hidden when value is 0');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2734,9 +2734,9 @@ ember-cp-validations@^4.0.0-beta.0:
     ember-require-module "^0.2.0"
     ember-validators "^1.1.1"
 
-ember-css-transitions@^0.1.14:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/ember-css-transitions/-/ember-css-transitions-0.1.14.tgz#85cbaad976bd8b5b4d88f2b4d517c00dc97455e4"
+ember-css-transitions@^0.1.15:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ember-css-transitions/-/ember-css-transitions-0.1.15.tgz#2a5b5fbba72092444edfe7fec315bb685250491d"
   dependencies:
     ember-cli-babel "^6.6.0"
 
@@ -7792,9 +7792,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-virtual-each@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/virtual-each/-/virtual-each-0.6.0.tgz#fa07ee1a387f1c6c23da74d347fd6b998c807905"
+"virtual-each@https://github.com/BobrImperator/virtual-each":
+  version "0.6.1"
+  resolved "https://github.com/BobrImperator/virtual-each#ce8fc7162093742580f9a42e4d7bb63f7ea54e35"
   dependencies:
     ember-cli-babel "^6.12.0"
     ember-cli-htmlbars "^2.0.3"


### PR DESCRIPTION
## Why
Right now when it's value is 0 it spins in ``indeterminate`` mode.
I believe it's not desired behaviour, it should only do so when it's value is ``null``.
also Why just not show it at all? Because in case of having an image inside the progress-circular, the image wouldn't show, that's why my PR sets it to invisibility.

If you have better ways to solve it, tell me, I'll gladly adjust it :1st_place_medal: 