### PR TITLE
remove unnecesary "fn" helper

### DIFF
--- a/addon/components/paper-autocomplete/ebd-content/template.hbs
+++ b/addon/components/paper-autocomplete/ebd-content/template.hbs
@@ -15,7 +15,7 @@
   @otherStyles={{this.customStyles}}
 
   @htmlTag="md-virtual-repeat-container"
-  @shouldReposition={{fn this.shouldReposition}}
+  @shouldReposition={{this.shouldReposition}}
   class="md-virtual-repeat-container md-autocomplete-suggestions-container"
 
   ...attributes>

--- a/addon/components/paper-autocomplete/eps-trigger/template.hbs
+++ b/addon/components/paper-autocomplete/eps-trigger/template.hbs
@@ -10,7 +10,7 @@
       @required={{@extra.required}}
       @passThru={{@extra.passThru}}
       @disabled={{@select.disabled}}
-      @onChange={{fn this._onInput}}
+      @onChange={{this._onInput}}
       @onFocus={{@onFocus}}
       @onBlur={{@onBlur}}
       @onKeyDown={{@onKeydown}}

--- a/addon/components/paper-autocomplete/template.hbs
+++ b/addon/components/paper-autocomplete/template.hbs
@@ -1,7 +1,7 @@
 <PowerSelect
   @selected={{@selected}}
   @options={{@options}}
-  @onChange={{fn this._onChange}}
+  @onChange={{this._onChange}}
   @disabled={{@disabled}}
   @placeholder={{@placeholder}}
   @searchEnabled={{@searchEnabled}}
@@ -18,20 +18,20 @@
   @matcher={{@matcher}}
   @eventType={{@eventType}}
 
-  @calculatePosition={{fn this.calculatePosition}}
+  @calculatePosition={{this.calculatePosition}}
   @extra={{hash label=@label labelPath=@labelPath required=@required passThru=@passThru inputClass=@inputClass}}
   @_ebdTriggerComponent={{component "paper-autocomplete/ebd-trigger" label=@label disabled=@disabled}}
   @triggerComponent={{component "paper-autocomplete/eps-trigger" isTouched=this.isTouched hideAllMessages=@hideAllMessages validationErrorMessages=@validationErrorMessages errors=@errors}}
 
   @_ebdContentComponent={{component "paper-autocomplete/ebd-content" select=this.publicAPI}}
   @optionsComponent="paper-autocomplete/options"
