### PR TITLE
Fix tab pagination controls

### DIFF
--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -74,7 +74,6 @@ export default Component.extend(ParentMixin, ColorMixin, {
     let updateCanvasWidth = () => {
       this.updateDimensions();
       this.updateStretchTabs();
-      this.fixOffsetIfNeeded();
     };
 
     window.addEventListener('resize', updateCanvasWidth);
@@ -128,7 +127,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     let tabLeftOffset = this.get('_selectedTab.left');
     let tabRightOffset = tabLeftOffset + this.get('_selectedTab.width');
 
-    let newOffset;
+    let newOffset = currentOffset;
     if (canvasWidth < this.get('_selectedTab.width')) {
       // align with selectedTab if canvas smaller than selected tab
       newOffset = tabLeftOffset;


### PR DESCRIPTION
Fixes #1063.

There were two main issues:
- `fixOffsetIfNeeded()` had been added into `updateCanvasWidth`, so it was being called on every render.  This means that it ran after the `nextPage` action, and effectively reverted the pagination offset change because it doesn't know/care about pagination (only the selected tab)
- `fixOffsetIfNeeded()` was setting `this.currentOffset` to `undefined` in some situations, which then prevented pagination from working as it's used in calculations

In order to address these issues, I've removed `fixOffsetIfNeeded()` from `updateCanvasWidth` (it seems to be being called directly where needed already) and defaulted `newOffset` to `currentOffset` in `fixOffsetIfNeeded()`.  I've done some manual testing in addition to running the automated tests, and all seems well.
