### PR TITLE
Allow to add title attribute to paper-input

### DIFF
--- a/addon/templates/components/paper-input.hbs
+++ b/addon/templates/components/paper-input.hbs
@@ -26,6 +26,7 @@
     cols={{passThru.cols}}
     maxlength={{passThru.maxlength}}
     tabindex={{passThru.tabindex}}
+    title={{title}}
     required={{passThru.required}}
     selectionEnd={{passThru.selectionEnd}}
     selectionStart={{passThru.selectionStart}}
@@ -76,6 +77,7 @@
     spellcheck={{passThru.spellcheck}}
     step={{passThru.step}}
     tabindex={{passThru.tabindex}}
+    title={{title}}
     width={{passThru.width}}>
 {{/if}}
 

--- a/tests/integration/components/paper-input-test.js
+++ b/tests/integration/components/paper-input-test.js
@@ -542,4 +542,9 @@ module('Integration | Component | paper-input', function(hooks) {
     assert.dom(`#${ariaDescribedbyValues[1]}`).exists();
   });
 
+  test('title attribute is set properly', async function(assert) {
+    await render(hbs`{{paper-input onChange=null title="important title"}}`);
+
+    assert.dom('input').hasAttribute('title');
+  });
 });


### PR DESCRIPTION
It allows us to add `title` attribute to the input field - improvement for screen readers. 