### PR TITLE
Make radio button accessible

### DIFF
--- a/addon/components/paper-radio-base.js
+++ b/addon/components/paper-radio-base.js
@@ -23,7 +23,11 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
   tagName: 'md-radio-button',
   classNames: ['md-default-theme'],
   classNameBindings: ['checked:md-checked'],
-  attributeBindings: ['role', 'ariaChecked:aria-checked'],
+  attributeBindings: [
+    'role',
+    'ariaChecked:aria-checked',
+    'ariaLabel:aria-label'
+  ],
 
   tabindex: null,
 
@@ -51,6 +55,10 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
 
   ariaChecked: computed('checked', function() {
     return this.get('checked') ? 'true' : 'false';
+  }),
+
+  labelId: computed('elementId', function() {
+    return `${this.elementId}-label`;
   }),
 
   click() {

--- a/addon/components/paper-radio-base.js
+++ b/addon/components/paper-radio-base.js
@@ -23,10 +23,12 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
   tagName: 'md-radio-button',
   classNames: ['md-default-theme'],
   classNameBindings: ['checked:md-checked'],
+  attributeBindings: ['role', 'ariaChecked:aria-checked'],
 
   tabindex: null,
 
   toggle: false,
+  role: 'radio',
 
   /* Ripple Overrides */
   rippleContainerSelector: '.md-container',
@@ -45,6 +47,10 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, {
 
   checked: computed('groupValue', 'value', function() {
     return this.get('groupValue') === this.get('value');
+  }),
+
+  ariaChecked: computed('checked', function() {
+    return this.get('checked') ? 'true' : 'false';
   }),
 
   click() {

--- a/addon/components/paper-radio-group-label.js
+++ b/addon/components/paper-radio-group-label.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import layout from '../templates/components/paper-radio-group-label';
+
+export default Component.extend({
+  layout,
+
+  tagName: 'md-label',
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    if (this.get('setAriaLabelledby')) {
+      this.get('setAriaLabelledby')(this.elementId);
+    }
+  }
+});

--- a/addon/components/paper-radio-group.js
+++ b/addon/components/paper-radio-group.js
@@ -11,7 +11,6 @@ import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import { ParentMixin } from 'ember-composability-tools';
 import { isPresent } from '@ember/utils';
 import { invokeAction } from 'ember-invoke-action';
-import { computed } from '@ember/object';
 
 /**
  * @class PaperRadioGroup
@@ -28,6 +27,7 @@ export default Component.extend(FocusableMixin, ParentMixin, {
   focusOnlyOnKey: true,
 
   radioComponent: 'paper-radio',
+  labelComponent: 'paper-radio-group-label',
   role: 'radiogroup',
 
   constants: service(),
@@ -38,13 +38,6 @@ export default Component.extend(FocusableMixin, ParentMixin, {
     assert('{{paper-radio-group}} requires an `onChange` action or null for no action', this.get('onChange') !== undefined);
   },
 
-  didInsertElement() {
-    this._super(...arguments);
-
-    let labelNode = this.element.querySelector(`#${this.get('labelId')}`);
-    this.set('labelNode', labelNode);
-  },
-
   attributeBindings: [
     'role',
     'ariaLabelledby:aria-labelledby'
@@ -53,14 +46,6 @@ export default Component.extend(FocusableMixin, ParentMixin, {
   enabledChildRadios: filterBy('childComponents', 'disabled', false),
   childValues: mapBy('enabledChildRadios', 'value'),
   hasLabel: notEmpty('labelNode'),
-
-  ariaLabelledby: computed('hasLabel', 'labelId', function() {
-    return this.get('hasLabel') ? this.get('labelId') : false;
-  }),
-
-  labelId: computed('elementId', function() {
-    return `${this.elementId}-label`;
-  }),
 
   keyDown(ev) {
 

--- a/addon/components/paper-radio-group.js
+++ b/addon/components/paper-radio-group.js
@@ -28,6 +28,7 @@ export default Component.extend(FocusableMixin, ParentMixin, {
   focusOnlyOnKey: true,
 
   radioComponent: 'paper-radio',
+  role: 'radiogroup',
 
   constants: service(),
 
@@ -44,7 +45,10 @@ export default Component.extend(FocusableMixin, ParentMixin, {
     this.set('labelNode', labelNode);
   },
 
-  attributeBindings: ['ariaLabelledby:aria-labelledby'],
+  attributeBindings: [
+    'role',
+    'ariaLabelledby:aria-labelledby'
+  ],
 
   enabledChildRadios: filterBy('childComponents', 'disabled', false),
   childValues: mapBy('enabledChildRadios', 'value'),

--- a/addon/components/paper-radio-group.js
+++ b/addon/components/paper-radio-group.js
@@ -3,7 +3,7 @@
  */
 import { inject as service } from '@ember/service';
 
-import { filterBy, mapBy } from '@ember/object/computed';
+import { filterBy, mapBy, notEmpty } from '@ember/object/computed';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
 import layout from '../templates/components/paper-radio-group';
@@ -11,6 +11,7 @@ import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import { ParentMixin } from 'ember-composability-tools';
 import { isPresent } from '@ember/utils';
 import { invokeAction } from 'ember-invoke-action';
+import { computed } from '@ember/object';
 
 /**
  * @class PaperRadioGroup
@@ -36,8 +37,26 @@ export default Component.extend(FocusableMixin, ParentMixin, {
     assert('{{paper-radio-group}} requires an `onChange` action or null for no action', this.get('onChange') !== undefined);
   },
 
+  didInsertElement() {
+    this._super(...arguments);
+
+    let labelNode = this.element.querySelector(`#${this.get('labelId')}`);
+    this.set('labelNode', labelNode);
+  },
+
+  attributeBindings: ['ariaLabelledby:aria-labelledby'],
+
   enabledChildRadios: filterBy('childComponents', 'disabled', false),
   childValues: mapBy('enabledChildRadios', 'value'),
+  hasLabel: notEmpty('labelNode'),
+
+  ariaLabelledby: computed('hasLabel', 'labelId', function() {
+    return this.get('hasLabel') ? this.get('labelId') : false;
+  }),
+
+  labelId: computed('elementId', function() {
+    return `${this.elementId}-label`;
+  }),
 
   keyDown(ev) {
 

--- a/addon/templates/components/paper-radio-group-label.hbs
+++ b/addon/templates/components/paper-radio-group-label.hbs
@@ -1,0 +1,6 @@
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  {{text}}
+{{/if}}
+

--- a/addon/templates/components/paper-radio-group.hbs
+++ b/addon/templates/components/paper-radio-group.hbs
@@ -1,4 +1,5 @@
 {{yield (hash
+  labelId=labelId
   radio=(component radioComponent
     toggle=toggle
     disabled=disabled

--- a/addon/templates/components/paper-radio-group.hbs
+++ b/addon/templates/components/paper-radio-group.hbs
@@ -1,5 +1,7 @@
 {{yield (hash
-  labelId=labelId
+  label=(component labelComponent
+    setAriaLabelledby=(action (mut ariaLabelledby))
+  )
   radio=(component radioComponent
     toggle=toggle
     disabled=disabled

--- a/app/components/paper-radio-group-label.js
+++ b/app/components/paper-radio-group-label.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-paper/components/paper-radio-group-label';

--- a/tests/integration/components/paper-radio-group-label-test.js
+++ b/tests/integration/components/paper-radio-group-label-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | paper-radio-group-label', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it calls `setAriaLabelledby` with self elementId when the component lands in the DOM`', async function(assert) {
+    assert.expect(1);
+
+    let setAriaLabelledby = (id) => {
+      assert.equal(this.element.querySelector('md-label').id, id, 'Calls `setAriaLabelledby` with correct param');
+    };
+
+    this.set('setAriaLabelledby', setAriaLabelledby);
+
+    await render(hbs`{{paper-radio-group-label setAriaLabelledby=setAriaLabelledby}}`);
+  });
+
+  test('it sets label content based on text property', async function(assert) {
+    await render(hbs`{{paper-radio-group-label text="hello"}}`);
+
+    assert.dom('md-label').hasText('hello');
+  });
+
+  test('it shows label passed as a block', async function(assert) {
+    await render(hbs`
+      {{#paper-radio-group-label}}
+        hello block
+      {{/paper-radio-group-label}}
+    `);
+
+    assert.dom('md-label').hasText('hello block');
+  });
+});

--- a/tests/integration/components/paper-radio-group-test.js
+++ b/tests/integration/components/paper-radio-group-test.js
@@ -249,4 +249,16 @@ module('Integration | Component | paper-radio-group', function(hooks) {
 
     assert.dom('md-radio-group').doesNotHaveAttribute('aria-labelledby');
   });
+
+  test('it has role attribute', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{#paper-radio-group onChange=null as |group|}}
+        {{group.radio}}
+      {{/paper-radio-group}}
+    `);
+
+    assert.dom('md-radio-group').hasAttribute('role');
+  });
 });

--- a/tests/integration/components/paper-radio-group-test.js
+++ b/tests/integration/components/paper-radio-group-test.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, triggerKeyEvent } from '@ember/test-helpers';
+import { render, click, triggerKeyEvent, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | paper-radio-group', function(hooks) {
@@ -212,5 +212,41 @@ module('Integration | Component | paper-radio-group', function(hooks) {
     `);
 
     assert.dom('.custom-radio').exists({ count: 1 }, 'custom radio component is displayed');
+  });
+
+  test('it yields labelId property', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{#paper-radio-group onChange=null as |group|}}
+        <md-label id={{group.labelId}}></md-label>
+      {{/paper-radio-group}}
+    `);
+
+    assert.dom('md-label').hasAttribute('id');
+  });
+
+  test('it sets aira-labelled property when group is labeled', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{#paper-radio-group onChange=null as |group|}}
+        <md-label id={{group.labelId}}>group label</md-label>
+      {{/paper-radio-group}}
+    `);
+    let labelId = find('md-radio-group').getAttribute('aria-labelledby');
+    assert.dom(`#${labelId}`).hasText('group label');
+  });
+
+  test('it doesn\'t show aria-labelled property when group does not have label element', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{#paper-radio-group onChange=null as |group|}}
+        {{group.radio}}
+      {{/paper-radio-group}}
+    `);
+
+    assert.dom('md-radio-group').doesNotHaveAttribute('aria-labelledby');
   });
 });

--- a/tests/integration/components/paper-radio-group-test.js
+++ b/tests/integration/components/paper-radio-group-test.js
@@ -212,34 +212,5 @@ module('Integration | Component | paper-radio-group', function(hooks) {
     `);
 
     assert.dom('.custom-radio').exists({ count: 1 }, 'custom radio component is displayed');
-
   });
-
-  test('it has role attribute', async function(assert) {
-    assert.expect(1);
-
-    await render(hbs`
-      {{#paper-radio-group onChange=null as |group|}}
-        {{group.radio}}
-      {{/paper-radio-group}}
-    `);
-
-    assert.dom('md-radio-button').hasAttribute('role');
-  }),
-
-  test('it correctly sets aria-checked attribute', async function(assert) {
-    this.set('groupValue', null);
-
-    await render(hbs`
-      {{#paper-radio-group groupValue=groupValue onChange=null as |group|}}
-        {{group.radio value="1"}}
-      {{/paper-radio-group}}
-    `);
-
-    assert.dom('md-radio-button').hasAttribute('aria-checked', 'false');
-
-    this.set('groupValue', '1');
-
-    assert.dom('md-radio-button').hasAttribute('aria-checked', 'true');
-  })
 });

--- a/tests/integration/components/paper-radio-group-test.js
+++ b/tests/integration/components/paper-radio-group-test.js
@@ -214,4 +214,32 @@ module('Integration | Component | paper-radio-group', function(hooks) {
     assert.dom('.custom-radio').exists({ count: 1 }, 'custom radio component is displayed');
 
   });
+
+  test('it has role attribute', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{#paper-radio-group onChange=null as |group|}}
+        {{group.radio}}
+      {{/paper-radio-group}}
+    `);
+
+    assert.dom('md-radio-button').hasAttribute('role');
+  }),
+
+  test('it correctly sets aria-checked attribute', async function(assert) {
+    this.set('groupValue', null);
+
+    await render(hbs`
+      {{#paper-radio-group groupValue=groupValue onChange=null as |group|}}
+        {{group.radio value="1"}}
+      {{/paper-radio-group}}
+    `);
+
+    assert.dom('md-radio-button').hasAttribute('aria-checked', 'false');
+
+    this.set('groupValue', '1');
+
+    assert.dom('md-radio-button').hasAttribute('aria-checked', 'true');
+  })
 });

--- a/tests/integration/components/paper-radio-group-test.js
+++ b/tests/integration/components/paper-radio-group-test.js
@@ -214,24 +214,28 @@ module('Integration | Component | paper-radio-group', function(hooks) {
     assert.dom('.custom-radio').exists({ count: 1 }, 'custom radio component is displayed');
   });
 
-  test('it yields labelId property', async function(assert) {
+  test('it yields label component', async function(assert) {
     assert.expect(1);
 
     await render(hbs`
       {{#paper-radio-group onChange=null as |group|}}
-        <md-label id={{group.labelId}}></md-label>
+        {{#group.label}}
+          group label
+        {{/group.label}}
       {{/paper-radio-group}}
     `);
 
-    assert.dom('md-label').hasAttribute('id');
+    assert.dom('md-label').exists();
   });
 
-  test('it sets aira-labelled property when group is labeled', async function(assert) {
+  test('it sets aira-labelled property when label is present', async function(assert) {
     assert.expect(1);
 
     await render(hbs`
       {{#paper-radio-group onChange=null as |group|}}
-        <md-label id={{group.labelId}}>group label</md-label>
+        {{#group.label}}
+          group label
+        {{/group.label}}
       {{/paper-radio-group}}
     `);
     let labelId = find('md-radio-group').getAttribute('aria-labelledby');

--- a/tests/integration/components/paper-radio-test.js
+++ b/tests/integration/components/paper-radio-test.js
@@ -104,4 +104,36 @@ module('Integration | Component | paper radio', function(hooks) {
       this.render(hbs`{{paper-radio value="1"}}`);
     }, /requires an `onChange` action/);
   });*/
+
+  test('it has role attribute', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{paper-radio onChange=null}}
+    `);
+
+    assert.dom('md-radio-button').hasAttribute('role');
+  });
+
+  test('it correctly sets aria-checked attribute', async function(assert) {
+    assert.expect(2);
+
+    this.set('groupValue', null);
+
+    await render(hbs`{{paper-radio value="1" groupValue=groupValue onChange=null}}`);
+
+    assert.dom('md-radio-button').hasAttribute('aria-checked', 'false');
+
+    this.set('groupValue', '1');
+
+    assert.dom('md-radio-button').hasAttribute('aria-checked', 'true');
+  });
+
+  test('it sets aria-label when ariaLabel is passed', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{paper-radio onChange=null ariaLabel="first radio button"}}`);
+
+    assert.dom('md-radio-button').hasAttribute('aria-label', 'first radio button');
+  });
 });


### PR DESCRIPTION
I've added
#### For `paper-radio-button`:
- [ ] aria-checked
- [ ] aria-label
- [ ] role

#### For `paper-radio-group`:
- [ ] role
- [ ] aria-labelledby

#### Added
- [ ] `paper-radio-group-label`

I don't like the solution with `aria-labelledby` inside the `paper-radio-group` I was thinking about creating the new component `paper-radio-group-label` which will be yielded like `labelId` and it would have passed action that will set the `aria-labelledby` on the parent radio group component. But I think that would be a bigger change from component API perspective - what do you think about that? 