### PR TITLE
[Fixes #1128] Protect against null querySelector in PaperMenu#focusItem

### DIFF
--- a/addon/components/paper-menu/content/component.js
+++ b/addon/components/paper-menu/content/component.js
@@ -80,7 +80,7 @@ class PaperMenuContent extends Component {
 
     // default to first non disabled item
     if (!focusTarget) {
-      let menuItem = element.querySelector('md-menu-item:not([disabled])')
+      let menuItem = element.querySelector('md-menu-item:not([disabled])');
       focusTarget = menuItem && menuItem.firstElementChild;
     }
 

--- a/addon/components/paper-menu/content/component.js
+++ b/addon/components/paper-menu/content/component.js
@@ -80,7 +80,8 @@ class PaperMenuContent extends Component {
 
     // default to first non disabled item
     if (!focusTarget) {
-      focusTarget = element.querySelector('md-menu-item:not([disabled])').firstElementChild;
+      let menuItem = element.querySelector('md-menu-item:not([disabled])')
+      focusTarget = menuItem && menuItem.firstElementChild;
     }
 
     if (focusTarget) {

--- a/tests/integration/components/paper-menu-test.js
+++ b/tests/integration/components/paper-menu-test.js
@@ -31,6 +31,31 @@ module('Integration | Component | paper-menu', function(hooks) {
 
   });
 
+  test('opens with all items disabled', async function(assert) {
+    assert.expect(1);
+    await render(hbs`
+      {{#paper-menu as |menu|}}
+        {{#menu.trigger}}
+          {{#paper-button iconButton=true}}
+            {{paper-icon "local_phone"}}
+          {{/paper-button}}
+        {{/menu.trigger}}
+        {{#menu.content width=4 as |content|}}
+          {{#content.menu-item disabled=true}}
+            <span id="menu-item">Test</span>
+          {{/content.menu-item}}
+        {{/menu.content}}
+      {{/paper-menu}}
+    `);
+
+    await settled();
+    await click('.ember-basic-dropdown-trigger');
+    await settled();
+    assert.dom('.md-open-menu-container').exists({ count: 1 });
+    await settled();
+
+  });
+
   test('backdrop removed if menu closed', async function(assert) {
     assert.expect(2);
     await render(hbs`


### PR DESCRIPTION
Fixes #1128 
Check for existence of query selector before getting first child