### PR TITLE
Fix paper-progress-circular test

### DIFF
--- a/tests/integration/components/paper-progress-circular-test.js
+++ b/tests/integration/components/paper-progress-circular-test.js
@@ -38,9 +38,10 @@ module('Integration | Component | paper progress circular', function(hooks) {
     assert.dom('md-progress-circular').hasAttribute('style', /height:.*25px/);
     assert.dom('md-progress-circular').hasAttribute('style', /width:.*25px/);
 
+    await waitUntil(() => find('md-progress-circular > svg > path[transform]'));
     let path = find('md-progress-circular > svg > path');
 
-    await waitUntil(() => find('md-progress-circular > svg > path[transform]'));
+    await settled();
 
     assert.dom(path).hasAttribute('transform', 'rotate(0 12.5 12.5)', 'rotated halfway');
 

--- a/tests/integration/components/paper-progress-circular-test.js
+++ b/tests/integration/components/paper-progress-circular-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, find } from '@ember/test-helpers';
+import { render, settled, find, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | paper progress circular', function(hooks) {
@@ -40,7 +40,7 @@ module('Integration | Component | paper progress circular', function(hooks) {
 
     let path = find('md-progress-circular > svg > path');
 
-    await settled();
+    await waitUntil(() => find('md-progress-circular > svg > path[transform]'));
 
     assert.dom(path).hasAttribute('transform', 'rotate(0 12.5 12.5)', 'rotated halfway');
 


### PR DESCRIPTION
The transform may arrived a few milliseconds later
Using waitFor prevent query the selector before the transform.