### PR TITLE
Use click instead of mouseUp to clear autocomplete (allowClear=true)

### DIFF
--- a/addon/components/paper-autocomplete/reset-button/component.js
+++ b/addon/components/paper-autocomplete/reset-button/component.js
@@ -15,7 +15,7 @@ class PaperAutocompleteResetButton extends Component.extend(TransitionMixin) {
   transitionClass = 'ng';
   onReset = null;
 
-  mouseUp(e) {
+  click(e) {
     let onReset = this.get('onReset');
     if (onReset === null) {
       return;


### PR DESCRIPTION
Click works on both mobile and desktop.

Fixes #1138 & #882 