### PR TITLE
FixOffset when Selected tab is not visible on initial render

### DIFF
--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -75,6 +75,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     let updateCanvasWidth = () => {
       this.updateDimensions();
       this.updateStretchTabs();
+      this.fixOffsetIfNeeded();
     };
 
     window.addEventListener('resize', updateCanvasWidth);


### PR DESCRIPTION
`this.fixOffsetIfNeeded();` added to updateCanvasWidth, so if we resize or change orientation, we also get the offsetCorrection to the possible now hidden tabs, also, fixOffset on initial render, so if start with a selected hidden tab, (i.e routable) we fix the offset

One issue I couldn't fix so far is that somehow the `this.element.offsetLeft` calculated by each tab via updateDimensions() is broken on the initial render. It's like the `offsetLeft` is modified later when other tabs grow(?) in size or something like that... I get this... 

![image](https://user-images.githubusercontent.com/9092644/45842126-643a3580-bce1-11e8-95d7-aeb87939834e.png)

If we fix the offsetLeft, this solves #759