### PR TITLE
bump ember-composability-tools to v0.0.12 to fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-polyfill-importer": "^0.0.2",
     "ember-cli-sass": "^7.2.0",
-    "ember-composability-tools": "^0.0.11",
+    "ember-composability-tools": "^0.0.12",
     "ember-css-transitions": "^0.1.15",
     "ember-get-config": "^0.2.4",
     "ember-invoke-action": "^1.5.1",


### PR DESCRIPTION
ember-paper is causing deprecation warnings for computed property overrides. The issue is stemming from `ember-composability-tools` and is fixed in version of v0.0.12 of that package. The related issue is [here](https://github.com/miguelcobain/ember-composability-tools/issues/23).