### PR TITLE
Change ember-power-select version to fix broken paper-menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-get-config": "^0.2.4",
     "ember-invoke-action": "^1.5.1",
     "ember-maybe-in-element": "^0.1.3",
-    "ember-power-select": "^2.0.0",
+    "ember-power-select": "2.0.3",
     "fastboot-transform": "^0.1.3",
     "hammerjs": "^2.0.8",
     "propagating-hammerjs": "^1.4.6",


### PR DESCRIPTION
Hello, I am with the same problem described on [#1035](https://github.com/miguelcobain/ember-paper/issues/1035) issue. Following @panthony issue, I could fix the problem forcing ember-power-select version to 2.0.3.
I don't know if this is a valid pull request, it's my first one 😅. But I will try, because the project depends of ember-paper.