### PR TITLE
Paper autocomplete text

### DIFF
--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -25,7 +25,7 @@ export default Component.extend({
     );
   }),
 
-  text: computed('select.selected}', function() {
+  text: computed('select.selected', function() {
     let selected = this.get('select.selected');
     if (selected) {
       return this.getSelectedAsText();

--- a/addon/components/paper-autocomplete-trigger.js
+++ b/addon/components/paper-autocomplete-trigger.js
@@ -25,12 +25,12 @@ export default Component.extend({
     );
   }),
 
-  text: computed('select.{searchText,selected}', function() {
+  text: computed('select.selected}', function() {
     let selected = this.get('select.selected');
     if (selected) {
       return this.getSelectedAsText();
     }
-    return this.get('select.searchText');
+    return null;
   }).readOnly(),
 
   // Lifecycle hooks


### PR DESCRIPTION
The `text` property should clear and not show the last searched (`searchText`) text if the selected property has been cleared.