### PR TITLE
Fix delay in transition at scale speed dial

### DIFF
--- a/addon/components/paper-speed-dial-actions-action.js
+++ b/addon/components/paper-speed-dial-actions-action.js
@@ -46,7 +46,7 @@ export default Component.extend({
 
     let opacity = open ? 1 : 0;
     let transform = open ? 'scale(1)' : 'scale(0)';
-    let transitionDelay = `${open ? offsetDelay : items.length - offsetDelay}ms`;
+    let transitionDelay = `${open ? offsetDelay : (items.length * delay) - offsetDelay}ms`;
 
     // Make the items closest to the trigger have the highest z-index
     let zIndex = (items.length - index) + startZIndex;

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -74,7 +74,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     let updateCanvasWidth = () => {
       this.updateDimensions();
       this.updateStretchTabs();
-      this.fixOffsetIfNeeded();
+      this.fixOffsetIfNeeded(true);
     };
 
     window.addEventListener('resize', updateCanvasWidth);
@@ -119,21 +119,23 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this.set('movingRight', movingRight);
   },
 
-  fixOffsetIfNeeded() {
+  fixOffsetIfNeeded(skipFocus = false) {
     let canvasWidth = this.get('canvasWidth');
     let currentOffset = this.get('currentOffset');
 
-    let tabRight = this.get('_selectedTab.left') + this.get('_selectedTab.width');
-    if (tabRight - currentOffset > canvasWidth) {
-      let newOffset = tabRight - canvasWidth;
-      this.set('currentOffset', newOffset);
-      this.set('paginationStyle', htmlSafe(`transform: translate3d(-${newOffset}px, 0px, 0px);`));
-    }
+    if (!skipFocus) {
+      let tabRight = this.get('_selectedTab.left') + this.get('_selectedTab.width');
+      if (tabRight - currentOffset > canvasWidth) {
+        let newOffset = tabRight - canvasWidth;
+        this.set('currentOffset', newOffset);
+        this.set('paginationStyle', htmlSafe(`transform: translate3d(-${newOffset}px, 0px, 0px);`));
+      }
 
-    if (this.get('_selectedTab.left') < currentOffset) {
-      let newOffset = this.get('_selectedTab.left');
-      this.set('currentOffset', newOffset);
-      this.set('paginationStyle', htmlSafe(`transform: translate3d(-${newOffset}px, 0px, 0px);`));
+      if (this.get('_selectedTab.left') < currentOffset) {
+        let newOffset = this.get('_selectedTab.left');
+        this.set('currentOffset', newOffset);
+        this.set('paginationStyle', htmlSafe(`transform: translate3d(-${newOffset}px, 0px, 0px);`));
+      }
     }
   },
 


### PR DESCRIPTION
Speed dial has wrong calculation when animation is "Scale".

The calculation of the delay is negative and it prevents click actions because the close animation start and the negative delay buttons disappear immediately so the release button event/action never trigger.