### PR TITLE
Use splattributes for paper-menu/item

### DIFF
--- a/addon/components/paper-menu/item/template.hbs
+++ b/addon/components/paper-menu/item/template.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-invalid-interactive }}
-<md-menu-item {{on "mouseenter" this.handleMouseEnter}} disabled={{@disabled}}>
+<md-menu-item {{on "mouseenter" this.handleMouseEnter}} ...attributes disabled={{@disabled}}>
   {{#if this.shouldRenderButton}}
     <PaperButton @onClick={{this.handleClick}} @href={{@href}} @target={{@target}} @disabled={{@disabled}}>
       {{yield}}


### PR DESCRIPTION
`paper-menu/item` wasn't forwarding `...attributes`

Fixes #1125 