### PR TITLE
Paper-tabs Assertion Failed: You modified canPageBack twice in a single render

### DIFF
--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -7,7 +7,6 @@ import layout from '../templates/components/paper-tabs';
 import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import { invokeAction } from 'ember-invoke-action';
-import { scheduleOnce } from '@ember/runloop';
 
 export default Component.extend(ParentMixin, ColorMixin, {
   layout,
@@ -20,12 +19,13 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
   selected: 0, // select first tab by default
 
-  _selectedTab: computed('childComponents.@each.isSelected', function() {
-    return this.get('childComponents').findBy('isSelected');
+  _selectedTab: computed('selected', function() {
+    return this.get('childComponents').findBy('value', this.get('selected'));
   }),
 
   _selectedTabDidChange: observer('_selectedTab', function() {
     let selectedTab = this.get('_selectedTab');
+    
     let previousSelectedTab = this.get('_previousSelectedTab');
 
     if (selectedTab === previousSelectedTab) {
@@ -33,10 +33,9 @@ export default Component.extend(ParentMixin, ColorMixin, {
     }
 
     this.setMovingRight();
-    scheduleOnce("afterRender", this, function() {
-      this.fixOffsetIfNeeded();
-    });
-
+    
+    this.fixOffsetIfNeeded();
+    
     this.set('_previousSelectedTab', selectedTab);
   }),
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -19,11 +19,11 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
   selected: 0, // select first tab by default
 
-  _selectedTab: computed('selected', function() {
+  _selectedTab: computed('childComponents.@each.value', 'selected', function() {
     return this.get('childComponents').findBy('value', this.get('selected'));
   }),
 
-  _selectedTabDidChange: observer('_selectedTab', function() {
+  _selectedTabDidChange: observer('_selectedTab', 'childComponents.[]', function() {
     let selectedTab = this.get('_selectedTab');
     
     let previousSelectedTab = this.get('_previousSelectedTab');

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -7,6 +7,7 @@ import layout from '../templates/components/paper-tabs';
 import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import { invokeAction } from 'ember-invoke-action';
+import { scheduleOnce } from '@ember/runloop';
 
 export default Component.extend(ParentMixin, ColorMixin, {
   layout,
@@ -32,7 +33,9 @@ export default Component.extend(ParentMixin, ColorMixin, {
     }
 
     this.setMovingRight();
-    this.fixOffsetIfNeeded();
+    scheduleOnce("afterRender", this, function() {
+      this.fixOffsetIfNeeded();
+    });
 
     this.set('_previousSelectedTab', selectedTab);
   }),


### PR DESCRIPTION
Im getting this error
`Assertion Failed: You modified "canPageBack" twice in a single render`
in mobile chrome which prevents the smoothly transition to hidden tabs.

I tracked it down to `this.fixOffsetIfNeeded();` which is executed everytime the `_selectedTab` change which at least in my use case, it can be changed both programatically (i.e `selected=someProperty`) or by the end user when clicked on a tab or the next, previous arrows.

