### PR TITLE
Missing dependency for paper-autocomplete

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const componentDependencies = {
       'components/autocomplete/autocomplete-theme.scss'
     ],
     dependencies: [
+      'paper-autocomplete-trigger-container',
       'paper-autocomplete-trigger',
       'paper-autocomplete-options',
       'paper-autocomplete-highlight',


### PR DESCRIPTION
I noticed this dep was missing for paper-autocomplete... `paper-autocomplete-trigger-container`