### PR TITLE
Associate input field with corresponding info messages for better a11y

### DIFF
--- a/addon/templates/components/paper-input.hbs
+++ b/addon/templates/components/paper-input.hbs
@@ -8,6 +8,7 @@
 
 {{#if textarea}}
   <textarea
+    aria-describedby={{concat elementId '-char-count ' elementId '-error-messages'}}
     class="md-input {{if isInvalid "ng-invalid"}} {{if isTouched "ng-dirty"}}"
     id={{inputElementId}}
     placeholder={{if shouldAddPlaceholder placeholder}}
@@ -49,6 +50,7 @@
     oninput={{action "handleInput"}}
 
     accept={{passThru.accept}}
+    aria-describedby={{concat elementId '-char-count ' elementId '-error-messages'}}
     autocomplete={{passThru.autocomplete}}
     autocorrect={{passThru.autocorrect}}
     autocapitalize={{passThru.autocapitalize}}
@@ -78,13 +80,13 @@
 {{/if}}
 
 {{#unless hideAllMessages}}
-  <div class="md-errors-spacer">
+  <div class="md-errors-spacer" id={{concat elementId '-char-count'}}>
     {{#if maxlength}}
       <div class="md-char-counter">{{renderCharCount}}</div>
     {{/if}}
   </div>
   {{#if isInvalidAndTouched}}
-    <div class="md-input-messages-animation md-auto-hide">
+    <div class="md-input-messages-animation md-auto-hide" id={{concat elementId '-error-messages'}}>
       {{#each validationErrorMessages as |error index|}}
         <div id="error-{{inputElementId}}-{{index}}"
         class="paper-input-error ng-enter ng-enter-active md-input-message-animation"

--- a/addon/templates/components/paper-input.hbs
+++ b/addon/templates/components/paper-input.hbs
@@ -8,12 +8,12 @@
 
 {{#if textarea}}
   <textarea
-    aria-describedby={{concat elementId '-char-count ' elementId '-error-messages'}}
     class="md-input {{if isInvalid "ng-invalid"}} {{if isTouched "ng-dirty"}}"
     id={{inputElementId}}
     placeholder={{if shouldAddPlaceholder placeholder}}
     disabled={{disabled}}
     autofocus={{autofocus}}
+    aria-describedby={{concat elementId "-char-count " elementId "-error-messages"}}
     onfocus={{onFocus}}
     onblur={{action "handleBlur"}}
     onkeydown={{onKeyDown}}
@@ -42,6 +42,7 @@
     type={{type}}
     disabled={{disabled}}
     autofocus={{autofocus}}
+    aria-describedby={{concat elementId "-char-count " elementId "-error-messages"}}
     onfocus={{onFocus}}
     onblur={{action "handleBlur"}}
     onkeydown={{onKeyDown}}
@@ -50,7 +51,6 @@
     oninput={{action "handleInput"}}
 
     accept={{passThru.accept}}
-    aria-describedby={{concat elementId '-char-count ' elementId '-error-messages'}}
     autocomplete={{passThru.autocomplete}}
     autocorrect={{passThru.autocorrect}}
     autocapitalize={{passThru.autocapitalize}}
@@ -80,13 +80,13 @@
 {{/if}}
 
 {{#unless hideAllMessages}}
-  <div class="md-errors-spacer" id={{concat elementId '-char-count'}}>
+  <div class="md-errors-spacer" id={{concat elementId "-char-count"}}>
     {{#if maxlength}}
       <div class="md-char-counter">{{renderCharCount}}</div>
     {{/if}}
   </div>
   {{#if isInvalidAndTouched}}
-    <div class="md-input-messages-animation md-auto-hide" id={{concat elementId '-error-messages'}}>
+    <div class="md-input-messages-animation md-auto-hide" id={{concat elementId "-error-messages"}}>
       {{#each validationErrorMessages as |error index|}}
         <div id="error-{{inputElementId}}-{{index}}"
         class="paper-input-error ng-enter ng-enter-active md-input-message-animation"

--- a/tests/integration/components/paper-input-test.js
+++ b/tests/integration/components/paper-input-test.js
@@ -518,4 +518,31 @@ module('Integration | Component | paper-input', function(hooks) {
 
     assert.dom('.other-stuff').exists();
   });
+
+  test('aria-describedby on input elements is set properly', async function(assert) {
+
+    let errors = [{
+      message: 'foo is required.',
+      attribute: 'foo'
+    }];
+    this.set('errors', errors);
+
+    await render(hbs`{{paper-input onChange=null errors=errors}}`);
+    await triggerEvent('input', 'blur');
+
+    let input = find('.md-input');
+    let aria_describedby_values = input.getAttribute('aria-describedby').split(' ');
+
+    assert.equal(aria_describedby_values.length, 2);
+
+    assert.ok(aria_describedby_values[0].includes('-char-count'));
+
+    assert.dom('#' + aria_describedby_values[0]).exists();
+
+    assert.ok(aria_describedby_values[1].includes('-error-messages'));
+
+    assert.dom('#' + aria_describedby_values[1]).exists();
+  });
+
+
 });

--- a/tests/integration/components/paper-input-test.js
+++ b/tests/integration/components/paper-input-test.js
@@ -531,17 +531,17 @@ module('Integration | Component | paper-input', function(hooks) {
     await triggerEvent('input', 'blur');
 
     let input = find('.md-input');
-    let aria_describedby_values = input.getAttribute('aria-describedby').split(' ');
+    let ariaDescribedbyValues = input.getAttribute('aria-describedby').split(' ');
 
-    assert.equal(aria_describedby_values.length, 2);
+    assert.equal(ariaDescribedbyValues.length, 2);
 
-    assert.ok(aria_describedby_values[0].includes('-char-count'));
+    assert.ok(ariaDescribedbyValues[0].includes('-char-count'));
 
-    assert.dom('#' + aria_describedby_values[0]).exists();
+    assert.dom('#' + ariaDescribedbyValues[0]).exists();
 
-    assert.ok(aria_describedby_values[1].includes('-error-messages'));
+    assert.ok(ariaDescribedbyValues[1].includes('-error-messages'));
 
-    assert.dom('#' + aria_describedby_values[1]).exists();
+    assert.dom('#' + ariaDescribedbyValues[1]).exists();
   });
 
 


### PR DESCRIPTION
Adding aria-describedby attribute to input fields with reference to occasionally appearing info text element below the related field causes screen readers to read out input fields together with corresponding info text (mainly error notification, e.g. failed validation). This change matches [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html) success criterion of WCAG 2.
Without this connection the info underneath the input field is being read out separately and for screen reader users it may not be clear which input element this info belongs to.