### PR TITLE
Add support for some aria-attributes on paper-button

### DIFF
--- a/addon/components/paper-button.js
+++ b/addon/components/paper-button.js
@@ -36,7 +36,10 @@ export default Component.extend(FocusableMixin, RippleMixin, ColorMixin, Proxiab
     'target',
     'title',
     'download',
-    'rel'
+    'rel',
+    'ariaLabel:aria-label',
+    'labelId:aria-labelledby',
+    'descriptionId:aria-describedby'
   ],
   classNameBindings: [
     'raised:md-raised',

--- a/tests/dummy/app/templates/demo/button.hbs
+++ b/tests/dummy/app/templates/demo/button.hbs
@@ -66,6 +66,12 @@
       (p-row "raised" "boolean" "Display button with a 3-D effect.")
     )
     "color"
+    (p-section
+      "Accessibility"
+      (p-row "ariaLabel" "string" "Set aria-label property on the button (an additional label which is not visible on the screen).")
+      (p-row "labelId" "string" "Set aria-labelledby property on the button. It should contain one or more Ids of the elements that have the text needed for labeling.")
+      (p-row "descriptionId" "string" "Set aria-describedby property on the button. It should contain Ids of the elements that describe the object.")
+    )
   }}
 
 {{/doc-content}}

--- a/tests/integration/components/paper-button-test.js
+++ b/tests/integration/components/paper-button-test.js
@@ -121,4 +121,20 @@ module('Integration | Component | paper-button', function(hooks) {
     assert.dom('a.md-button').exists({ count: 1 });
     assert.dom('a.md-button').hasAttribute('target', '_blank');
   });
+
+  test('it sets aria-label when ariaLabel is passed', async function(assert) {
+    await render(hbs`{{paper-button onChange=null value=true ariaLabel="test label"}}`);
+    assert.dom('.md-button').hasAttribute('aria-label', 'test label');
+  });
+
+  test('it sets aria-labelledby when labelId is passed', async function(assert) {
+    await render(hbs`{{paper-button onChange=null value=true labelId="buttonTestLabel"}}`);
+    assert.dom('.md-button').hasAttribute('aria-labelledby', 'buttonTestLabel');
+  });
+
+  test('it sets aria-describedby when descriptionId is passed', async function(assert) {
+    await render(hbs`{{paper-button onChange=null value=true descriptionId="buttonDescription"}}`);
+    assert.dom('.md-button').hasAttribute('aria-describedby', 'buttonDescription');
+  });
+
 });


### PR DESCRIPTION
- [x] - aria-label
- [x] - aria-labelledby
- [x] - aria-describedby
- [x] - updated description in demo accordingly