### PR TITLE
fix missing md-content when displaying searchMessage in paper-select

### DIFF
--- a/addon/templates/components/paper-select.hbs
+++ b/addon/templates/components/paper-select.hbs
@@ -85,10 +85,12 @@
     {{/if}}
 
     {{#if mustShowSearchMessage}}
-      {{component searchMessageComponent
-        searchMessage=(readonly searchMessage)
-        select=(readonly publicAPI)
-      }}
+      <md-content>
+        {{component searchMessageComponent
+          searchMessage=(readonly searchMessage)
+          select=(readonly publicAPI)
+        }}
+      </md-content>
     {{else if mustShowNoMessages}}
       {{#if (hasBlock "inverse")}}
         {{yield to="inverse"}}

--- a/tests/integration/components/paper-select-test.js
+++ b/tests/integration/components/paper-select-test.js
@@ -110,4 +110,22 @@ module('Integration | Component | paper select', function(hooks) {
 
     assert.dom('md-select-menu md-option').hasText('small (12-inch)');
   });
+
+  test('it shows search message before entering search string', async function(assert) {
+    this.search = (value) => this.sizes.filter((size) => size.includes(value));
+
+    await render(hbs`{{#paper-select
+      search=search
+      searchEnabled=true
+      selected=selectedSize
+      onChange=(action (mut selectedSize))
+      as |size|
+    }}
+      {{size}}
+    {{/paper-select}}`);
+
+    await clickTrigger('md-input-container');
+    assert.dom('md-select-menu > md-content').exists();
+    assert.dom('md-select-menu > md-content').hasText('Type to search');
+  });
 });


### PR DESCRIPTION
#941 removed the wrapping `md-content` tag in `paper-select` with `searchEnabled=true` which causes problems (#1025) in the `calculatePosition` method of `paper-select-menu` when the `paper-select` is clicked without any `options` available. 

This PR adds a `md-content` wrapper around the `searchMessageComponent` in `paper-select`.