### PR TITLE
Add guard against missing original.parentNode

### DIFF
--- a/addon/components/paper-backdrop.js
+++ b/addon/components/paper-backdrop.js
@@ -29,7 +29,9 @@ export default Component.extend(TransitionMixin, {
   }),
 
   addDestroyedElementClone(original, clone) {
-    original.parentNode.appendChild(clone);
+    if (original.parentNode) {
+      original.parentNode.appendChild(clone);
+    }
   },
 
   sendClickAction(e) {


### PR DESCRIPTION
This is a naïve fix for a problem I was experiencing in tests after updating Ember Paper, you can see an example here:
https://travis-ci.org/backspace/prison-rideshare-ui/builds/530523899#L578

It seems somewhat akin to what’s discussed in #925, but I’m definitely at the limit of my understanding of what’s happening. I only encountered this problem in tests.

Let me know if I can provide any details from the application that might help solve this differently.