-  @noMatchesMessageComponent={{component "paper-autocomplete/no-matches-message" onCreate=(fn this._onCreate)}}
-  @onClose={{fn this.close}}
-  @onOpen={{fn this.open}}
-  @onFocus={{fn this.focus}}
-  @onBlur={{fn this.blur}}
-  @onInput={{fn this._onInput}}
-  @scrollTo={{fn this.scrollTo}}
+  @noMatchesMessageComponent={{component "paper-autocomplete/no-matches-message" onCreate=this._onCreate}}
+  @onClose={{this.close}}
+  @onOpen={{this.open}}
+  @onFocus={{this.focus}}
+  @onBlur={{this.blur}}
+  @onInput={{this._onInput}}
+  @scrollTo={{this.scrollTo}}
   @onKeydown={{@onKeydown}}
   as |option term|>
   {{#if hasBlock}}

--- a/addon/components/paper-chips/template.hbs
+++ b/addon/components/paper-chips/template.hbs
@@ -57,11 +57,11 @@
             @matcher={{@matcher}}
             @noMatchesMessage={{@noMatchesMessage}}
             @searchText={{this.searchText}}
-            @onSelectionChange={{fn this.handleAutocompleteChange}}
-            @onSearchTextChange={{fn this.handleSearchTextChange}}
-            @onOpen={{fn this.handleAutocompleteOpen}}
-            @onCreate={{fn this.handleAddItem}}
-            @onKeydown={{fn this.handleAutocompleteKeydown}}
+            @onSelectionChange={{this.handleAutocompleteChange}}
+            @onSearchTextChange={{this.handleSearchTextChange}}
+            @onOpen={{this.handleAutocompleteOpen}}
+            @onCreate={{this.handleAddItem}}
+            @onKeydown={{this.handleAutocompleteKeydown}}
             as |item|>
             {{#if hasBlock}}
               {{yield item "suggestion"}}

--- a/addon/components/paper-menu/item/template.hbs
+++ b/addon/components/paper-menu/item/template.hbs
@@ -1,7 +1,7 @@
 {{! template-lint-disable no-invalid-interactive }}
 <md-menu-item {{on "mouseenter" this.handleMouseEnter}} disabled={{@disabled}}>
   {{#if this.shouldRenderButton}}
-    <PaperButton @onClick={{fn this.handleClick}} @href={{@href}} @target={{@target}} @disabled={{@disabled}}>
+    <PaperButton @onClick={{this.handleClick}} @href={{@href}} @target={{@target}} @disabled={{@disabled}}>
       {{yield}}
     </PaperButton>
   {{else}}

--- a/addon/components/paper-menu/template.hbs
+++ b/addon/components/paper-menu/template.hbs
@@ -1,9 +1,9 @@
 <BasicDropdown
   @triggerComponent="paper-menu/trigger"
   @contentComponent="paper-menu/content"
-  @calculatePosition={{fn this.calculatePosition}}
-  @onClose={{fn this.close}}
-  @onOpen={{fn this.open}}
+  @calculatePosition={{this.calculatePosition}}
+  @onClose={{this.close}}
+  @onOpen={{this.open}}
   as |dd|>
   {{yield (hash
     trigger=dd.Trigger

--- a/addon/components/paper-select/ebd-content/template.hbs
+++ b/addon/components/paper-select/ebd-content/template.hbs
@@ -23,7 +23,7 @@
   @height={{@height}}
   @otherStyles={{this.customStyles}}
 
-  @shouldReposition={{fn this.shouldReposition}}
+  @shouldReposition={{this.shouldReposition}}
   class="md-select-menu-container md-clickable {{if this.isActive "md-active"}}"
 
   ...attributes>

--- a/addon/components/paper-select/template.hbs
+++ b/addon/components/paper-select/template.hbs
@@ -12,7 +12,7 @@
     @searchPlaceholder={{@searchPlaceholder}}
     @registerAPI={{action (mut this.publicAPI)}}
 
-    @calculatePosition={{fn this.calculatePosition}}
+    @calculatePosition={{this.calculatePosition}}
     @extra={{hash label=@label}}
     @_ebdTriggerComponent={{component "paper-select/ebd-trigger" label=@label selected=@selected required=@required disabled=@disabled}}
     @triggerComponent="paper-select/eps-trigger"
@@ -23,10 +23,10 @@
     @beforeOptionsComponent="paper-select/search"
     @noMatchesMessageComponent="paper-select/no-matches-message"
     @searchMessageComponent="paper-select/search-message"
-    @onClose={{fn this.close}}
-    @onOpen={{fn this.open}}
-    @onFocus={{fn this.focus}}
-    @onBlur={{fn this.blur}}
+    @onClose={{this.close}}
+    @onOpen={{this.open}}
+    @onFocus={{this.focus}}
+    @onBlur={{this.blur}}
     as |opt term|>
     {{yield opt term}}
   </PowerSelect>


### PR DESCRIPTION
The new changes to `paper-menu` `paper-select` `paper-chips` and `paper-autocomplete` had unnecessary usage of `fn` helper, the recommended way in octane is just

```ts
import { action } from '@ember/object';
export default class SomeComponent extends Component {
 
  @action
  open() {
    //do stuff that needs this component's context
   this.set('isOpen', true);
  }

 calculatePosition(e) {
    //this function doesn't need component's context
    e.getBoundingClientRect(); 
  }

 @action
  async close(opt) {
   //This function needs component's context and receives an argument
 
    if(opt.id === this.selectedOpt.id) { //whatever
      return await this.onClose();
    }
  }
}
```

```hbs

<button {{on "click" this.open}}>Open Stuff </button>

{{#if this.isOpen}}
   <div {{did-insert this.calculatePosition}} ...attributes>
     <button {{on "click" (fn this.close @opt)}}>Close</button>
   </div>
{{/if}}

```