### PR TITLE
Demo and docs for shortly added accessibility features

### DIFF
--- a/tests/dummy/app/controllers/demo/radio.js
+++ b/tests/dummy/app/controllers/demo/radio.js
@@ -3,6 +3,7 @@ import Controller from '@ember/controller';
 export default Controller.extend({
 
   selectedFruit: 'Apple',
-  selectedGraphic: 'graphic-1'
+  selectedGraphic: 'graphic-1',
+  selectedAccessibilityLevel: 'middle'
 
 });

--- a/tests/dummy/app/templates/demo/checkbox.hbs
+++ b/tests/dummy/app/templates/demo/checkbox.hbs
@@ -38,4 +38,12 @@
   <h3>Template</h3>
   {{code-snippet name="checkbox.hbs"}}
 
+  {{paper-api
+    (p-section
+    "Accessibility"
+      (p-row "ariaLabel" "string" "Sets aria-label on the checkbox. It's only reasonable if the new label is not visible on the page.")
+      (p-row "labelId" "string" "Sets aria-labelledby on the checkbox. It usually contains one or more Ids of the elements that have the text needed for labeling.")
+    )
+  }}
+
 {{/doc-content}}

--- a/tests/dummy/app/templates/demo/icons.hbs
+++ b/tests/dummy/app/templates/demo/icons.hbs
@@ -38,4 +38,11 @@
     {{! END-SNIPPET }}
   </div>
   {{code-snippet name="icons.spinners.hbs"}}
+
+  {{paper-api
+    (p-section
+    "Accessibility"
+      (p-row "aria-hidden" "boolean" "Sets aria-hidden property. 'True' prevents screen reader from reading the icon text.")
+    )
+  }}
 {{/doc-content}}

--- a/tests/dummy/app/templates/demo/radio.hbs
+++ b/tests/dummy/app/templates/demo/radio.hbs
@@ -74,6 +74,35 @@
       <h3>Template</h3>
       {{code-snippet name="radio.images.hbs"}}
 
+
+      <p>
+        Accessible radio group
+      </p>
+      {{! BEGIN-SNIPPET radio.accessibility }}
+      {{#paper-radio-group
+         groupValue=selectedAccessibilityLevel
+         onChange=(action (mut selectedAccessibilityLevel)) as |group|}}
+        {{group.label text="Accessibility level"}}
+        {{#group.radio
+            toggle=true
+            tabindex=0
+            value="middle"
+        }}Middle
+          {{/group.radio}}
+        {{#group.radio
+          toggle=true
+          tabindex=0
+          value="high"
+        }}High
+          {{/group.radio}}
+      {{/paper-radio-group}}
+      {{! END-SNIPPET }}
+
+      <h3>Template</h3>
+      {{code-snippet name="radio.accessibility.hbs"}}
+
+      In order to make a radio group accessible, make sure to set tabindex=0 on each option and include a label element into the group.
+
     {{/paper-card-content}}
   {{/paper-card}}
 {{/doc-content}}


### PR DESCRIPTION
Added description of following accessibility features into doc pages:

- aria-hidden on paper-icon
- aria-label and aria-labelledby on paper-checkbox
- accessibility of radio groups