### PR TITLE
Trying to address paper-tabs issues

### DIFF
--- a/addon/components/paper-tab.js
+++ b/addon/components/paper-tab.js
@@ -47,6 +47,7 @@ export default Component.extend(ChildMixin, RippleMixin, FocusableMixin, {
     // this is the initial tab width
     // it is used to calculate if we need pagination or not
     this.set('width', width);
+    this.set('left', this.element.offsetLeft);
   },
 
   didRender() {

--- a/addon/components/paper-tab.js
+++ b/addon/components/paper-tab.js
@@ -41,15 +41,6 @@ export default Component.extend(ChildMixin, RippleMixin, FocusableMixin, {
     }
   },
 
-  didInsertElement() {
-    this._super(...arguments);
-    let width = this.element.offsetWidth;
-    // this is the initial tab width
-    // it is used to calculate if we need pagination or not
-    this.set('width', width);
-    this.set('left', this.element.offsetLeft);
-  },
-
   didRender() {
     this._super(...arguments);
     this.updateDimensions();

--- a/addon/components/paper-tab.js
+++ b/addon/components/paper-tab.js
@@ -41,12 +41,7 @@ export default Component.extend(ChildMixin, RippleMixin, FocusableMixin, {
     }
   },
 
-  didRender() {
-    this._super(...arguments);
-    this.updateDimensions();
-  },
-
-  // this method is also called by the parent
+  // this method is called by the parent
   updateDimensions() {
     // this is the true current width
     // it is used to calculate the ink bar position & pagination offset

--- a/addon/components/paper-tab.js
+++ b/addon/components/paper-tab.js
@@ -57,11 +57,12 @@ export default Component.extend(ChildMixin, RippleMixin, FocusableMixin, {
 
   // this method is also called by the parent
   updateDimensions() {
-    let left = this.element.offsetLeft;
     // this is the true current width
-    // it is used to calculate the ink bar position
-    let currentWidth = this.element.offsetWidth;
-    this.setProperties({ left, currentWidth });
+    // it is used to calculate the ink bar position & pagination offset
+    this.setProperties({
+      left: this.element.offsetLeft,
+      width: this.element.offsetWidth
+    });
   },
 
   click() {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -19,10 +19,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
   selected: 0, // select first tab by default
 
-  _selectedTab: computed('childComponents.@each.isSelected', function() {
-    return this.get('childComponents').findBy('isSelected');
-  }),
-
   _selectedTabDidChange: observer('_selectedTab', function() {
     let selectedTab = this.get('_selectedTab');
     let previousSelectedTab = this.get('_previousSelectedTab');
@@ -84,7 +80,19 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this._super(...arguments);
     // this makes sure that the tabs react to stretch and center changes
     // this method is also called whenever one of the tab is re-rendered (content changes)
+    this.updateSelectedTab();
     this.updateCanvasWidth();
+  },
+
+  /**
+   * Updates the currently selected tab only once all the <paper-tab> has rendered.
+   *
+   * If we were to use a computed property the observer would get triggered once per
+   * nested <paper-tab> because we pass the 'selected' property to them that will
+   * invalidate their 'isSelected' property.
+   */
+  updateSelectedTab() {
+    this.set('_selectedTab', this.get('childComponents').findBy('isSelected'));
   },
 
   willDestroyElement() {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -3,6 +3,7 @@ import { gt } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { htmlSafe } from '@ember/string';
+import { scheduleOnce } from '@ember/runloop';
 import layout from '../templates/components/paper-tabs';
 import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
@@ -61,11 +62,12 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this.updateCanvasWidth = () => {
       this.updateDimensions();
       this.updateStretchTabs();
-      this.fixOffsetIfNeeded();
     };
 
     window.addEventListener('resize', this.updateCanvasWidth);
     window.addEventListener('orientationchange', this.updateCanvasWidth);
+
+    scheduleOnce('afterRender', this, this.fixOffsetIfNeeded);
   },
 
   didRender() {
@@ -93,6 +95,8 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
     this.set('movingRight', !selectedTab || !previousSelectedTab || previousSelectedTab.get('left') < selectedTab.get('left'));
     this.set('_selectedTab', selectedTab);
+
+    scheduleOnce('afterRender', this, this.fixOffsetIfNeeded);
   },
 
   willDestroyElement() {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -43,7 +43,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
   noInkBar: false,
   noInk: false,
   ariaLabel: null,
-  previousInkBarPosition: 0,
   stretch: 'sm',
 
   inkBarLeft: computed('_selectedTab.left', function() {
@@ -52,10 +51,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
   inkBarRight: computed('wrapperWidth', '_selectedTab.currentWidth', 'inkBarLeft', function() {
     return this.get('wrapperWidth') - this.get('inkBarLeft') - (this.get('_selectedTab.currentWidth') || 0);
-  }),
-
-  tabsWidth: computed('childComponents.@each.width', function() {
-    return this.get('childComponents').reduce((prev, t) => prev + t.get('width'), 0);
   }),
 
   shouldPaginate: false,

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -3,7 +3,6 @@ import { gt } from '@ember/object/computed';
 import { computed, observer } from '@ember/object';
 import Component from '@ember/component';
 import { htmlSafe } from '@ember/string';
-import { scheduleOnce, next } from '@ember/runloop';
 import layout from '../templates/components/paper-tabs';
 import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -41,6 +41,10 @@ export default Component.extend(ParentMixin, ColorMixin, {
     };
   }),
 
+  paginationStyle: computed('currentOffset', function() {
+    return htmlSafe(`transform: translate3d(-${this.get('currentOffset')}px, 0px, 0px);`);
+  }),
+
   shouldPaginate: true,
 
   shouldCenter: computed('shouldPaginate', 'center', function() {
@@ -132,7 +136,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
     }
 
     this.set('currentOffset', newOffset);
-    this.set('paginationStyle', htmlSafe(`transform: translate3d(-${newOffset}px, 0px, 0px);`));
   },
 
   updateDimensions() {
@@ -174,7 +177,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
       if (tab) {
         let left = Math.max(0, tab.get('left') - this.get('canvasWidth'));
         this.set('currentOffset', left);
-        this.set('paginationStyle', htmlSafe(`transform: translate3d(-${left}px, 0px, 0px);`));
       }
     },
 
@@ -184,7 +186,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
       });
       if (tab) {
         this.set('currentOffset', tab.get('left'));
-        this.set('paginationStyle', htmlSafe(`transform: translate3d(-${tab.get('left')}px, 0px, 0px);`));
       }
     },
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -61,7 +61,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     };
   }),
 
-  shouldPaginate: false,
+  shouldPaginate: true,
 
   shouldCenter: computed('shouldPaginate', 'center', function() {
     return !this.get('shouldPaginate') && this.get('center');
@@ -160,8 +160,8 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this.set('canvasWidth', canvasWidth);
     this.set('wrapperWidth', wrapperWidth);
 
-    if (wrapperWidth > canvasWidth) {
-      this.set('shouldPaginate', true);
+    if (wrapperWidth <= canvasWidth) {
+      this.set('shouldPaginate', false);
     }
   },
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -45,12 +45,20 @@ export default Component.extend(ParentMixin, ColorMixin, {
   ariaLabel: null,
   stretch: 'sm',
 
-  inkBarLeft: computed('_selectedTab.left', function() {
-    return this.get('_selectedTab.left') || 0;
-  }),
+  inkBar: computed('noInkBar', '_selectedTab.{currentWidth,left}', 'wrapperWidth', function() {
+    if (this.get('noInkBar')) {
+      return null;
+    }
 
-  inkBarRight: computed('wrapperWidth', '_selectedTab.currentWidth', 'inkBarLeft', function() {
-    return this.get('wrapperWidth') - this.get('inkBarLeft') - (this.get('_selectedTab.currentWidth') || 0);
+    let selectedTab = this.get('_selectedTab');
+    if (!selectedTab || selectedTab.get('left') === undefined) {
+      return null;
+    }
+
+    return {
+      left: selectedTab.get('left'),
+      right: this.get('wrapperWidth') - selectedTab.get('left') - selectedTab.get('currentWidth')
+    };
   }),
 
   shouldPaginate: false,

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -141,6 +141,8 @@ export default Component.extend(ParentMixin, ColorMixin, {
     } else if (tabLeftOffset < currentOffset) {
       // ensure selectedTab is not partially hidden on the left side
       newOffset = tabLeftOffset;
+    } else {
+      newOffset = 0;
     }
 
     if (newOffset === currentOffset) {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -182,7 +182,8 @@ export default Component.extend(ParentMixin, ColorMixin, {
   actions: {
     previousPage() {
       let tab = this.get('childComponents').find((t) => {
-        return t.get('left') >= this.get('currentOffset');
+        // ensure we are no stuck because of a tab with a width > canvasWidth
+        return (t.get('left') + t.get('width')) >= this.get('currentOffset');
       });
       if (tab) {
         let left = Math.max(0, tab.get('left') - this.get('canvasWidth'));

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -192,7 +192,11 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
     nextPage() {
       let tab = this.get('childComponents').find((t) => {
-        return t.get('left') + t.get('width') - this.get('currentOffset') > this.get('canvasWidth');
+        // ensure tab's offset is greater than current
+        // otherwise if the tab's width is greater than canvas we cannot paginate through it
+        return t.get('left') > this.get('currentOffset')
+          // paginate until the first partially hidden tab
+          && t.get('left') + t.get('width') - this.get('currentOffset') > this.get('canvasWidth');
       });
       if (tab) {
         this.set('currentOffset', tab.get('left'));

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -87,6 +87,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
   didRender() {
     this._super(...arguments);
     // this makes sure that the tabs react to stretch and center changes
+    // this method is also called whenever one of the tab is re-rendered (content changes)
     this.updateCanvasWidth();
   },
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -35,8 +35,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
     this.setMovingRight();
 
-    this.fixOffsetIfNeeded();
-
     this.set('_previousSelectedTab', selectedTab);
   }),
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -142,7 +142,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
       // ensure selectedTab is not partially hidden on the left side
       newOffset = tabLeftOffset;
     } else {
-      newOffset = 0;
+      newOffset = currentOffset;
     }
 
     if (newOffset === currentOffset) {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -45,7 +45,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
   ariaLabel: null,
   stretch: 'sm',
 
-  inkBar: computed('noInkBar', '_selectedTab.{currentWidth,left}', 'wrapperWidth', function() {
+  inkBar: computed('noInkBar', '_selectedTab.{width,left}', 'wrapperWidth', function() {
     if (this.get('noInkBar')) {
       return null;
     }
@@ -57,7 +57,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
     return {
       left: selectedTab.get('left'),
-      right: this.get('wrapperWidth') - selectedTab.get('left') - selectedTab.get('currentWidth')
+      right: this.get('wrapperWidth') - selectedTab.get('left') - selectedTab.get('width')
     };
   }),
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -115,6 +115,10 @@ export default Component.extend(ParentMixin, ColorMixin, {
   },
 
   fixOffsetIfNeeded() {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
     let canvasWidth = this.get('canvasWidth');
     let currentOffset = this.get('currentOffset');
 

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -3,7 +3,7 @@ import { gt } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { htmlSafe } from '@ember/string';
-import { scheduleOnce } from '@ember/runloop';
+import { scheduleOnce, join } from '@ember/runloop';
 import layout from '../templates/components/paper-tabs';
 import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
@@ -60,8 +60,10 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this._super(...arguments);
 
     this.updateCanvasWidth = () => {
-      this.updateDimensions();
-      this.updateStretchTabs();
+      join(() => {
+        this.updateDimensions();
+        this.updateStretchTabs();
+      });
     };
 
     window.addEventListener('resize', this.updateCanvasWidth);

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -74,28 +74,14 @@ export default Component.extend(ParentMixin, ColorMixin, {
   didInsertElement() {
     this._super(...arguments);
 
-    let updateCanvasWidth = () => {
+    this.updateCanvasWidth = () => {
       this.updateDimensions();
       this.updateStretchTabs();
       this.fixOffsetIfNeeded();
     };
 
-    window.addEventListener('resize', updateCanvasWidth);
-    window.addEventListener('orientationchange', updateCanvasWidth);
-    this.updateCanvasWidth = updateCanvasWidth;
-
-    // trigger updateDimensions to calculate shouldPaginate early on
-    this.updateDimensions();
-    scheduleOnce('afterRender', () => {
-      next(() => {
-        // here the previous and next buttons should already be renderd
-        // and hence the offsets are correctly calculated
-        if (!this.isDestroyed && !this.isDestroying) {
-          this.updateDimensions();
-          this.fixOffsetIfNeeded();
-        }
-      });
-    });
+    window.addEventListener('resize', this.updateCanvasWidth);
+    window.addEventListener('orientationchange', this.updateCanvasWidth);
   },
 
   didRender() {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -26,15 +26,13 @@ export default Component.extend(ParentMixin, ColorMixin, {
 
   _selectedTabDidChange: observer('_selectedTab', function() {
     let selectedTab = this.get('_selectedTab');
-
     let previousSelectedTab = this.get('_previousSelectedTab');
 
-    if (selectedTab === previousSelectedTab) {
+    if (!selectedTab || selectedTab === previousSelectedTab) {
       return;
     }
 
-    this.setMovingRight();
-
+    this.set('movingRight', !previousSelectedTab || previousSelectedTab.get('left') < selectedTab.get('left'));
     this.set('_previousSelectedTab', selectedTab);
   }),
 
@@ -42,6 +40,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
   noInk: false,
   ariaLabel: null,
   stretch: 'sm',
+  movingRight: true,
 
   inkBar: computed('noInkBar', '_selectedTab.{width,left}', 'wrapperWidth', function() {
     if (this.get('noInkBar')) {
@@ -102,11 +101,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
       let length = this.childComponents.get('length');
       childComponent.set('value', length - 1);
     }
-  },
-
-  setMovingRight() {
-    let movingRight = this.get('_previousSelectedTab.left') < this.get('_selectedTab.left');
-    this.set('movingRight', movingRight);
   },
 
   fixOffsetIfNeeded() {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -159,10 +159,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this.get('childComponents').invoke('updateDimensions');
     this.set('canvasWidth', canvasWidth);
     this.set('wrapperWidth', wrapperWidth);
-
-    if (wrapperWidth <= canvasWidth) {
-      this.set('shouldPaginate', false);
-    }
+    this.set('shouldPaginate', wrapperWidth > canvasWidth);
   },
 
   updateStretchTabs() {

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import { gt } from '@ember/object/computed';
-import { computed, observer } from '@ember/object';
+import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { htmlSafe } from '@ember/string';
 import layout from '../templates/components/paper-tabs';
@@ -18,18 +18,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
   constants: service(),
 
   selected: 0, // select first tab by default
-
-  _selectedTabDidChange: observer('_selectedTab', function() {
-    let selectedTab = this.get('_selectedTab');
-    let previousSelectedTab = this.get('_previousSelectedTab');
-
-    if (!selectedTab || selectedTab === previousSelectedTab) {
-      return;
-    }
-
-    this.set('movingRight', !previousSelectedTab || previousSelectedTab.get('left') < selectedTab.get('left'));
-    this.set('_previousSelectedTab', selectedTab);
-  }),
 
   noInkBar: false,
   noInk: false,
@@ -92,7 +80,15 @@ export default Component.extend(ParentMixin, ColorMixin, {
    * invalidate their 'isSelected' property.
    */
   updateSelectedTab() {
-    this.set('_selectedTab', this.get('childComponents').findBy('isSelected'));
+    let selectedTab = this.get('childComponents').findBy('isSelected');
+    let previousSelectedTab = this.get('_selectedTab');
+
+    if (selectedTab === previousSelectedTab) {
+      return;
+    }
+
+    this.set('movingRight', !selectedTab || !previousSelectedTab || previousSelectedTab.get('left') < selectedTab.get('left'));
+    this.set('_selectedTab', selectedTab);
   },
 
   willDestroyElement() {

--- a/addon/templates/components/paper-tabs.hbs
+++ b/addon/templates/components/paper-tabs.hbs
@@ -20,9 +20,9 @@
         )
       )}}
 
-      {{#unless noInkBar}}
-        {{paper-ink-bar movingRight=movingRight left=inkBarLeft right=inkBarRight}}
-      {{/unless}}
+      {{#if inkBar}}
+        {{paper-ink-bar movingRight=movingRight left=inkBar.left right=inkBar.right}}
+      {{/if}}
 
     </md-pagination-wrapper>
   </md-tabs-canvas>

--- a/tests/integration/components/paper-tabs-test.js
+++ b/tests/integration/components/paper-tabs-test.js
@@ -160,6 +160,27 @@ module('Integration | Component | paper tabs', function(hooks) {
     assert.notOk(find('md-ink-bar'));
   });
 
+  test('ink bar has md-left or md-right class', async function(assert) {
+      await render(hbs`
+        {{#paper-tabs as |tabs|}}
+          {{tabs.tab name="Tab one"}}
+          {{tabs.tab name="Tab two"}}
+          {{tabs.tab name="Tab three"}}
+        {{/paper-tabs}}
+      `);
+
+    assert.dom('md-ink-bar').hasClass('md-right');
+
+    await click('.md-tab:nth-child(2)');
+
+    assert.dom('md-ink-bar').hasClass('md-right');
+
+    await click('.md-tab:nth-child(1)');
+
+    assert.dom('md-ink-bar').hasClass('md-left');
+
+  });
+
   test('borderBottom true adds border', async function(assert) {
     await render(hbs`
       {{#paper-tabs borderBottom=true as |tabs|}}

--- a/tests/integration/components/paper-tabs-test.js
+++ b/tests/integration/components/paper-tabs-test.js
@@ -161,7 +161,7 @@ module('Integration | Component | paper tabs', function(hooks) {
   });
 
   test('ink bar has md-left or md-right class', async function(assert) {
-      await render(hbs`
+    await render(hbs`
         {{#paper-tabs as |tabs|}}
           {{tabs.tab name="Tab one"}}
           {{tabs.tab name="Tab two"}}


### PR DESCRIPTION
Hopefully:

- Superseed #982 
- Fixes #858
- Fixes #759 
- Fixes #893 


I'm trying to take a fresh start at paper tabs offsets handling as they are may issues at the moment.

If they are things that I'm missing feel free to tell me.

Amongs the hopefully fixed issues:

- infinite rendering
- movingRight that is not properly set
- currentOffset that may not be set
- inkBar that may be rendered without proper left/right offset
- lot's of (I think) unnecessary 'updateXXX' calls

Issues yet to be fixed:

- when you paginate, it triggers a re-render that eventually calls 'fixOffset' which 'cancel' the pagination because it caused the selected tab to be partially hidden :sob:

**edit**:

To correct this 'fixOffset' issue that breaks the pagination I now call it in only 2 cases:

- upon first render to ensure the selected tab is visible
- upon selected tab update to put the whole tab in focus

I'm not calling it anymore in 'didRender' which means that if the tab's label is updated while selected it might become partially hidden but this is way WAY minor IMO.


**edit²**:

Unfortunately I do not have time for this right away but I think we should add some tests with a wrapper around "paper-tabs" with a small max width, to ensure that we can still paginate around.