### PR TITLE
Fix backdrop-bug

### DIFF
--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -21,7 +21,10 @@ export default Component.extend(TransitionMixin, {
   attributeBindings: ['backdropStyle:style'],
 
   // TransitionMixin:
-  transitionName: 'ng',
+  transitionName: computed('shouldTransition', function() {
+    // TransitionMixin is NoOp if transitionName is not given
+    return this.get('shouldTransition') ? 'ng' : null;
+  }),
   shouldTransition: bool('opaque'),
 
   backdropStyle: computed('fixed', function() {


### PR DESCRIPTION
When using multiple components that have an invisible background (like paper-menu) paper-backdrop seems to remain on the page and capture clicks.  After looking through issues I found issue #925 where @panthony mentioned a work around but never offered it as a PR.  I'm doing that for him because this issue is annoying.