### PR TITLE
Improve paper-icon a11y

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -20,7 +20,7 @@ let PaperIconComponent = Component.extend(ColorMixin, {
   tagName: 'md-icon',
   classNames: ['paper-icon', 'md-font', 'material-icons', 'md-default-theme'],
   classNameBindings: ['spinClass'],
-  attributeBindings: ['aria-label', 'title', 'sizeStyle:style', 'iconClass:md-font-icon'],
+  attributeBindings: ['aria-hidden', 'aria-label', 'title', 'sizeStyle:style', 'iconClass:md-font-icon'],
 
   icon: '',
   spin: false,
@@ -31,6 +31,7 @@ let PaperIconComponent = Component.extend(ColorMixin, {
     return icon;
   }),
 
+  'aria-hidden': false,
   'aria-label': reads('iconClass'),
 
   spinClass: computed('spin', 'reverseSpin', function() {

--- a/tests/integration/components/paper-icon-test.js
+++ b/tests/integration/components/paper-icon-test.js
@@ -128,4 +128,13 @@ module('Integration | Component | paper-icon', function(hooks) {
 
     assert.dom('md-icon').hasAttribute('md-font-icon', 'check');
   });
+
+  test('it renders with a provided aria-hidden attribute', async function(assert) {
+    assert.expect(1);
+
+    this.set('ariaHidden', true);
+    await render(hbs`{{paper-icon "check" aria-hidden=ariaHidden}}`);
+
+    assert.dom('md-icon').hasAttribute('aria-hidden');
+  });
 });


### PR DESCRIPTION
Icon's and related text element's meaning usually overlap. Which is why reading out icons' label is often redundant. Developers should be able to prevent screen reader from reading out paper-icons using aria-hidden attribute which is set to false by default. This change aims [WCAG2 Success Criterion 1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)