### PR TITLE
paper-tabs: correct 'paginationStyle' updated twice in single render

### DIFF
--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -35,7 +35,8 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
     this.setMovingRight();
 
-    this.fixOffsetIfNeeded();
+    this.scheduleAfterRender(() =>
+      this.fixOffsetIfNeeded());
 
     this.set('_previousSelectedTab', selectedTab);
   }),
@@ -83,15 +84,11 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
     // trigger updateDimensions to calculate shouldPaginate early on
     this.updateDimensions();
-    scheduleOnce('afterRender', () => {
-      next(() => {
-        // here the previous and next buttons should already be renderd
-        // and hence the offsets are correctly calculated
-        if (!this.isDestroyed && !this.isDestroying) {
-          this.updateDimensions();
-          this.fixOffsetIfNeeded();
-        }
-      });
+    this.scheduleAfterRender(() => {
+      // here the previous and next buttons should already be rendered
+      // and hence the offsets are correctly calculated
+      this.updateDimensions();
+      this.fixOffsetIfNeeded();
     });
   },
 
@@ -105,6 +102,16 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this._super(...arguments);
     window.removeEventListener('resize', this.updateCanvasWidth);
     window.removeEventListener('orientationchange', this.updateCanvasWidth);
+  },
+
+  scheduleAfterRender(fct) {
+    scheduleOnce('afterRender', () => {
+      next(() => {
+        if (!this.isDestroying && !this.isDestroyed) {
+          fct();
+        }
+      });
+    });
   },
 
   registerChild(childComponent) {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -138,6 +138,8 @@ export default Component.extend(ParentMixin, ColorMixin, {
     } else if (tabLeftOffset < currentOffset) {
       // ensure selectedTab is not partially hidden on the left side
       newOffset = tabLeftOffset;
+    } else {
+      newOffset = 0;
     }
 
     if (newOffset === currentOffset) {


### PR DESCRIPTION
Two fixes in this PR:

- ensure `newOffset` is never undefined
- fix `paginationStyle updated twice in single render`

In my case, the later only occurred in tests. Not sure if due to the "speed" of the tests or the viewport that is much smaller and trigger more often the pagination
