### PR TITLE
fix: correct import for closest polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ module.exports = {
         caniuse: 'classlist'
       },
       'element-closest': {
-        files: ['browser.js'],
+        files: ['element-closest.js'],
         caniuse: 'element-closest'
       },
       'matchmedia-polyfill': {


### PR DESCRIPTION
Closes #1100 

Couldn't find a trace of any `browser.js` in element-closest