### PR TITLE
Fix paper select click-catcher to call dropdown.actions.close on click

### DIFF
--- a/addon/templates/components/paper-select-content.hbs
+++ b/addon/templates/components/paper-select-content.hbs
@@ -1,11 +1,6 @@
 {{#if dropdown.isOpen}}
   {{#maybe-in-element destinationEl renderInPlace}}
-    {{!-- we already have our own paper-backdrop
-      {{#if overlay}}
-        <div class="ember-basic-dropdown-overlay"></div>
-      {{/if}}
-    --}}
-    {{paper-backdrop class="md-select-backdrop md-click-catcher"}}
+    {{paper-backdrop class="md-select-backdrop md-click-catcher" onClick=(action dropdown.actions.close)}}
     <div
       id={{dropdownId}}
       class="ember-basic-dropdown-content {{class}} {{if renderInPlace "ember-basic-dropdown-content--in-place"}} {{if hPosition (concat "ember-basic-dropdown-content--" hPosition)}} {{if vPosition (concat "ember-basic-dropdown-content--" vPosition)}}


### PR DESCRIPTION
In a project where I'm using the latest beta of ember-paper, I noticed my paper selects were not closing when clicking outside the menu options area. Seems the paper-backdrop does not have the onClick value set. Making it call the dropdown.actions.close fixed the issue as per this PR.

Not 100% sure if I'm using the component somehow wrong as in the demo it seems to work. In any case, if this fix is relevant do merge this in - if not, ignore! Thanks for all the work on this. :)