### PR TITLE
Paper-button touch UX enhancement

### DIFF
--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -9,6 +9,7 @@ import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import RippleMixin from 'ember-paper/mixins/ripple-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
+import TouchableMixin from 'ember-paper/mixins/touchable-mixin';
 
 /**
  * @class PaperButton
@@ -18,7 +19,7 @@ import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';
  * @uses ColorMixin
  * @uses ProxiableMixin
  */
-export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, {
+export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, ProxiableMixin, TouchableMixin, {
   layout,
   tagName: 'button',
   classNames: ['md-default-theme', 'md-button'],
@@ -29,6 +30,8 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, Proxiab
   type: 'button',
   href: null,
   target: null,
+  timesClicked: 0,
+
   attributeBindings: [
     'type',
     'href',

--- a/addon/mixins/touchable-mixin.js
+++ b/addon/mixins/touchable-mixin.js
@@ -1,0 +1,123 @@
+import Mixin from '@ember/object/mixin';
+import { get, set } from '@ember/object';
+
+export default Mixin.create({
+
+  useCapture: true,
+  draggedOut: false,
+  touchable: false,
+
+  didInsertElement(){
+
+    this._super(...arguments);
+
+    if(typeof FastBoot === 'undefined' && get(this, 'touchable')){
+
+      const options = {
+        capture: get(this, 'useCapture'),
+        passive: false
+      };
+
+      this._touchStart = function() {
+        this.element.addEventListener('touchmove', get(this, 'didTouchMove').bind(this), {capture: true, passive: true});
+      }.bind(this);
+
+      this.element.addEventListener('touchstart', this._touchStart);
+
+      this.element.addEventListener('touchend', get(this, 'didTouchEnd').bind(this), options);
+
+    }
+
+  },
+
+  /*
+  * Check on touchmove if the first placed finger is still inside this.element area
+  * */
+  didTouchMove(e){
+
+    //this.element
+    let elemRect = this.element.getBoundingClientRect();
+    let { x, y, width: w, height: h } = elemRect;
+    let xPlusWidth = x + w;
+    let yPlusHeight = y + h;
+
+    //event gesture
+
+    let { pageX, pageY } = e.changedTouches[0];
+
+    // console.log(
+    //   `
+    //    BOUNDING RECT \n
+    //    x: ${x}\n
+    //    y: ${y}\n
+    //    w: ${w}\n
+    //    h: ${h}\n
+    //
+    //    PLUS\n
+    //    xPlusWidth: ${xPlusWidth}\n
+    //    yPlusHeight: ${yPlusHeight}\n
+    //
+    //    TOUCHES\n
+    //    pageX: ${pageX}\n
+    //    pageY: ${pageY}\n
+    //
+    //   `
+    // );
+
+    //if its already dragged out, ignore
+    if(!get(this, 'draggedOut')){
+      //Verify if the current touch finger is outside the clientRect
+      if( !(pageX >= x && pageX <= xPlusWidth && pageY >= y && pageY <= yPlusHeight) ){
+        set(this, 'draggedOut', true);
+      }
+    }
+
+  },
+
+  /*
+  * Verify if the user didn't 'draggedOut' the first placed finger, if so...
+  * Stop by all means the event bubbling to avoid ghost clicks
+  * and trigger an instantaneous click on the element (to prevent waiting for the default 300ms)
+  * */
+  didTouchEnd(e){
+
+    this.element.removeEventListener('touchmove', get(this, 'didTouchMove').bind(this));
+
+    e.cancelBubble = true;
+    e.returnValue = false;
+
+    e.preventDefault();
+
+    //e.stopPropagation works only in Firefox.
+    if (e.stopPropagation) {
+      e.stopPropagation();
+    }
+
+    //If no exit
+    if(!get(this, 'draggedOut')){
+      this.element.click();
+    }
+
+    if(!this.isDestroyed) {
+      set(this, 'draggedOut', false);
+    }
+
+    return false;
+
+  },
+
+  /*
+  * Tear down event listeners
+  * */
+  willDestroyElement(){
+
+    this._super(...arguments);
+
+    this.element.removeEventListener('touchmove', get(this, 'didTouchMove').bind(this));
+    this.element.removeEventListener('touchstart', this._touchStart);
+    this.element.removeEventListener('touchend', get(this, 'didTouchEnd').bind(this));
+
+  },
+
+
+});

--- a/tests/integration/components/paper-button-test.js
+++ b/tests/integration/components/paper-button-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | paper button', function(hooks) {
@@ -60,6 +60,51 @@ module('Integration | Component | paper button', function(hooks) {
         A label
       {{/paper-button}}
     `);
+    assert.ok(this.$('.md-button').hasClass('md-raised'));
+  });
+
+  test('triggers onClick function if attribute touchable is true and touchend event is fired', async function(assert) {
+
+    assert.expect(1);
+
+    this.set('foo', () => {
+      assert.ok(true);
+    });
+
+    await this.render(hbs`
+      {{#paper-button onClick=foo touchable=true}}
+        A label
+      {{/paper-button}}
+    `);
+
+    await triggerEvent('.md-button', 'touchend');
+
+  });
+
+  test('does nothing onClick if attribute touchable is false and touchend event is fired', async function(assert) {
+
+    assert.expect(0);
+
+    this.set('foo', () => {
+      assert.ok(true);
+    });
+
+    await this.render(hbs`
+      {{#paper-button onClick=foo touchable=false}}
+        A label
+      {{/paper-button}}
+    `);
+
+    await triggerEvent('.md-button', 'touchend');
+
+  });
+
+  test('uses md-raised class when raised=true', function(assert) {
+    this.render(hbs`
+    {{#paper-button raised=true}}
+      A label
+    {{/paper-button}}
+  `);
     assert.ok(this.$('.md-button').hasClass('md-raised'));
   });
 


### PR DESCRIPTION
I've been using this mixin in a few projects that I've been working on, mostly Ember PWAs and Ember Cordova apps.

¿Why? 

Current behaivor only support clicks. In most mobile browsers without the correct meta tag

`<meta name="viewport" content="width=device-width, initial-scale=1  user-scalable=no">`

clicks get delayed by 300ms, while it's functional its not a good UX for mobile first apps or even worst, for Cordova Ember apps. And there is also the ghost clicks issue which may cause terrible effects.

So looking for solutions I found `ember-gestures`, `hammer.js` and `ember-fastclick`

`ember-gestures`: added a dependency to my project, so no. 

`hammer.js`: was already a dependency of ember-paper, so I went that road in my first attempts. I stumbled with some issues with tap events, mostly css (touch area was dramatically reduced, alot of css workarounds) and ghost clicks issues and the dead-lines were coming, so I dropped my attempts it was just too much involved.

`ember-fastclick`: correctly solves the 300ms delay in all clicks in the dom.

But... Then my requirement changed, I had to mimick as much as possible the native experience in all the buttons and clickable list items, when the user holds down a finger or "long presses" a button for a few moments (even seconds if moving the finger around), when they release, the onClick action must be called if and only if **The user didn't leave at any moment the first placed finger out of the button/list-item while pressing/holding.** so they can move the finger around the button/list-item area freely, release and still get the expected action to be triggered (try pressing the gmail app create mail button and you will discover what I mean). 

So this wasn't possible with fastclick because I had to track touchstart, touchmove and touchend.

So I made this mixin, ¿why a mixin?, because I use it in some other components, for example, I made a touchable-component which receives a tagName and implements the mixin, so the idea is to make it more mobile friendly via the mixin.

Here is a quick demo [questionable-fog.surge.sh](url) 
Try this scenarios in a mobile browser:
1. "Long press" both, you will notice only one button will get the number incremented.
2. Press and move the finger inside the button area, you will notice when you release the finger, one button will still increment the counter. 
3. Press and drag your finger out, then release, none will increment.

Drawbacks: since I wanted to avoid ghostclicks or calling onClick twice I prevent the event from bubbling and preventDefault, manually calling an instant click, this could be an issue if a parent component is waiting for the event, that's why this behaivor is only added with touchable=true, to be 100% sure, also I'm truly open for other ways to do it.

I would like to get a review mostly to check if the ripple mixin is working correclty or some changes has to be done.

I added a few tests but I'm not that experienced in testing.

Anyway, I thought someone else might benefit, so here is it.
