### PR TITLE
[CLEAN] Fix delay in transition at scale speed dial

### DIFF
--- a/addon/components/paper-speed-dial-actions-action.js
+++ b/addon/components/paper-speed-dial-actions-action.js
@@ -46,7 +46,7 @@ export default Component.extend({
 
     let opacity = open ? 1 : 0;
     let transform = open ? 'scale(1)' : 'scale(0)';
-    let transitionDelay = `${open ? offsetDelay : items.length - offsetDelay}ms`;
+    let transitionDelay = `${open ? offsetDelay : (items.length * delay) - offsetDelay}ms`;
 
     // Make the items closest to the trigger have the highest z-index
     let zIndex = (items.length - index) + startZIndex;


### PR DESCRIPTION
Clean PR for #1072 credits to @woohoou

Speed dial has wrong calculation when animation is "Scale".

The calculation of the delay is negative and it prevents click actions because the close animation start and the negative delay buttons disappear immediately so the release button event/action never trigger.