### PR TITLE
add little github icon in demo toolbar

### DIFF
--- a/tests/dummy/app/styles/demo.scss
+++ b/tests/dummy/app/styles/demo.scss
@@ -185,6 +185,24 @@ md-toolbar.md-default-theme.page-main-toolbar {
   }
 }
 
+.nav-github {
+  vertical-align: middle;
+  display: inline-block;
+
+  &, &-icon {
+    width: 22px;
+    height: 22px;
+  }
+
+  &, &:hover {
+    border-bottom: 0;
+    text-underline: none;
+  }
+
+  opacity: .7;
+  &:hover { opacity: 1; }
+}
+
 
 .demo-header-searchbox {
   border: none;

--- a/tests/dummy/app/templates/components/page-toolbar.hbs
+++ b/tests/dummy/app/templates/components/page-toolbar.hbs
@@ -5,16 +5,29 @@
         {{paper-icon "menu"}}
       {{/paper-button}}
     {{/paper-sidenav-toggle}}
-    <h2>
-      {{#if isDemo}}
-        Components {{paper-icon "chevron-right"}}
-      {{else if isLayout}}
-        Layout {{paper-icon "chevron-right"}}
-      {{/if}}
-      {{pageTitle}}
-      {{#if isWIP}}
-        {{paper-icon "warning" title="Not updated yet."}}
-      {{/if}}
-    </h2>
+    <div class="layout-row flex">
+      <h2>
+        {{#if isDemo}}
+          Components {{paper-icon "chevron-right"}}
+        {{else if isLayout}}
+          Layout {{paper-icon "chevron-right"}}
+        {{/if}}
+        {{pageTitle}}
+        {{#if isWIP}}
+          {{paper-icon "warning" title="Not updated yet."}}
+        {{/if}}
+      </h2>
+
+      <div class="flex"></div>
+
+      <div class="flex-nogrow">
+        <a href="https://github.com/miguelcobain/ember-paper" target="_blank" rel="noopener" aria-label="GitHub" class="nav-github">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 499.36" focusable="false" class="nav-github-icon">
+            <title>GitHub</title>
+            <path d="M256 0C114.64 0 0 114.61 0 256c0 113.09 73.34 209 175.08 242.9 12.8 2.35 17.47-5.56 17.47-12.34 0-6.08-.22-22.18-.35-43.54-71.2 15.49-86.2-34.34-86.2-34.34-11.64-29.57-28.42-37.45-28.42-37.45-23.27-15.84 1.73-15.55 1.73-15.55 25.69 1.81 39.21 26.38 39.21 26.38 22.84 39.12 59.92 27.82 74.5 21.27 2.33-16.54 8.94-27.82 16.25-34.22-56.84-6.43-116.6-28.43-116.6-126.49 0-27.95 10-50.8 26.35-68.69-2.63-6.48-11.42-32.5 2.51-67.75 0 0 21.49-6.88 70.4 26.24a242.65 242.65 0 0 1 128.18 0c48.87-33.13 70.33-26.24 70.33-26.24 14 35.25 5.18 61.27 2.55 67.75 16.41 17.9 26.31 40.75 26.31 68.69 0 98.35-59.85 120-116.88 126.32 9.19 7.9 17.38 23.53 17.38 47.41 0 34.22-.31 61.83-.31 70.23 0 6.85 4.61 14.81 17.6 12.31C438.72 464.97 512 369.08 512 256.02 512 114.62 397.37 0 256 0z" fill="currentColor" fill-rule="evenodd"></path>
+          </svg>
+        </a>
+      </div>
+    </div>
   {{/toolbar.tools}}
 {{/paper-toolbar}}


### PR DESCRIPTION
The idea is to have a more visible link between the demo website and the github repository.

![capture d ecran 2019-01-24 a 09 51 22](https://user-images.githubusercontent.com/230462/51666307-d4bdcf80-1fbd-11e9-8cf3-16efd74114c5.png)
