### PR TITLE
Added missing slashes in closing tags of typography demo template

### DIFF
--- a/tests/dummy/app/templates/typography.hbs
+++ b/tests/dummy/app/templates/typography.hbs
@@ -14,21 +14,21 @@
 
   <h3>Formatting</h3>
   <div class="preview-block">
-    <p><u>&lt;u&gt;Underlined&lt;u&gt;</u></p>
+    <p><u>&lt;u&gt;Underlined&lt;/u&gt;</u></p>
 
-    <p><b>&lt;b&gt;Bold&lt;b&gt;</b></p>
+    <p><b>&lt;b&gt;Bold&lt;/b&gt;</b></p>
 
-    <p><strong>&lt;strong&gt;Strong&lt;strong&gt;</strong></p>
+    <p><strong>&lt;strong&gt;Strong&lt;/strong&gt;</strong></p>
 
-    <p><i>&lt;italic&gt;Italic&lt;italic&gt;</i></p>
+    <p><i>&lt;italic&gt;Italic&lt;/italic&gt;</i></p>
 
-    <p><em>&lt;em&gt;Em&lt;em&gt;</em></p>
+    <p><em>&lt;em&gt;Em&lt;/em&gt;</em></p>
 
-    <p><s>&lt;s&gt;Strikethrough&lt;s&gt;</s></p>
+    <p><s>&lt;s&gt;Strikethrough&lt;/s&gt;</s></p>
 
-    <p><small>&lt;small&gt;Small&lt;small&gt;</small></p>
+    <p><small>&lt;small&gt;Small&lt;/small&gt;</small></p>
 
-    <p><mark>&lt;mark&gt;Mark&lt;mark&gt;</mark></p>
+    <p><mark>&lt;mark&gt;Mark&lt;/mark&gt;</mark></p>
   </div>
 
   <h3>Subtitles</h3>


### PR DESCRIPTION
I assume the missing slashes in the closing tags were just an oversight and not intentional.