### PR TITLE
paper-dialog no jquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Ember Paper Changelog
 
 ### master
-- [#794](https://github.com/miguelcobain/ember-paper/pull/794) forward primary/warn arguments to the toasts' paper-button
+- [#794](https://github.com/miguelcobain/ember-paper/pull/794) forward primary/warn arguments to the toasts' paper-button.
+- [dd7979e](https://github.com/miguelcobain/ember-paper/commit/dd7979ec08a94be6470aa355c6da12db5b2ec20b) correctly escape paper-autocomplete-highlight output (fixes [#985](https://github.com/miguelcobain/ember-paper/issues/985)).
 
 ### 1.0.0-beta.18
 - [68ca72e](https://github.com/miguelcobain/ember-paper/commit/d931d1918e9ddd208cecf045bb6378b39148d7d1) not using ember-cli-sass-variables-export addon anymore since it doesn't output the generated files when using `ember build` (just `ember s`). We're manually including the generated files until we find a better solution. The palettes aren't likely to change anyway.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project aims to bring Google's new [Material Design](https://www.google.com/design/spec/material-design/introduction.html) to Ember. The goal is to encapsulate everything possible in Ember components. This project is packaged as an [Ember-cli](http://www.ember-cli.com/) addon.
 
+[Explore Ember Paper docs »](https://miguelcobain.github.io/ember-paper/)
+
 ## Installation
 
 Install the ember-cli addon in your ember-cli project:
@@ -33,7 +35,6 @@ This is a very ambitious project. Google's design specs are extensive, and non-t
 
 With everyone's help, we can bring this amazing design spec to Ember in a modular and elegant way. The Ember way.
 
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/addon/components/paper-dialog-inner.js
+++ b/addon/components/paper-dialog-inner.js
@@ -24,7 +24,7 @@ export default Component.extend(Translate3dMixin, {
         let focusableButtons = this.element.querySelectorAll('md-dialog-actions button');
         toFocus = focusableButtons[focusableButtons.length - 1];
       }
-      if(toFocus) {
+      if (toFocus) {
         toFocus.focus();
       }
     }
@@ -41,18 +41,18 @@ export default Component.extend(Translate3dMixin, {
     this.checkContentOverflow();
     // content overflow might change depending on load of images inside dialog.
     let imageElements = this.element.querySelectorAll('img');
-    this._checkContentOverflowOnLoad = run.bind(this, this.checkContentOverflow) 
-    imageElements.forEach( image => {
-      image.addEventListener('load', this._checkContentOverflowOnLoad)
+    this._checkContentOverflowOnLoad = run.bind(this, this.checkContentOverflow)
+    imageElements.forEach((image) => {
+      image.addEventListener('load', this._checkContentOverflowOnLoad);
     });
-  
+
   },
 
   willDestroyElement() {
     this._super(...arguments);
     let imageElements = this.element.querySelectorAll('img');
-    imageElements.forEach( image => {
-      image.removeEventListener('load', this._checkContentOverflowOnLoad)
+    imageElements.forEach((image) => {
+      image.removeEventListener('load', this._checkContentOverflowOnLoad);
     });
     this._checkContentOverflowOnLoad = null;
   },

--- a/addon/components/paper-dialog-inner.js
+++ b/addon/components/paper-dialog-inner.js
@@ -41,8 +41,9 @@ export default Component.extend(Translate3dMixin, {
     this.checkContentOverflow();
     // content overflow might change depending on load of images inside dialog.
     let imageElements = this.element.querySelectorAll('img');
+    this._checkContentOverflowOnLoad = run.bind(this, this.checkContentOverflow) 
     imageElements.forEach( image => {
-      image.addEventListener('load', run.bind(this, this.checkContentOverflow))
+      image.addEventListener('load', this._checkContentOverflowOnLoad)
     });
   
   },
@@ -51,8 +52,9 @@ export default Component.extend(Translate3dMixin, {
     this._super(...arguments);
     let imageElements = this.element.querySelectorAll('img');
     imageElements.forEach( image => {
-      image.removeEventListener('load', run.bind(this, this.checkContentOverflow))
+      image.removeEventListener('load', this._checkContentOverflowOnLoad)
     });
+    this._checkContentOverflowOnLoad = null;
   },
 
   checkContentOverflow() {

--- a/addon/components/paper-dialog.js
+++ b/addon/components/paper-dialog.js
@@ -1,8 +1,6 @@
 /**
  * @module ember-paper
  */
-import { inject as service } from '@ember/service';
-
 import { or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
@@ -63,15 +61,13 @@ export default Component.extend({
     return document.querySelector(this.get('destinationId'));
   }),
 
-  constants: service(),
-
   didInsertElement() {
     this._super(...arguments);
     if (this.get('escapeToClose')) {
 
       this._destinationEle = document.querySelector(this.get('destinationId'));
       this._onKeyDown = (e) => {
-        if (e.keyCode === this.get('constants.KEYCODE.ESCAPE') && this.get('onClose')) {
+        if (e.keyCode === 27 && this.get('onClose')) {
           invokeAction(this, 'onClose');
         }
       }
@@ -82,8 +78,9 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    if (this.get('escapeToClose')) {
+    if (this.get('escapeToClose') && this._destinationEle) {
       this._destinationEle.removeEventListener('keydown', this._onKeyDown);
+      this._onKeyDown = null;
     }
   },
 

--- a/addon/components/paper-dialog.js
+++ b/addon/components/paper-dialog.js
@@ -41,7 +41,7 @@ export default Component.extend({
       return '#ember-testing';
     }
     let parent = this.get('defaultedParent');
-    let parentEle = document.querySelector(parent);
+    let parentEle = typeof parent === "string" ? document.querySelector(parent) : parent;
     // If the parentEle isn't found, assume that it is an id, but that the DOM doesn't
     // exist yet. This only happens during integration tests or if entire application
     // route is a dialog.

--- a/addon/components/paper-dialog.js
+++ b/addon/components/paper-dialog.js
@@ -41,11 +41,11 @@ export default Component.extend({
       return '#ember-testing';
     }
     let parent = this.get('defaultedParent');
-    let parentEle = typeof parent === "string" ? document.querySelector(parent) : parent;
+    let parentEle = typeof parent === 'string' ? document.querySelector(parent) : parent;
     // If the parentEle isn't found, assume that it is an id, but that the DOM doesn't
     // exist yet. This only happens during integration tests or if entire application
     // route is a dialog.
-    if (!parentEle && parent.charAt(0) === '#') {
+    if (typeof parent === 'string' && parent.charAt(0) === '#') {
       return `#${parent.substring(1)}`;
     } else {
       let id = parentEle.getAttribute('id');
@@ -69,7 +69,7 @@ export default Component.extend({
     this._super(...arguments);
     if (this.get('escapeToClose')) {
 
-      this._destinationEle = document.querySelector(this.destinationId);
+      this._destinationEle = document.querySelector(this.get('destinationId'));
       this._onKeyDown = (e) => {
         if (e.keyCode === this.get('constants.KEYCODE.ESCAPE') && this.get('onClose')) {
           invokeAction(this, 'onClose');

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -193,7 +193,7 @@ export default Mixin.create({
                 ? document.querySelector(element)
                 : element;
                 
-    let bounds = document.querySelector(element).getBoundingClientRect();
+    let bounds = element.getBoundingClientRect();
 
     // If the event origin element has zero size, it has probably been hidden.
     return bounds && (bounds.width > 0) && (bounds.height > 0) ? this.copyRect(bounds) : null;

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -75,8 +75,8 @@ export default Mixin.create({
     this._super(...arguments);
   
     let config = getOwner(this).resolveRegistration('config:environment');
-
-    let containerClone = this.element.parentElement.cloneNode(true);
+    
+    let containerClone = this.element.parentNode.cloneNode(true);
     let dialogClone = containerClone.querySelector('md-dialog');
     
     let parent = this.get('defaultedParent');
@@ -85,7 +85,7 @@ export default Mixin.create({
       parent = '#ember-testing';
     }
 
-    document.querySelector(parent).parentElement.appendChild(containerClone);
+    document.querySelector(parent).parentNode.appendChild(containerClone);
     
     let toStyle = this.toTransformCss(this.calculateZoomToOrigin(this.element, this.get('defaultedCloseTo')));
 
@@ -94,7 +94,7 @@ export default Mixin.create({
                     : this.get('origin');
 
     nextTick().then(() => {
-      dialogClone.classList.remove('md-transition-in')
+      dialogClone.classList.remove('md-transition-in');
       dialogClone.classList.add('md-transition-out');
       dialogClone.style.cssText = toStyle;
       nextTick().then(() => {

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -1,8 +1,6 @@
 /**
  * @module ember-paper
  */
-import { inject as service } from '@ember/service';
-
 import Mixin from '@ember/object/mixin';
 import { htmlSafe } from '@ember/string';
 import { computed } from '@ember/object';
@@ -15,7 +13,6 @@ import { getOwner } from '@ember/application';
  * @extends Ember.Mixin
  */
 export default Mixin.create({
-  constants: service(),
 
   attributeBindings: ['translateStyle:style'],
   classNameBindings: ['transformIn:md-transition-in'],
@@ -73,23 +70,23 @@ export default Mixin.create({
    */
   willDestroyElement() {
     this._super(...arguments);
-  
+
     let config = getOwner(this).resolveRegistration('config:environment');
-    
+
     let containerClone = this.element.parentNode.cloneNode(true);
     let dialogClone = containerClone.querySelector('md-dialog');
-    
+
     let parent = this.get('defaultedParent');
-    
+
     if (config.environment === 'test' && !this.get('parent')) {
       parent = '#ember-testing';
     }
 
     document.querySelector(parent).parentNode.appendChild(containerClone);
-    
+
     let toStyle = this.toTransformCss(this.calculateZoomToOrigin(this.element, this.get('defaultedCloseTo')));
 
-    let origin = typeof this.get('origin') === "string"
+    let origin = typeof this.get('origin') === 'string'
                     ? document.querySelector(this.get('origin'))
                     : this.get('origin');
 
@@ -120,7 +117,7 @@ export default Mixin.create({
    */
   calculateZoomToOrigin(element, originator) {
     let zoomStyle;
-    originator = typeof originator === "string"
+    originator = typeof originator === 'string'
                     ? document.querySelector(originator)
                     : originator;
     if (originator) {
@@ -147,17 +144,8 @@ export default Mixin.create({
    *
    * @public
    */
-  toTransformCss(transform, addTransition) {
-    let styles = '';
-    this.get('constants').get('CSS').TRANSFORM.split(' ').forEach((key) => {
-      styles += `${key}:${transform};`;
-    });
-
-    if (addTransition) {
-      styles += 'transform: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) !important;';
-    }
-
-    return styles;
+  toTransformCss(transform) {
+    return `transform: ${transform};`;
   },
 
   /**
@@ -180,23 +168,6 @@ export default Mixin.create({
     destination.height = destination.height || (destination.bottom - destination.top);
 
     return destination;
-  },
-
-  /**
-   * Calculate ClientRect of element; return null if hidden or zero size
-   *
-   * @public
-   */
-  clientRect(element) {
-
-    element = typeof element === "string"
-                ? document.querySelector(element)
-                : element;
-                
-    let bounds = element.getBoundingClientRect();
-
-    // If the event origin element has zero size, it has probably been hidden.
-    return bounds && (bounds.width > 0) && (bounds.height > 0) ? this.copyRect(bounds) : null;
   },
 
   /**

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -188,6 +188,11 @@ export default Mixin.create({
    * @public
    */
   clientRect(element) {
+
+    element = typeof element === "string"
+                ? document.querySelector(element)
+                : element;
+                
     let bounds = document.querySelector(element).getBoundingClientRect();
 
     // If the event origin element has zero size, it has probably been hidden.

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -8,6 +8,7 @@ import { htmlSafe } from '@ember/string';
 import { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import { nextTick, computeTimeout } from 'ember-css-transitions/mixins/transition-mixin';
+import { getOwner } from '@ember/application';
 
 /**
  * @class Translate3dMixin
@@ -73,11 +74,19 @@ export default Mixin.create({
   willDestroyElement() {
     this._super(...arguments);
   
+    let config = getOwner(this).resolveRegistration('config:environment');
+
     let containerClone = this.element.parentElement.cloneNode(true);
     let dialogClone = containerClone.querySelector('md-dialog');
     
-    console.log(document.querySelector(this.get('defaultedParent'))) 
-    document.querySelector(this.get('defaultedParent')).parentElement.appendChild(containerClone);
+    let parent = this.get('defaultedParent');
+    
+    if (config.environment === 'test' && !this.get('parent')) {
+      parent = '#ember-testing';
+    }
+
+    document.querySelector(parent).parentElement.appendChild(containerClone);
+    
     let toStyle = this.toTransformCss(this.calculateZoomToOrigin(this.element, this.get('defaultedCloseTo')));
 
     let origin = typeof this.get('origin') === "string"

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, find, findAll, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';ç
+import { render, settled, find, findAll, click, focus, triggerKeyEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | paper dialog', function(hooks) {
   setupRenderingTest(hooks);
@@ -34,18 +34,14 @@ module('Integration | Component | paper dialog', function(hooks) {
         Lorem ipsum.
       {{/paper-dialog}}
     `);
-
-    let dialogContent = find('md-dialog').innerHTML.trim();
-
-    assert.equal(dialogContent, 'Lorem ipsum.', 'yielded dialog content');
+    assert.dom('md-dialog').hasText('Lorem ipsum.')
   });
 
   test('should render in ember-testing if no parent is defined', async function(assert) {
     await render(hbs`
       {{paper-dialog}}
     `);
-
-    assert.ok(find('#ember-testing md-dialog'), 'rendered in default');
+    assert.dom('#ember-testing md-dialog').exists()
   });
 
   test('should render in specific wormhole if parent is defined', async function(assert) {
@@ -57,9 +53,10 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    assert.ok(!find('#paper-wormhole md-dialog'), 'did not render in default');
-    assert.ok(find('#sagittarius-a md-dialog'), 'rendered in parent');
-    assert.ok(find('#ember-testing md-dialog'), 'still rendered in ember-testing');
+    assert.dom('#paper-wormhole md-dialog').doesNotExist()
+    assert.dom('#sagittarius-a md-dialog').exists()
+    assert.dom('#ember-testing md-dialog').exists()
+
   });
 
   test('should only prevent scrolling behind scoped modal', async function(assert) {
@@ -67,8 +64,8 @@ module('Integration | Component | paper dialog', function(hooks) {
       <div id="sagittarius-a"></div>
       {{paper-dialog parent="#sagittarius-a"}}
     `);
-
-    assert.equal(find('md-backdrop').style.position, 'absolute', 'backdrop is absolute');
+  
+    assert.equal(window.getComputedStyle(find('md-backdrop')).getPropertyValue("position"), 'absolute', 'backdrop is absolute');
   });
 
   test('backdrop is opaque by default', async function(assert) {
@@ -76,8 +73,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       <div id="paper-wormhole"></div>
       {{paper-dialog}}
     `);
-
-    assert.ok(find('md-backdrop').classList.contains('md-opaque'), 'backdrop is opaque');
+    assert.dom('md-backdrop').hasClass('md-opaque');
   });
 
   test('backdrop opaqueness can be disabled ', async function(assert) {
@@ -85,8 +81,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       <div id="paper-wormhole"></div>
       {{paper-dialog opaque=false}}
     `);
-
-    assert.notOk(find('md-backdrop').classList.contains('md-opaque'), 'backdrop is not opaque');
+    assert.dom('md-backdrop').doesNotHaveClass('md-opaque');
   });
 
   test('should prevent scrolling entirely behind fixed modal', async function(assert) {
@@ -145,9 +140,9 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/if}}
     `);
 
-    assert.ok(find('md-dialog'), 'dialog is showing');
+    assert.dom('md-dialog').exists();
 
-    click(find('.md-dialog-container'));
+    click('.md-dialog-container');
   });
 
   test('click outside should not close dialog by default', async function(assert) {
@@ -156,10 +151,10 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog}}
     `);
 
-    assert.ok(find('md-dialog'), 'dialog is showing');
+    assert.dom('md-dialog').exists();
 
-    click(find('.md-dialog-container'));
-    assert.ok(find('md-dialog'), 'dialog is still showing');
+    click('.md-dialog-container');
+    assert.dom('md-dialog').exists();
   });
 
   test('dialog shouldn\'t swallow click events', async function(assert) {
@@ -171,18 +166,17 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    assert.ok(find('md-dialog'), 'dialog is showing');
+    assert.dom('md-dialog').exists();
 
-    click(find('#the-button'));
-    assert.ok(find('md-dialog'), 'dialog is still showing');
+    click('#the-button');
+    assert.dom('md-dialog').exists();
   });
 
   test('has opt-in support for fullscreen at responsive breakpoint', async function(assert) {
     await render(hbs`
       {{paper-dialog fullscreen=true}}
     `);
-
-    assert.ok(find('md-dialog').classList.contains('md-dialog-fullscreen'), 'has class for fullscreen');
+    assert.dom('md-dialog').hasClass('md-dialog-fullscreen');
   });
 
   test('pressing escape triggers close action', async function(assert) {
@@ -201,16 +195,14 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/if}}
     `);
 
-    assert.ok(find('md-dialog'), 'dialog is showing');
-
-    let event = new Event("keydown");
-    event.keyCode = 27;
-    
-    find('md-dialog').dispatchEvent(event);
+    assert.dom('md-dialog').exists();
+  
+    triggerKeyEvent('md-dialog', 'keydown', 27);  
 
   });
 
   test('opening gives focus', async function(assert) {
+  
     assert.expect(3);
 
     this.set('openDialog', () => {
@@ -230,31 +222,32 @@ module('Integration | Component | paper dialog', function(hooks) {
       </button>
     `);
 
-    focus('#theorigin')
-    assert.equal(document.activeElement, find('#theorigin'));
+    await focus('#theorigin')
+    assert.dom('#theorigin').isFocused();
     click('#theorigin')
 
     let done = assert.async();
 
     return settled().then(() => {
-      assert.equal(document.activeElement, find('#thedialogbutton'));
+      assert.dom('#thedialogbutton').isFocused();
       this.set('showDialog', false);
 
       return settled();
     }).then(() => {
-      assert.equal(document.activeElement, find('#theorigin'));
+      assert.dom('#theorigin').isFocused();
       done();
     });
 
   });
-
+  
   test('can specify dialog container classes', async function(assert) {
     await render(hbs`
       {{paper-dialog dialogContainerClass="flex-50 my-dialog-container"}}
     `);
 
-    assert.ok(find('.md-dialog-container').classList.contains('flex-50'), 'has flex-50 css class');
-    assert.ok(find('.md-dialog-container').classList.contains('my-dialog-container'), 'has my-dialog-container css class');
+    assert.dom('.md-dialog-container').hasClass('flex-50');
+    assert.dom('.md-dialog-container').hasClass('my-dialog-container');
+    
   });
 
   test('can specify dialog css classes', async function(assert) {
@@ -262,7 +255,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog class="flex-50 my-dialog-inner"}}
     `);
 
-    assert.ok(find('md-dialog').classList.contains('flex-50'), 'has flex-50 css class');
-    assert.ok(find('md-dialog').classList.contains('my-dialog-inner'), 'has my-dialog-inner css class');
+    assert.dom('md-dialog').hasClass('flex-50');
+    assert.dom('md-dialog').hasClass('my-dialog-inner');
   });
 });

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | paper dialog', function(hooks) {
         Lorem ipsum.
       {{/paper-dialog}}
     `);
-    assert.dom('md-dialog').hasText('Lorem ipsum.')
+    assert.dom('md-dialog').hasText('Lorem ipsum.');
   });
 
   test('should render in ember-testing if no parent is defined', async function(assert) {
@@ -53,9 +53,9 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    assert.dom('#paper-wormhole md-dialog').doesNotExist()
-    assert.dom('#sagittarius-a md-dialog').exists()
-    assert.dom('#ember-testing md-dialog').exists()
+    assert.dom('#paper-wormhole md-dialog').doesNotExist();
+    assert.dom('#sagittarius-a md-dialog').exists();
+    assert.dom('#ember-testing md-dialog').exists();
 
   });
 
@@ -65,7 +65,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog parent="#sagittarius-a"}}
     `);
   
-    assert.equal(window.getComputedStyle(find('md-backdrop')).getPropertyValue("position"), 'absolute', 'backdrop is absolute');
+    assert.equal(window.getComputedStyle(find('md-backdrop')).getPropertyValue('position'), 'absolute', 'backdrop is absolute');
   });
 
   test('backdrop is opaque by default', async function(assert) {
@@ -113,17 +113,13 @@ module('Integration | Component | paper dialog', function(hooks) {
     let dialogTransform = getDialogTransform();
     assert.ok(dialogTransform.indexOf('translate3d') !== -1, 'open translate was added');
 
-    return settled().then(() => {
-      let dialogTransform = getDialogTransform();
-      assert.ok(!dialogTransform, 'open translate was removed');
-      this.set('dialogOpen', false);
+    await settled();
+    dialogTransform = getDialogTransform();
+    assert.ok(!dialogTransform, 'open translate was removed');
+    this.set('dialogOpen', false);
 
-      return settled();
-    }).then(() => {
-      // TODO test that close translate is applied
-      // let dialogTransform = getDialogTransform();
-      // assert.ok(dialogTransform.indexOf('translate3d') !== -1, 'close translate was added');
-    });
+    await settled();
+
   });
 
   test('click outside should close dialog if clickOutsideToClose', async function(assert) {
@@ -222,21 +218,19 @@ module('Integration | Component | paper dialog', function(hooks) {
       </button>
     `);
 
-    await focus('#theorigin')
+    await focus('#theorigin');
     assert.dom('#theorigin').isFocused();
-    await click('#theorigin')
+    await click('#theorigin');
 
     let done = assert.async();
 
-    return settled().then(() => {
-      assert.dom('#thedialogbutton').isFocused();
-      this.set('showDialog', false);
+    await settled();
+    assert.dom('#thedialogbutton').isFocused();
+    this.set('showDialog', false);
 
-      return settled();
-    }).then(() => {
-      assert.dom('#theorigin').isFocused();
-      done();
-    });
+    await settled();
+    assert.dom('#theorigin').isFocused();
+    done();
 
   });
   

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, find, findAll, click, focus, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | paper dialog', function(hooks) {
+module('Integration | Component | paper-dialog', function(hooks) {
   setupRenderingTest(hooks);
 
   test('should render proper dialog wrapping selectors', async function(assert) {
@@ -41,7 +41,7 @@ module('Integration | Component | paper dialog', function(hooks) {
     await render(hbs`
       {{paper-dialog}}
     `);
-    assert.dom('#ember-testing md-dialog').exists()
+    assert.dom('#ember-testing md-dialog').exists({ count: 1 });
   });
 
   test('should render in specific wormhole if parent is defined', async function(assert) {
@@ -64,7 +64,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       <div id="sagittarius-a"></div>
       {{paper-dialog parent="#sagittarius-a"}}
     `);
-  
+
     assert.equal(window.getComputedStyle(find('md-backdrop')).getPropertyValue('position'), 'absolute', 'backdrop is absolute');
   });
 
@@ -91,9 +91,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog}}
     `);
 
-    assert.equal(
-      find('md-backdrop').style.position, 'fixed', 'backdrop is fixed'
-    );
+    assert.equal(find('md-backdrop').style.position, 'fixed', 'backdrop is fixed');
   });
 
   test('applies transitions when opening and closing', async function(assert) {
@@ -107,11 +105,11 @@ module('Integration | Component | paper dialog', function(hooks) {
     let getDialogTransform = () => {
       let dialog = find('md-dialog');
       assert.ok(dialog, 'dialog found');
-      return dialog && (dialog.style.webkitTransform || dialog.style.transform);
+      return dialog && dialog.style.transform;
     };
 
     let dialogTransform = getDialogTransform();
-    assert.ok(dialogTransform.indexOf('translate3d') !== -1, 'open translate was added');
+    assert.ok(dialogTransform.includes('translate3d'), 'open translate was added');
 
     await settled();
     dialogTransform = getDialogTransform();
@@ -119,7 +117,6 @@ module('Integration | Component | paper dialog', function(hooks) {
     this.set('dialogOpen', false);
 
     await settled();
-
   });
 
   test('click outside should close dialog if clickOutsideToClose', async function(assert) {
@@ -136,7 +133,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/if}}
     `);
 
-    assert.dom('md-dialog').exists();
+    assert.dom('md-dialog').exists({ count: 1 });
 
     await click('.md-dialog-container');
   });
@@ -150,7 +147,7 @@ module('Integration | Component | paper dialog', function(hooks) {
     assert.dom('md-dialog').exists();
 
     await click('.md-dialog-container');
-    assert.dom('md-dialog').exists();
+    assert.dom('md-dialog').exists({ count: 1 });
   });
 
   test('dialog shouldn\'t swallow click events', async function(assert) {
@@ -162,10 +159,10 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    assert.dom('md-dialog').exists();
+    assert.dom('md-dialog').exists({ count: 1 });
 
     await click('#the-button');
-    assert.dom('md-dialog').exists();
+    assert.dom('md-dialog').exists({ count: 1 });
   });
 
   test('has opt-in support for fullscreen at responsive breakpoint', async function(assert) {
@@ -177,12 +174,10 @@ module('Integration | Component | paper dialog', function(hooks) {
 
   test('pressing escape triggers close action', async function(assert) {
     assert.expect(2);
-    let done = assert.async();
 
     this.set('showDialog', true);
     this.set('closeDialog', () => {
       assert.ok(true, 'dialog closing handler fired');
-      done();
     });
 
     await render(hbs`
@@ -191,14 +186,13 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/if}}
     `);
 
-    assert.dom('md-dialog').exists();
-  
-    await triggerKeyEvent('md-dialog', 'keydown', 27);  
+    assert.dom('md-dialog').exists({ count: 1 });
 
+    await triggerKeyEvent('md-dialog', 'keydown', 27);
   });
 
   test('opening gives focus', async function(assert) {
-  
+
     assert.expect(3);
 
     this.set('openDialog', () => {
@@ -222,18 +216,14 @@ module('Integration | Component | paper dialog', function(hooks) {
     assert.dom('#theorigin').isFocused();
     await click('#theorigin');
 
-    let done = assert.async();
-
     await settled();
     assert.dom('#thedialogbutton').isFocused();
     this.set('showDialog', false);
 
     await settled();
     assert.dom('#theorigin').isFocused();
-    done();
-
   });
-  
+
   test('can specify dialog container classes', async function(assert) {
     await render(hbs`
       {{paper-dialog dialogContainerClass="flex-50 my-dialog-container"}}
@@ -241,7 +231,6 @@ module('Integration | Component | paper dialog', function(hooks) {
 
     assert.dom('.md-dialog-container').hasClass('flex-50');
     assert.dom('.md-dialog-container').hasClass('my-dialog-container');
-    
   });
 
   test('can specify dialog css classes', async function(assert) {

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
-import $ from 'jquery';
+import { render, settled, find, findAll, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';ç
 
 module('Integration | Component | paper dialog', function(hooks) {
   setupRenderingTest(hooks);
@@ -12,7 +11,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog}}
     `);
 
-    let selectors = $('#ember-testing > .md-dialog-container md-dialog');
+    let selectors = findAll('#ember-testing > .md-dialog-container md-dialog');
 
     assert.ok(selectors.length, 'has proper selector nesting');
 
@@ -22,7 +21,8 @@ module('Integration | Component | paper dialog', function(hooks) {
     await render(hbs`
       {{paper-dialog}}
     `);
-    let dialogContent = $('md-dialog').html()
+
+    let dialogContent = find('md-dialog').innerHTML
       .replace('<!--', '').replace('-->', '').trim();
 
     assert.equal(dialogContent, '', 'has an empty dialog container');
@@ -35,7 +35,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    let dialogContent = $('md-dialog').html().trim();
+    let dialogContent = find('md-dialog').innerHTML.trim();
 
     assert.equal(dialogContent, 'Lorem ipsum.', 'yielded dialog content');
   });
@@ -45,7 +45,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog}}
     `);
 
-    assert.ok($().find('#ember-testing md-dialog'), 'rendered in default');
+    assert.ok(find('#ember-testing md-dialog'), 'rendered in default');
   });
 
   test('should render in specific wormhole if parent is defined', async function(assert) {
@@ -57,9 +57,9 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    assert.ok(!$('#paper-wormhole md-dialog').length, 'did not render in default');
-    assert.ok($('#sagittarius-a md-dialog').length, 'rendered in parent');
-    assert.ok($('#ember-testing md-dialog').length, 'still rendered in ember-testing');
+    assert.ok(!find('#paper-wormhole md-dialog'), 'did not render in default');
+    assert.ok(find('#sagittarius-a md-dialog'), 'rendered in parent');
+    assert.ok(find('#ember-testing md-dialog'), 'still rendered in ember-testing');
   });
 
   test('should only prevent scrolling behind scoped modal', async function(assert) {
@@ -68,7 +68,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog parent="#sagittarius-a"}}
     `);
 
-    assert.equal($('md-backdrop').css('position'), 'absolute', 'backdrop is absolute');
+    assert.equal(find('md-backdrop').style.position, 'absolute', 'backdrop is absolute');
   });
 
   test('backdrop is opaque by default', async function(assert) {
@@ -77,7 +77,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog}}
     `);
 
-    assert.ok($('md-backdrop').hasClass('md-opaque'), 'backdrop is opaque');
+    assert.ok(find('md-backdrop').classList.contains('md-opaque'), 'backdrop is opaque');
   });
 
   test('backdrop opaqueness can be disabled ', async function(assert) {
@@ -86,7 +86,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog opaque=false}}
     `);
 
-    assert.notOk($('md-backdrop').hasClass('md-opaque'), 'backdrop is not opaque');
+    assert.notOk(find('md-backdrop').classList.contains('md-opaque'), 'backdrop is not opaque');
   });
 
   test('should prevent scrolling entirely behind fixed modal', async function(assert) {
@@ -97,7 +97,7 @@ module('Integration | Component | paper dialog', function(hooks) {
     `);
 
     assert.equal(
-      $('md-backdrop').css('position'), 'fixed', 'backdrop is fixed'
+      find('md-backdrop').style.position, 'fixed', 'backdrop is fixed'
     );
   });
 
@@ -110,7 +110,7 @@ module('Integration | Component | paper dialog', function(hooks) {
     this.set('dialogOpen', true);
 
     let getDialogTransform = () => {
-      let dialog = $('md-dialog').get(0);
+      let dialog = find('md-dialog');
       assert.ok(dialog, 'dialog found');
       return dialog && (dialog.style.webkitTransform || dialog.style.transform);
     };
@@ -145,9 +145,9 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/if}}
     `);
 
-    assert.ok($('md-dialog').length, 'dialog is showing');
+    assert.ok(find('md-dialog'), 'dialog is showing');
 
-    $('.md-dialog-container').mousedown().mouseup().click();
+    click(find('.md-dialog-container'));
   });
 
   test('click outside should not close dialog by default', async function(assert) {
@@ -156,10 +156,10 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog}}
     `);
 
-    assert.ok($('md-dialog').length, 'dialog is showing');
+    assert.ok(find('md-dialog'), 'dialog is showing');
 
-    $('.md-dialog-container').mousedown().mouseup().click();
-    assert.ok($('md-dialog').length, 'dialog is still showing');
+    click(find('.md-dialog-container'));
+    assert.ok(find('md-dialog'), 'dialog is still showing');
   });
 
   test('dialog shouldn\'t swallow click events', async function(assert) {
@@ -171,10 +171,10 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/paper-dialog}}
     `);
 
-    assert.ok($('md-dialog').length, 'dialog is showing');
+    assert.ok(find('md-dialog'), 'dialog is showing');
 
-    $('#the-button').mousedown().mouseup().click();
-    assert.ok($('md-dialog').length, 'dialog is still showing');
+    click(find('#the-button'));
+    assert.ok(find('md-dialog'), 'dialog is still showing');
   });
 
   test('has opt-in support for fullscreen at responsive breakpoint', async function(assert) {
@@ -182,7 +182,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog fullscreen=true}}
     `);
 
-    assert.ok($('md-dialog').hasClass('md-dialog-fullscreen'), 'has class for fullscreen');
+    assert.ok(find('md-dialog').classList.contains('md-dialog-fullscreen'), 'has class for fullscreen');
   });
 
   test('pressing escape triggers close action', async function(assert) {
@@ -201,11 +201,12 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{/if}}
     `);
 
-    assert.ok($('md-dialog'), 'dialog is showing');
+    assert.ok(find('md-dialog'), 'dialog is showing');
 
-    let event = new $.Event('keydown');
+    let event = new Event("keydown");
     event.keyCode = 27;
-    $('md-dialog').trigger(event);
+    
+    find('md-dialog').dispatchEvent(event);
 
   });
 
@@ -229,19 +230,19 @@ module('Integration | Component | paper dialog', function(hooks) {
       </button>
     `);
 
-    $('#theorigin').focus();
-    assert.equal(document.activeElement, $('#theorigin').get(0));
-    $('#theorigin').click();
+    focus('#theorigin')
+    assert.equal(document.activeElement, find('#theorigin'));
+    click('#theorigin')
 
     let done = assert.async();
 
     return settled().then(() => {
-      assert.equal(document.activeElement, $('#thedialogbutton').get(0));
+      assert.equal(document.activeElement, find('#thedialogbutton'));
       this.set('showDialog', false);
 
       return settled();
     }).then(() => {
-      assert.equal(document.activeElement, $('#theorigin').get(0));
+      assert.equal(document.activeElement, find('#theorigin'));
       done();
     });
 
@@ -252,8 +253,8 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog dialogContainerClass="flex-50 my-dialog-container"}}
     `);
 
-    assert.ok($('.md-dialog-container').hasClass('flex-50'), 'has flex-50 css class');
-    assert.ok($('.md-dialog-container').hasClass('my-dialog-container'), 'has my-dialog-container css class');
+    assert.ok(find('.md-dialog-container').classList.contains('flex-50'), 'has flex-50 css class');
+    assert.ok(find('.md-dialog-container').classList.contains('my-dialog-container'), 'has my-dialog-container css class');
   });
 
   test('can specify dialog css classes', async function(assert) {
@@ -261,7 +262,7 @@ module('Integration | Component | paper dialog', function(hooks) {
       {{paper-dialog class="flex-50 my-dialog-inner"}}
     `);
 
-    assert.ok($('md-dialog').hasClass('flex-50'), 'has flex-50 css class');
-    assert.ok($('md-dialog').hasClass('my-dialog-inner'), 'has my-dialog-inner css class');
+    assert.ok(find('md-dialog').classList.contains('flex-50'), 'has flex-50 css class');
+    assert.ok(find('md-dialog').classList.contains('my-dialog-inner'), 'has my-dialog-inner css class');
   });
 });

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -142,7 +142,7 @@ module('Integration | Component | paper dialog', function(hooks) {
 
     assert.dom('md-dialog').exists();
 
-    click('.md-dialog-container');
+    await click('.md-dialog-container');
   });
 
   test('click outside should not close dialog by default', async function(assert) {
@@ -153,7 +153,7 @@ module('Integration | Component | paper dialog', function(hooks) {
 
     assert.dom('md-dialog').exists();
 
-    click('.md-dialog-container');
+    await click('.md-dialog-container');
     assert.dom('md-dialog').exists();
   });
 
@@ -168,7 +168,7 @@ module('Integration | Component | paper dialog', function(hooks) {
 
     assert.dom('md-dialog').exists();
 
-    click('#the-button');
+    await click('#the-button');
     assert.dom('md-dialog').exists();
   });
 
@@ -197,7 +197,7 @@ module('Integration | Component | paper dialog', function(hooks) {
 
     assert.dom('md-dialog').exists();
   
-    triggerKeyEvent('md-dialog', 'keydown', 27);  
+    await triggerKeyEvent('md-dialog', 'keydown', 27);  
 
   });
 
@@ -224,7 +224,7 @@ module('Integration | Component | paper dialog', function(hooks) {
 
     await focus('#theorigin')
     assert.dom('#theorigin').isFocused();
-    click('#theorigin')
+    await click('#theorigin')
 
     let done = assert.async();
 


### PR DESCRIPTION
Hello, I refactored jquery from the component and from the component integration tests, it seems to be working ok. I have three tests failing though.

1. `test('should only prevent scrolling behind scoped modal')`
2. `test('pressing escape triggers close action`)` this was failing even without the refactor.
3. `test('opening gives focus')`
