### PR TITLE
Add support of node 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "8.* || >= 10.* || >= 12.*"
   },
   "bugs": {
     "url": "https://github.com/miguelcobain/ember-paper/issues"
@@ -67,7 +67,7 @@
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-polyfill-importer": "^0.0.2",
-    "ember-cli-sass": "^7.2.0",
+    "ember-cli-sass": "^9.0.1",
     "ember-composability-tools": "^0.0.11",
     "ember-css-transitions": "^0.1.15",
     "ember-get-config": "^0.2.4",
@@ -80,6 +80,7 @@
     "polyfill-nodelist-foreach": "^1.0.1",
     "propagating-hammerjs": "^1.4.6",
     "resolve": "^1.5.0",
+    "sass": "^1.14.3",
     "tinycolor2": "^1.4.1",
     "virtual-each": "~0.6.0"
   },


### PR DESCRIPTION
```
~ $ node -v
v12.8.0
```

```
~ $ npm test

> ember-paper@1.0.0-beta.26 test 
> ember test

Environment: test
cleaning up...
Built project successfully.
# tests 713
# pass  713
# skip  0
# fail  0

# ok
```