### PR TITLE
[docs] updates all docs to use Angle Bracket syntax

### DIFF
--- a/tests/dummy/app/templates/addons.hbs
+++ b/tests/dummy/app/templates/addons.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Addons" isDemo=false}}
+<PageToolbar @pageTitle="Addons" @isDemo={{false}} />
 
-{{#paper-content class="md-padding"}}
+<PaperContent @class="md-padding">
   <div class="doc-content">
     <p>
       <code>ember-paper</code> does not include every component mentioned in the material design specifications.
@@ -14,28 +14,28 @@
       Note that addons are maintained by third-party developers and may not necessarily be kept up to date.
     </p>
 
-    {{#paper-card}}
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+    <PaperCard>
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Ember paper addons</h2>
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
-      {{#paper-list}}
+        </PaperToolbarTools>
+      </PaperToolbar>
+      <PaperList>
 
-        {{#paper-subheader}}
+        <PaperSubheader>
           Material design components
-        {{/paper-subheader}}
+        </PaperSubheader>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a target="_blank" rel="noopener" href="https://github.com/CoachLogix/ember-paper-stepper">ember-paper-stepper</a></h3>
             <p>
               Provides an implementation of <a target="_blank" rel="noopener" href="https://material.io/guidelines/components/steppers.html">material steppers</a>.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3>
               <a target="_blank" rel="noopener" href="https://github.com/CoachLogix/ember-paper-selection-dialog">ember-paper-selection-dialog</a>
@@ -44,9 +44,9 @@
               Provides dialogs for selections. Think of it as a select component, but using dialogs.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a target="_blank" rel="noopener" href="https://github.com/CoachLogix/ember-paper-swiper">ember-paper-swiper</a></h3>
             <p>
@@ -59,9 +59,9 @@
               </a>.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/miguelcobain/ember-paper-expansion-panel">ember-paper-expansion-panel</a></h3>
             <p>
@@ -71,36 +71,36 @@
               </a>.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/ibarrick/paper-data-table">paper-data-table</a></h3>
             <p>
               Provides an implementation of <a target="_blank" rel="noopener" href="https://material.io/guidelines/components/data-tables.html">material data tables</a>.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/devotox/ember-paper-pikaday">ember-paper-pikaday</a></h3>
             <p>
               Ember Pikaday wrapped as a Paper Item
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/devotox/ember-paper-time-picker">ember-paper-time-picker</a></h3>
             <p>
               Time Picker attached to an input field that allows both keyboard and mouse entry
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/betocantu93/ember-paper-flatpickr">ember-paper-flatpickr</a></h3>
             <p>
@@ -108,18 +108,18 @@
               it wraps <a href="https://github.com/shipshapecode/ember-flatpickr">ember-flatpickr </a>
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/devotox/ember-paper-password">ember-paper-password</a></h3>
             <p>
               Simple paper input field with type password with an eye icon on the right that when clicked toggles between showing the password and not
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/devotox/ember-paper-input-mask">ember-paper-input-mask</a></h3>
             <p>
@@ -127,52 +127,52 @@
               Look to Input mask to see possible options along with Paper Input options
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{paper-divider}}
-        {{#paper-subheader}}
+        <PaperDivider />
+        <PaperSubheader>
           Components adding additional functionality
-        {{/paper-subheader}}
+        </PaperSubheader>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/NLincoln/ember-paper-dual-slider">ember-paper-dual-slider</a></h3>
             <p>
               A slider component which supports <code>to</code> and <code>from</code> values.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/Subtletree/ember-paper-link">ember-paper-link</a></h3>
             <p>
               A <code>link-to</code> component with <code>paper-button</code> styling that handles active route state and query params.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/betocantu93/ember-paper-mobile-autocomplete">ember-paper-mobile-autocomplete</a></h3>
             <p>
               A component to enhance autocomplete experience in mobile, local filtering or remote, mimics a radio or checkbox, with UX close to Google Calendar mobile "invite people" to event dialog.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{#paper-item class="md-2-line"}}
+        <PaperItem @class="md-2-line">
           <div class="md-list-item-text">
             <h3><a href="https://github.com/onechiporenko/ember-paper-modals-manager">ember-paper-modals-manager</a></h3>
             <p>
               Modals-manager with predefined modals like `alert`, `prompt`, `confirm` etc. Any modal window can be created using `paper-dialog` and processed in the page with `modals-manager`-service.
             </p>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
 
-      {{/paper-list}}
-    {{/paper-card}}
+      </PaperList>
+    </PaperCard>
 
     <h3>Contributing an addon</h3>
 
@@ -180,4 +180,4 @@
       If you have an <code>ember-paper</code> specific component, service etc that you think would be usable by others, please feel free to create an ember addon, publish to npm then <a href="https://github.com/miguelcobain/ember-paper/pulls">submit a pull request</a> on GitHub for it to be included here.
     </p>
   </div>
-{{/paper-content}}
+</PaperContent>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,72 +1,71 @@
-{{#paper-sidenav-container class="site-nav-container"}}
-  {{#paper-sidenav class="md-whiteframe-z2 site-sidenav" lockedOpen="gt-sm"
-    open=isSidenavOpen onToggle=(action (mut isSidenavOpen))}}
-    {{#paper-toolbar class="site-content-toolbar" tall=true}}
+<PaperSidenavContainer @class="site-nav-container">
+  <PaperSidenav @class="md-whiteframe-z2 site-sidenav" @lockedOpen="gt-sm" @open={{isSidenavOpen}} @onToggle={{action (mut isSidenavOpen)}}>
+    <PaperToolbar @class="site-content-toolbar" @tall={{true}}>
       <div class="logo layout-column layout-align-center-center">
         <img alt="ember" src="ember-logo-white.png">
         <div>paper</div>
       </div>
-    {{/paper-toolbar}}
+    </PaperToolbar>
 
-    {{#paper-content}}
+    <PaperContent>
 
-      {{#paper-list}}
-        {{#menu-item active=(is-active "index" currentRouteName) href=(href-to "index")}}Introduction{{/menu-item}}
+      <PaperList>
+        <MenuItem @active={{is-active "index" currentRouteName}} @href={{href-to "index"}}>Introduction</MenuItem>
 
-        {{#menu-item onClick=(action "toggleExpandedItem" "demos") expanded=demosExpanded canExpand=true}}Components{{/menu-item}}
+        <MenuItem @onClick={{action "toggleExpandedItem" "demos"}} @expanded={{demosExpanded}} @canExpand={{true}}>Components</MenuItem>
 
         <div class="submenu">
           {{#liquid-if demosExpanded}}
-            {{#submenu-item active=(is-active "demo.autocomplete" currentRouteName) href=(href-to "demo.autocomplete")}}Autocomplete{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.button" currentRouteName) href=(href-to "demo.button")}}Button{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.card" currentRouteName) href=(href-to "demo.card")}}Card{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.checkbox" currentRouteName) href=(href-to "demo.checkbox")}}Checkbox{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.chips" currentRouteName) href=(href-to "demo.chips")}}Chips{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.dialog" currentRouteName) href=(href-to "demo.dialog")}}Dialog{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.divider" currentRouteName) href=(href-to "demo.divider")}}Divider{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.grid-list" currentRouteName) href=(href-to "demo.grid-list")}}Grid List{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.icons" currentRouteName) href=(href-to "demo.icons")}}Icons{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.input" currentRouteName) href=(href-to "demo.input")}}Input{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.list" currentRouteName) href=(href-to "demo.list")}}List{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.menu" currentRouteName) href=(href-to "demo.menu")}}Menu{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.progress-circular" currentRouteName) href=(href-to "demo.progress-circular")}}Progress Circular{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.progress-linear" currentRouteName) href=(href-to "demo.progress-linear")}}Progress Linear{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.radio" currentRouteName) href=(href-to "demo.radio")}}Radio{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.select" currentRouteName) href=(href-to "demo.select")}}Select{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.sidenav" currentRouteName) href=(href-to "demo.sidenav")}}Sidenav{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.slider" currentRouteName) href=(href-to "demo.slider")}}Slider{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.speed-dial" currentRouteName) href=(href-to "demo.speed-dial")}}Speed Dial{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.switch" currentRouteName) href=(href-to "demo.switch")}}Switch{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.tabs.index" currentRouteName) href=(href-to "demo.tabs")}}Tabs{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.toast" currentRouteName) href=(href-to "demo.toast")}}Toast{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.toolbar" currentRouteName) href=(href-to "demo.toolbar")}}Toolbar{{/submenu-item}}
-            {{#submenu-item active=(is-active "demo.tooltip" currentRouteName) href=(href-to "demo.tooltip")}}Tooltip{{/submenu-item}}
+            <SubmenuItem @active={{is-active "demo.autocomplete" currentRouteName}} @href={{href-to "demo.autocomplete"}}>Autocomplete</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.button" currentRouteName}} @href={{href-to "demo.button"}}>Button</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.card" currentRouteName}} @href={{href-to "demo.card"}}>Card</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.checkbox" currentRouteName}} @href={{href-to "demo.checkbox"}}>Checkbox</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.chips" currentRouteName}} @href={{href-to "demo.chips"}}>Chips</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.dialog" currentRouteName}} @href={{href-to "demo.dialog"}}>Dialog</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.divider" currentRouteName}} @href={{href-to "demo.divider"}}>Divider</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.grid-list" currentRouteName}} @href={{href-to "demo.grid-list"}}>Grid List</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.icons" currentRouteName}} @href={{href-to "demo.icons"}}>Icons</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.input" currentRouteName}} @href={{href-to "demo.input"}}>Input</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.list" currentRouteName}} @href={{href-to "demo.list"}}>List</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.menu" currentRouteName}} @href={{href-to "demo.menu"}}>Menu</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.progress-circular" currentRouteName}} @href={{href-to "demo.progress-circular"}}>Progress Circular</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.progress-linear" currentRouteName}} @href={{href-to "demo.progress-linear"}}>Progress Linear</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.radio" currentRouteName}} @href={{href-to "demo.radio"}}>Radio</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.select" currentRouteName}} @href={{href-to "demo.select"}}>Select</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.sidenav" currentRouteName}} @href={{href-to "demo.sidenav"}}>Sidenav</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.slider" currentRouteName}} @href={{href-to "demo.slider"}}>Slider</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.speed-dial" currentRouteName}} @href={{href-to "demo.speed-dial"}}>Speed Dial</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.switch" currentRouteName}} @href={{href-to "demo.switch"}}>Switch</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.tabs.index" currentRouteName}} @href={{href-to "demo.tabs"}}>Tabs</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.toast" currentRouteName}} @href={{href-to "demo.toast"}}>Toast</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.toolbar" currentRouteName}} @href={{href-to "demo.toolbar"}}>Toolbar</SubmenuItem>
+            <SubmenuItem @active={{is-active "demo.tooltip" currentRouteName}} @href={{href-to "demo.tooltip"}}>Tooltip</SubmenuItem>
           {{/liquid-if}}
         </div>
-        {{#menu-item active=(is-active "forms" currentRouteName) href=(href-to "forms")}}Forms{{/menu-item}}
-        {{#menu-item active=(is-active "typography" currentRouteName) href=(href-to "typography")}}Typography{{/menu-item}}
-        {{#menu-item active=(is-active "theme" currentRouteName) href=(href-to "theme")}}Color & Theme{{/menu-item}}
+        <MenuItem @active={{is-active "forms" currentRouteName}} @href={{href-to "forms"}}>Forms</MenuItem>
+        <MenuItem @active={{is-active "typography" currentRouteName}} @href={{href-to "typography"}}>Typography</MenuItem>
+        <MenuItem @active={{is-active "theme" currentRouteName}} @href={{href-to "theme"}}>Color & Theme</MenuItem>
 
-        {{#menu-item onClick=(action "toggleExpandedItem" "layout") expanded=layoutExpanded canExpand=true}}Layout{{/menu-item}}
+        <MenuItem @onClick={{action "toggleExpandedItem" "layout"}} @expanded={{layoutExpanded}} @canExpand={{true}}>Layout</MenuItem>
         <div class="submenu">
           {{#liquid-if layoutExpanded}}
-            {{#submenu-item active=(is-active "layout.introduction" currentRouteName) href=(href-to "layout.introduction")}}Introduction{{/submenu-item}}
-            {{#submenu-item active=(is-active "layout.layout-containers" currentRouteName) href=(href-to "layout.layout-containers")}}Layout Containers{{/submenu-item}}
-            {{#submenu-item active=(is-active "layout.layout-children" currentRouteName) href=(href-to "layout.layout-children")}}Layout Children{{/submenu-item}}
-            {{#submenu-item active=(is-active "layout.child-alignment" currentRouteName) href=(href-to "layout.child-alignment")}}Child Alignment{{/submenu-item}}
+            <SubmenuItem @active={{is-active "layout.introduction" currentRouteName}} @href={{href-to "layout.introduction"}}>Introduction</SubmenuItem>
+            <SubmenuItem @active={{is-active "layout.layout-containers" currentRouteName}} @href={{href-to "layout.layout-containers"}}>Layout Containers</SubmenuItem>
+            <SubmenuItem @active={{is-active "layout.layout-children" currentRouteName}} @href={{href-to "layout.layout-children"}}>Layout Children</SubmenuItem>
+            <SubmenuItem @active={{is-active "layout.child-alignment" currentRouteName}} @href={{href-to "layout.child-alignment"}}>Child Alignment</SubmenuItem>
           {{/liquid-if}}
         </div>
 
-        {{#menu-item active=(is-active "cookbook" currentRouteName) href=(href-to "cookbook")}}Cookbook{{/menu-item}}
-        {{#menu-item active=(is-active "addons" currentRouteName) href=(href-to "addons")}}Addons{{/menu-item}}
-      {{/paper-list}}
+        <MenuItem @active={{is-active "cookbook" currentRouteName}} @href={{href-to "cookbook"}}>Cookbook</MenuItem>
+        <MenuItem @active={{is-active "addons" currentRouteName}} @href={{href-to "addons"}}>Addons</MenuItem>
+      </PaperList>
 
-    {{/paper-content}}
-  {{/paper-sidenav}}
+    </PaperContent>
+  </PaperSidenav>
 
   <div id="main" class="flex layout-column" tabindex="-1" role="main">
     {{outlet}}
   </div>
-{{/paper-sidenav-container}}
+</PaperSidenavContainer>
 
-{{paper-toaster parent="#main"}}
+<PaperToaster @parent="#main" />

--- a/tests/dummy/app/templates/components/doc-content.hbs
+++ b/tests/dummy/app/templates/components/doc-content.hbs
@@ -1,5 +1,5 @@
-{{#paper-content class="md-padding"}}
+<PaperContent @class="md-padding">
   <div class="doc-content {{class}}">
     {{yield}}
   </div>
-{{/paper-content}}
+</PaperContent>

--- a/tests/dummy/app/templates/components/example-item.hbs
+++ b/tests/dummy/app/templates/components/example-item.hbs
@@ -2,6 +2,6 @@
 {{! app/templates/components/example-item.hbs }}
 <span class="item-title">
   {{paper-icon "star"}}
-  <span>{{paper-autocomplete-highlight searchText=searchText label=item}} (index {{index}} )</span>
+  <span><PaperAutocompleteHighlight @searchText={{searchText}} @label={{item}} /> (index {{index}} )</span>
 </span>
 {{! END-SNIPPET }}

--- a/tests/dummy/app/templates/components/menu-item.hbs
+++ b/tests/dummy/app/templates/components/menu-item.hbs
@@ -1,6 +1,6 @@
-{{#paper-item onClick=onClick href=href class=(concat "menu-item" (if active " active") (if expanded " expanded"))}}
+<PaperItem @onClick={{onClick}} @href={{href}} @class={{concat "menu-item" (if active " active") (if expanded " expanded")}}>
   {{yield}}
   {{#if canExpand}}
     {{paper-icon "expand-more" class="expand-icon"}}
   {{/if}}
-{{/paper-item}}
+</PaperItem>

--- a/tests/dummy/app/templates/components/page-toolbar.hbs
+++ b/tests/dummy/app/templates/components/page-toolbar.hbs
@@ -1,10 +1,10 @@
-{{#paper-toolbar class="md-whiteframe-1dp page-main-toolbar" as |toolbar|}}
-  {{#toolbar.tools}}
-    {{#paper-sidenav-toggle as |toggleAction|}}
-      {{#paper-button class="hide-gt-sm" onClick=(action toggleAction) iconButton=true}}
+<PaperToolbar @class="md-whiteframe-1dp page-main-toolbar" as |toolbar|>
+  <toolbar.tools>
+    <PaperSidenavToggle as |toggleAction|>
+      <PaperButton @class="hide-gt-sm" @onClick={{action toggleAction}} @iconButton={{true}}>
         {{paper-icon "menu"}}
-      {{/paper-button}}
-    {{/paper-sidenav-toggle}}
+      </PaperButton>
+    </PaperSidenavToggle>
     <div class="layout-row flex">
       <h2>
         {{#if isDemo}}
@@ -29,5 +29,5 @@
         </a>
       </div>
     </div>
-  {{/toolbar.tools}}
-{{/paper-toolbar}}
+  </toolbar.tools>
+</PaperToolbar>

--- a/tests/dummy/app/templates/components/submenu-item.hbs
+++ b/tests/dummy/app/templates/components/submenu-item.hbs
@@ -1,3 +1,3 @@
-{{#paper-item onClick=onClick href=href class=(concat "submenu-item" (if active " active"))}}
+<PaperItem @onClick={{onClick}} @href={{href}} @class={{concat "submenu-item" (if active " active")}}>
   {{yield}}
-{{/paper-item}}
+</PaperItem>

--- a/tests/dummy/app/templates/cookbook.hbs
+++ b/tests/dummy/app/templates/cookbook.hbs
@@ -1,15 +1,15 @@
-{{page-toolbar pageTitle="Cookbook" isDemo=false}}
+<PageToolbar @pageTitle="Cookbook" @isDemo={{false}} />
 
-{{#paper-content class="md-padding"}}
+<PaperContent @class="md-padding">
   <div class="doc-content">
     <h3>Hiding the <code>\{{paper-input}}</code> character counts</h3>
     <p>
       Material Design <a href="https://material.google.com/components/text-fields.html#text-fields-character-counter">requires that a character count is displayed</a> for input elements which have a length restriction. However, when forms have many input elements, some may prefer to display the count only when the element is focused or invalid. This CSS achieves this.
     </p>
-    {{code-snippet name="cookbook.no-char-count.scss"}}
+    <CodeSnippet @name="cookbook.no-char-count.scss" />
     <h3>Recipe contributions</h3>
     <p>
       Have a great tip or solution for <code>ember-paper</code>? <a href="https://github.com/miguelcobain/ember-paper/pulls">Submit a pull request</a> on GitHub or discuss it with the team on <a href="https://discord.gg/zT3asNS"> Discord #e-paper</a> for inclusion here.
     </p>
   </div>
-{{/paper-content}}
+</PaperContent>

--- a/tests/dummy/app/templates/demo/autocomplete.hbs
+++ b/tests/dummy/app/templates/demo/autocomplete.hbs
@@ -1,28 +1,14 @@
-{{page-toolbar pageTitle="Autocomplete" isDemo=true}}
+<PageToolbar @pageTitle="Autocomplete" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-card-content}}
+  <PaperCard>
+    <PaperCardContent>
       <h2>Basic Usage</h2>
       <blockquote>Use <code>\{{paper-autocomplete}}</code> to search for matches from local or remote data sources.</blockquote>
       <form>
         {{! BEGIN-SNIPPET autocomplete.basic-usage }}
-        {{paper-autocomplete
-          disabled=firstDisabled
-          onCreate=(action "addCountry")
-          options=items
-          allowClear=true
-          defaultHighlighted=(if enableDefaultHighlighted highlightFirstMatch)
-          searchText=(readonly countrySearchText)
-          onSearchTextChange=(action (mut countrySearchText))
-          selected=selectedCountry
-          search=(if simulateQuery (action "searchCountries"))
-          searchField="name"
-          labelPath="name"
-          placeholder="Select a Country..."
-          noMatchesMessage="Oops this country doesn't exist. Create a new country?"
-          onSelectionChange=(action (mut selectedCountry))}}
+        <PaperAutocomplete @disabled={{firstDisabled}} @onCreate={{action "addCountry"}} @options={{items}} @allowClear={{true}} @defaultHighlighted={{if enableDefaultHighlighted highlightFirstMatch}} @searchText={{readonly countrySearchText}} @onSearchTextChange={{action (mut countrySearchText)}} @selected={{selectedCountry}} @search={{if simulateQuery (action "searchCountries")}} @searchField="name" @labelPath="name" @placeholder="Select a Country..." @noMatchesMessage="Oops this country doesn't exist. Create a new country?" @onSelectionChange={{action (mut selectedCountry)}} />
         {{! END-SNIPPET }}
       </form>
       <p>
@@ -39,38 +25,26 @@
           No search text
         {{/if}}
       </p>
-      {{#paper-checkbox
-        value=firstDisabled
-        onChange=(action (mut firstDisabled))}}
+      <PaperCheckbox @value={{firstDisabled}} @onChange={{action (mut firstDisabled)}}>
         Disable input
-      {{/paper-checkbox}}
-      {{#paper-checkbox
-        value=simulateQuery
-        onChange=(action (mut simulateQuery))}}
+      </PaperCheckbox>
+      <PaperCheckbox @value={{simulateQuery}} @onChange={{action (mut simulateQuery)}}>
         Simulate query
-      {{/paper-checkbox}}
-      {{#paper-checkbox
-        value=enableDefaultHighlighted
-        onChange=(action (mut enableDefaultHighlighted))}}
+      </PaperCheckbox>
+      <PaperCheckbox @value={{enableDefaultHighlighted}} @onChange={{action (mut enableDefaultHighlighted)}}>
         Highlight first match
-      {{/paper-checkbox}}
-      {{paper-button
-        primary=true
-        label="Reset search-Text"
-        onClick=(action (mut countrySearchText) "")}}
-      {{paper-button
-        primary=true
-        label="Reset selected"
-        onClick=(action (mut selectedCountry) null)}}
+      </PaperCheckbox>
+      <PaperButton @primary={{true}} @label="Reset search-Text" @onClick={{action (mut countrySearchText) ""}} />
+      <PaperButton @primary={{true}} @label="Reset selected" @onClick={{action (mut selectedCountry) null}} />
 
       <h3>Template</h3>
-      {{code-snippet name="autocomplete.basic-usage.hbs"}}
+      <CodeSnippet @name="autocomplete.basic-usage.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-card-content}}
+  <PaperCard>
+    <PaperCardContent>
       <h2>Block Custom template</h2>
       <blockquote>Use <code>\{{paper-autocomplete}}</code> with custom templates to show styled autocomplete results.</blockquote>
 
@@ -87,7 +61,7 @@
           <span class="item-title">
             {{paper-icon "star"}}
             <span>
-              {{paper-autocomplete-highlight searchText=term.searchText flags="i" label=item}}
+              <PaperAutocompleteHighlight @searchText={{term.searchText}} @flags="i" @label={{item}} />
             </span>
           </span>
         {{else}}
@@ -101,35 +75,20 @@
       </p>
 
       <h3>Template</h3>
-      {{code-snippet name="autocomplete.block-custom-template.hbs"}}
-    {{/paper-card-content}}
-  {{/paper-card}}
+      <CodeSnippet @name="autocomplete.block-custom-template.hbs" />
+    </PaperCardContent>
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-card-content}}
+  <PaperCard>
+    <PaperCardContent>
       <h2>Floating Label</h2>
       <blockquote>The following example demonstrates floating labels being used as a normal form element.</blockquote>
       <form class="layout-row">
         {{! BEGIN-SNIPPET autocomplete.floating-label }}
-        {{paper-input label="Name" value=name onChange=(action (mut name)) class="flex"}}
-        {{#paper-autocomplete
-          disabled=(readonly disabled2)
-          required=(readonly isRequired)
-          triggerClass="flex"
-          options=items
-          selected=selectedCountry2
-          search=(if simulateQuery2 (action "searchCountries"))
-          searchField="name"
-          labelPath="name"
-          label="Select a Country..."
-          allowClear=(readonly allowClearWithLabel)
-          noMatchesMessage="Oops this country doesn't exist."
-          onSelectionChange=(action (mut selectedCountry2)) as |country select|}}
-          {{paper-autocomplete-highlight
-            label=country.name
-            searchText=select.searchText
-            flags="i"}}
-        {{/paper-autocomplete}}
+        <PaperInput @label="Name" @value={{name}} @onChange={{action (mut name)}} @class="flex" />
+        <PaperAutocomplete @disabled={{readonly disabled2}} @required={{readonly isRequired}} @triggerClass="flex" @options={{items}} @selected={{selectedCountry2}} @search={{if simulateQuery2 (action "searchCountries")}} @searchField="name" @labelPath="name" @label="Select a Country..." @allowClear={{readonly allowClearWithLabel}} @noMatchesMessage="Oops this country doesn't exist." @onSelectionChange={{action (mut selectedCountry2)}} as |country select|>
+          <PaperAutocompleteHighlight @label={{country.name}} @searchText={{select.searchText}} @flags="i" />
+        </PaperAutocomplete>
 
         {{! END-SNIPPET }}
       </form>
@@ -140,31 +99,23 @@
           Nothing is selected.
         {{/if}}
       </p>
-      {{#paper-checkbox
-        value=(readonly disabled2)
-        onChange=(action (mut disabled2))}}
+      <PaperCheckbox @value={{readonly disabled2}} @onChange={{action (mut disabled2)}}>
         Disable input
-      {{/paper-checkbox}}
-      {{#paper-checkbox
-        value=(readonly simulateQuery2)
-        onChange=(action (mut simulateQuery2))}}
+      </PaperCheckbox>
+      <PaperCheckbox @value={{readonly simulateQuery2}} @onChange={{action (mut simulateQuery2)}}>
         Simulate query
-      {{/paper-checkbox}}
-      {{#paper-checkbox
-        value=isRequired
-        onChange=(action (mut isRequired))}}
+      </PaperCheckbox>
+      <PaperCheckbox @value={{isRequired}} @onChange={{action (mut isRequired)}}>
         Is required
-      {{/paper-checkbox}}
-      {{#paper-checkbox
-        value=(readonly allowClearWithLabel)
-        onChange=(action (mut allowClearWithLabel))}}
+      </PaperCheckbox>
+      <PaperCheckbox @value={{readonly allowClearWithLabel}} @onChange={{action (mut allowClearWithLabel)}}>
         Allow Clear
-      {{/paper-checkbox}}
+      </PaperCheckbox>
 
       <h3>Template</h3>
-      {{code-snippet name="autocomplete.floating-label.hbs"}}
+      <CodeSnippet @name="autocomplete.floating-label.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/button.hbs
+++ b/tests/dummy/app/templates/demo/button.hbs
@@ -1,47 +1,47 @@
-{{page-toolbar pageTitle="Button" isDemo=true}}
+<PageToolbar @pageTitle="Button" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   {{! BEGIN-SNIPPET buttons.example }}
   <div class="layout-row">
-    {{#paper-button onClick=(action "flatButton")}}Button with action{{/paper-button}}
-    {{#paper-button noink=true primary=true}}Primary (noink){{/paper-button}}
-    {{#paper-button disabled=true}}disabled{{/paper-button}}
-    {{#paper-button warn=true}}warn{{/paper-button}}
-    {{#paper-button accent=true}}accent{{/paper-button}}
-    {{#paper-button href="http://emberjs.com/images/tomsters/original.png" target="_blank"}}href link{{/paper-button}}
+    <PaperButton @onClick={{action "flatButton"}}>Button with action</PaperButton>
+    <PaperButton @noink={{true}} @primary={{true}}>Primary (noink)</PaperButton>
+    <PaperButton @disabled={{true}}>disabled</PaperButton>
+    <PaperButton @warn={{true}}>warn</PaperButton>
+    <PaperButton @accent={{true}}>accent</PaperButton>
+    <PaperButton @href="http://emberjs.com/images/tomsters/original.png" @target="_blank">href link</PaperButton>
   </div>
   <p>
-    {{#paper-button raised=true onClick=(action "raisedButton")}}Button with action{{/paper-button}}
-    {{#paper-button raised=true primary=true}}Primary{{/paper-button}}
-    {{#paper-button raised=true disabled=true}}disabled{{/paper-button}}
-    {{#paper-button raised=true warn=true}}warn{{/paper-button}}
-    {{#paper-button raised=true accent=true}}accent{{/paper-button}}
+    <PaperButton @raised={{true}} @onClick={{action "raisedButton"}}>Button with action</PaperButton>
+    <PaperButton @raised={{true}} @primary={{true}}>Primary</PaperButton>
+    <PaperButton @raised={{true}} @disabled={{true}}>disabled</PaperButton>
+    <PaperButton @raised={{true}} @warn={{true}}>warn</PaperButton>
+    <PaperButton @raised={{true}} @accent={{true}}>accent</PaperButton>
   </p>
-  {{#custom-button}}
+  <CustomButton>
     <p>
-      {{#paper-button raised=true onClick=(action "targetButton")}}Button with target{{/paper-button}}
-      {{#paper-button raised=true primary=true onClick=(action "targetButton")}}Button with bubble{{/paper-button}}
-      {{#paper-button raised=true primary=true onClick=(action "targetButton") bubbles=false}}Button no bubble{{/paper-button}}
+      <PaperButton @raised={{true}} @onClick={{action "targetButton"}}>Button with target</PaperButton>
+      <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "targetButton"}}>Button with bubble</PaperButton>
+      <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "targetButton"}} @bubbles={{false}}>Button no bubble</PaperButton>
     </p>
-  {{/custom-button}}
+  </CustomButton>
 
   <p>
-    {{#paper-button raised=true fab=true}}Fab{{/paper-button}}
-    {{#paper-button raised=true fab=true accent=true}}Fab{{/paper-button}}
-    {{#paper-button raised=true mini=true}}Mini{{/paper-button}}
-    {{#paper-button raised=true mini=true primary=true}}Mini{{/paper-button}}
-    {{#paper-button iconButton=true}}{{paper-icon "accessibility"}}{{/paper-button}}
+    <PaperButton @raised={{true}} @fab={{true}}>Fab</PaperButton>
+    <PaperButton @raised={{true}} @fab={{true}} @accent={{true}}>Fab</PaperButton>
+    <PaperButton @raised={{true}} @mini={{true}}>Mini</PaperButton>
+    <PaperButton @raised={{true}} @mini={{true}} @primary={{true}}>Mini</PaperButton>
+    <PaperButton @iconButton={{true}}>{{paper-icon "accessibility"}}</PaperButton>
   </p>
 
   <p>
-    {{paper-button raised=true label="Blockless version"}}
+    <PaperButton @raised={{true}} @label="Blockless version" />
   </p>
   {{! END-SNIPPET }}
   <h3>Template</h3>
-  {{code-snippet name="buttons.example.hbs"}}
+  <CodeSnippet @name="buttons.example.hbs" />
 
   <h3>Controller</h3>
-  {{code-snippet name="buttons.component.js"}}
+  <CodeSnippet @name="buttons.component.js" />
 
   {{paper-api
     (p-section
@@ -68,4 +68,4 @@
     "color"
   }}
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/card.hbs
+++ b/tests/dummy/app/templates/demo/card.hbs
@@ -1,92 +1,92 @@
-{{page-toolbar pageTitle="Card" isDemo=true}}
+<PageToolbar @pageTitle="Card" @isDemo={{true}} />
 
-{{#doc-content class="card-demo"}}
+<DocContent @class="card-demo">
   <h2>Basic Usage</h2>
   {{! BEGIN-SNIPPET card.basic-usage }}
   <div class="layout-row layout-xs-column">
     <div class="layout-column flex-xs flex-gt-xs-50">
-      {{#paper-card as |card|}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Card with image{{/text.headline}}
-            {{#text.subhead}}Large{{/text.subhead}}
-          {{/title.text}}
-          {{title.media size="lg" src="tomster.png" alt="Tomster" title="Tomster"}}
-        {{/card.title}}
-        {{#card.actions}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+      <PaperCard as |card|>
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Card with image</text.headline>
+            <text.subhead>Large</text.subhead>
+          </title.text>
+          <title.media @size="lg" @src="tomster.png" @alt="Tomster" @title="Tomster" />
+        </card.title>
+        <card.actions>
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+      </PaperCard>
 
-      {{#paper-card as |card|}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Card with block{{/text.headline}}
-            {{#text.subhead}}Extra large{{/text.subhead}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.content class="layout-row layout-align-space-between"}}
-          {{#card.media size="xl"}}
+      <PaperCard as |card|>
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Card with block</text.headline>
+            <text.subhead>Extra large</text.subhead>
+          </title.text>
+        </card.title>
+        <card.content @class="layout-row layout-align-space-between">
+          <card.media @size="xl">
             <div class="card-media"></div>
-          {{/card.media}}
-          {{#card.actions class="layout-column"}}
-            {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
-            {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
-            {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
-          {{/card.actions}}
-        {{/card.content}}
-      {{/paper-card}}
+          </card.media>
+          <card.actions @class="layout-column">
+            <PaperButton @iconButton={{true}}>{{paper-icon "favorite"}}</PaperButton>
+            <PaperButton @iconButton={{true}}>{{paper-icon "settings"}}</PaperButton>
+            <PaperButton @iconButton={{true}}>{{paper-icon "share"}}</PaperButton>
+          </card.actions>
+        </card.content>
+      </PaperCard>
     </div>
     <div class="layout-column flex-xs flex-gt-xs-50">
-      {{#paper-card as |card|}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Card with image{{/text.headline}}
-            {{#text.subhead}}Small{{/text.subhead}}
-          {{/title.text}}
-          {{title.media size="sm" src="tomster.png" alt="Tomster" title="Tomster"}}
-        {{/card.title}}
-        {{#card.actions}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+      <PaperCard as |card|>
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Card with image</text.headline>
+            <text.subhead>Small</text.subhead>
+          </title.text>
+          <title.media @size="sm" @src="tomster.png" @alt="Tomster" @title="Tomster" />
+        </card.title>
+        <card.actions>
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+      </PaperCard>
 
-      {{#paper-card as |card|}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Card with block{{/text.headline}}
-            {{#text.subhead}}Medium{{/text.subhead}}
-          {{/title.text}}
-          {{#title.media size="md"}}
+      <PaperCard as |card|>
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Card with block</text.headline>
+            <text.subhead>Medium</text.subhead>
+          </title.text>
+          <title.media @size="md">
             <div class="card-media"></div>
-          {{/title.media}}
-        {{/card.title}}
-        {{#card.actions}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+          </title.media>
+        </card.title>
+        <card.actions>
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+      </PaperCard>
     </div>
   </div>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="card.basic-usage.hbs"}}
+  <CodeSnippet @name="card.basic-usage.hbs" />
 
   <h2>Card Action Buttons</h2>
   {{! BEGIN-SNIPPET card.action-buttons }}
   <div class="layout-row layout-xs-column">
     <div class="layout-column flex-xs flex-gt-xs-50">
-      {{#paper-card as |card|}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Action buttons{{/text.headline}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.content}}
+      <PaperCard as |card|>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Action buttons</text.headline>
+          </title.text>
+        </card.title>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
@@ -99,187 +99,187 @@
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-        {{#card.actions}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+        </card.content>
+        <card.actions>
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+      </PaperCard>
 
-      {{#paper-card as |card|}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Vertical action buttons{{/text.headline}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.content}}
+      <PaperCard as |card|>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Vertical action buttons</text.headline>
+          </title.text>
+        </card.title>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-        {{#card.actions class="layout-column"}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+        </card.content>
+        <card.actions @class="layout-column">
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+      </PaperCard>
     </div>
 
     <div class="layout-column flex-xs flex-gt-xs-50">
-      {{#paper-card as |card|}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Icon action buttons{{/text.headline}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.content}}
+      <PaperCard as |card|>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Icon action buttons</text.headline>
+          </title.text>
+        </card.title>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-        {{#card.actions}}
-          {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
-          {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
-          {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+        </card.content>
+        <card.actions>
+          <PaperButton @iconButton={{true}}>{{paper-icon "favorite"}}</PaperButton>
+          <PaperButton @iconButton={{true}}>{{paper-icon "settings"}}</PaperButton>
+          <PaperButton @iconButton={{true}}>{{paper-icon "share"}}</PaperButton>
+        </card.actions>
+      </PaperCard>
 
-      {{#paper-card as |card|}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.actions}}
-          {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
-          {{#paper-button iconButton=true}}{{paper-icon "settings"}}{{/paper-button}}
-          {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
-        {{/card.actions}}
-      {{/paper-card}}
+      <PaperCard as |card|>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.actions>
+          <PaperButton @iconButton={{true}}>{{paper-icon "favorite"}}</PaperButton>
+          <PaperButton @iconButton={{true}}>{{paper-icon "settings"}}</PaperButton>
+          <PaperButton @iconButton={{true}}>{{paper-icon "share"}}</PaperButton>
+        </card.actions>
+      </PaperCard>
 
-      {{#paper-card as |card|}}
-        {{#card.header as |header|}}
-          {{#header.avatar}}
+      <PaperCard as |card|>
+        <card.header as |header|>
+          <header.avatar>
             <img src="tomster.png" alt="tomster">
-          {{/header.avatar}}
-          {{#header.text as |text|}}
-            {{#text.title}}Ember{{/text.title}}
-            {{#text.subhead}}Paper{{/text.subhead}}
-          {{/header.text}}
-        {{/card.header}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}Card header{{/text.headline}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.content}}
+          </header.avatar>
+          <header.text as |text|>
+            <text.title>Ember</text.title>
+            <text.subhead>Paper</text.subhead>
+          </header.text>
+        </card.header>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>Card header</text.headline>
+          </title.text>
+        </card.title>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-      {{/paper-card}}
+        </card.content>
+      </PaperCard>
     </div>
   </div>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="card.action-buttons.hbs"}}
+  <CodeSnippet @name="card.action-buttons.hbs" />
 
   <h2>In Card Actions</h2>
   {{! BEGIN-SNIPPET card.in-card-actions }}
   <div class="layout-row layout-xs-column">
     <div class="layout-column flex-xs flex-gt-xs-50">
-      {{#paper-card as |card|}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}In-card mixed actions{{/text.headline}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
-          {{#actions.icons}}
-            {{#paper-button iconButton=true}}{{paper-icon "favorite"}}{{/paper-button}}
-            {{#paper-button iconButton=true}}{{paper-icon "share"}}{{/paper-button}}
-          {{/actions.icons}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-        {{#card.content}}
+      <PaperCard as |card|>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>In-card mixed actions</text.headline>
+          </title.text>
+        </card.title>
+        <card.actions @class="layout-row layout-align-start-center" as |actions|>
+          <actions.icons>
+            <PaperButton @iconButton={{true}}>{{paper-icon "favorite"}}</PaperButton>
+            <PaperButton @iconButton={{true}}>{{paper-icon "share"}}</PaperButton>
+          </actions.icons>
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-      {{/paper-card}}
+        </card.content>
+      </PaperCard>
 
-      {{#paper-card as |card|}}
-        {{#card.header as |header|}}
-          {{#header.avatar}}
+      <PaperCard as |card|>
+        <card.header as |header|>
+          <header.avatar>
             <img src="tomster.png" alt="tomster">
-          {{/header.avatar}}
-          {{#header.text as |text|}}
-            {{#text.title}}User{{/text.title}}
-            {{#text.subhead}}subhead{{/text.subhead}}
-          {{/header.text}}
-        {{/card.header}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}In-card mixed actions{{/text.headline}}
-            {{#text.subhead}}Reversed{{/text.subhead}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.actions class="layout-row layout-align-start-center" as |actions|}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-          {{#actions.icons}}
-            {{#paper-button iconButton=true}}{{paper-icon "expand-less"}}{{/paper-button}}
-          {{/actions.icons}}
-        {{/card.actions}}
-        {{#card.content}}
+          </header.avatar>
+          <header.text as |text|>
+            <text.title>User</text.title>
+            <text.subhead>subhead</text.subhead>
+          </header.text>
+        </card.header>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>In-card mixed actions</text.headline>
+            <text.subhead>Reversed</text.subhead>
+          </title.text>
+        </card.title>
+        <card.actions @class="layout-row layout-align-start-center" as |actions|>
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+          <actions.icons>
+            <PaperButton @iconButton={{true}}>{{paper-icon "expand-less"}}</PaperButton>
+          </actions.icons>
+        </card.actions>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-      {{/paper-card}}
+        </card.content>
+      </PaperCard>
     </div>
 
     <div class="layout-column flex-xs flex-gt-xs-50">
-      {{#paper-card as |card|}}
-        {{#card.header as |header|}}
-          {{#header.avatar}}
+      <PaperCard as |card|>
+        <card.header as |header|>
+          <header.avatar>
             <img src="tomster.png" alt="tomster">
-          {{/header.avatar}}
-          {{#header.text as |text|}}
-            {{#text.title}}Title{{/text.title}}
-            {{#text.subhead}}subhead{{/text.subhead}}
-          {{/header.text}}
-        {{/card.header}}
-        {{card.image src="washedout.png" alt="Washed Out" title="Washed Out"}}
-        {{#card.title as |title|}}
-          {{#title.text as |text|}}
-            {{#text.headline}}In-card mixed actions{{/text.headline}}
-            {{#text.subhead}}Description{{/text.subhead}}
-          {{/title.text}}
-        {{/card.title}}
-        {{#card.actions class="layout-row layout-align-start-center"}}
-          {{#paper-button}}Action 1{{/paper-button}}
-          {{#paper-button}}Action 2{{/paper-button}}
-        {{/card.actions}}
-        {{#card.content}}
+          </header.avatar>
+          <header.text as |text|>
+            <text.title>Title</text.title>
+            <text.subhead>subhead</text.subhead>
+          </header.text>
+        </card.header>
+        <card.image @src="washedout.png" @alt="Washed Out" @title="Washed Out" />
+        <card.title as |title|>
+          <title.text as |text|>
+            <text.headline>In-card mixed actions</text.headline>
+            <text.subhead>Description</text.subhead>
+          </title.text>
+        </card.title>
+        <card.actions @class="layout-row layout-align-start-center">
+          <PaperButton>Action 1</PaperButton>
+          <PaperButton>Action 2</PaperButton>
+        </card.actions>
+        <card.content>
           <p>
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
-        {{/card.content}}
-      {{/paper-card}}
+        </card.content>
+      </PaperCard>
     </div>
   </div>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="card.in-card-actions.hbs"}}
+  <CodeSnippet @name="card.in-card-actions.hbs" />
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/checkbox.hbs
+++ b/tests/dummy/app/templates/demo/checkbox.hbs
@@ -1,41 +1,41 @@
-{{page-toolbar pageTitle="Checkbox" isDemo=true}}
+<PageToolbar @pageTitle="Checkbox" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   {{! BEGIN-SNIPPET checkbox }}
   <div class="layout-column">
-    {{#paper-checkbox value=value1 onChange=(action (mut value1))}}
+    <PaperCheckbox @value={{value1}} @onChange={{action (mut value1)}}>
       A checkbox: {{value1}}
-    {{/paper-checkbox}}
+    </PaperCheckbox>
 
-    {{#paper-checkbox value=value2 onChange=(action (mut value2))}}
+    <PaperCheckbox @value={{value2}} @onChange={{action (mut value2)}}>
       A checkbox: {{if value2 "yep" "nope"}}
-    {{/paper-checkbox}}
+    </PaperCheckbox>
 
-    {{#paper-checkbox value=value3 onChange=(action (mut value3)) disabled=true}}
+    <PaperCheckbox @value={{value3}} @onChange={{action (mut value3)}} @disabled={{true}}>
       Checkbox (disabled)
-    {{/paper-checkbox}}
+    </PaperCheckbox>
 
-    {{#paper-checkbox value=true onChange=(action (mut value4)) disabled=true}}
+    <PaperCheckbox @value={{true}} @onChange={{action (mut value4)}} @disabled={{true}}>
       Checkbox (disabled and value)
-    {{/paper-checkbox}}
+    </PaperCheckbox>
 
-    {{#paper-checkbox value=value5 onChange=(action (mut value5)) noink=true}}
+    <PaperCheckbox @value={{value5}} @onChange={{action (mut value5)}} @noink={{true}}>
       Checkbox (no ink)
-    {{/paper-checkbox}}
+    </PaperCheckbox>
 
-    {{paper-checkbox label="Blockless version" value=value6 onChange=(action "toggleValue6")}}
+    <PaperCheckbox @label="Blockless version" @value={{value6}} @onChange={{action "toggleValue6"}} />
 
-    {{#paper-checkbox indeterminate=isIndeterminate value=value7 onChange=(action (mut value7))}}
+    <PaperCheckbox @indeterminate={{isIndeterminate}} @value={{value7}} @onChange={{action (mut value7)}}>
       Indeterminate checkbox
-    {{/paper-checkbox}}
+    </PaperCheckbox>
 
-    {{#paper-checkbox disabled=true indeterminate=isIndeterminate value=value7 onChange=null}}
+    <PaperCheckbox @disabled={{true}} @indeterminate={{isIndeterminate}} @value={{value7}} @onChange={{null}}>
       Indeterminate checkbox (disabled)
-    {{/paper-checkbox}}
+    </PaperCheckbox>
   </div>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="checkbox.hbs"}}
+  <CodeSnippet @name="checkbox.hbs" />
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/chips.hbs
+++ b/tests/dummy/app/templates/demo/chips.hbs
@@ -1,85 +1,54 @@
-{{page-toolbar pageTitle="Chips" isDemo=true}}
+<PageToolbar @pageTitle="Chips" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic Usage</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-card-content}}
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperCardContent>
       {{! BEGIN-SNIPPET chips.example }}
       <h2>Default Template</h2>
-      {{paper-chips
-        content=fruitNames
-        readOnly=readOnly
-        removeItem=(action "removeItem")
-        addItem=(action "addItem")
-        placeholder="Add a tag"}}
+      <PaperChips @content={{fruitNames}} @readOnly={{readOnly}} @removeItem={{action "removeItem"}} @addItem={{action "addItem"}} @placeholder="Add a tag" />
 
       <h2>Custom Template</h2>
-      {{#paper-chips
-        readOnly=readOnly
-        removeItem=(action "removeCustomItem")
-        addItem=(action "addCustomItem")
-        placeholder="Add a tag"
-        content=customFruitNames as |item|}}
+      <PaperChips @readOnly={{readOnly}} @removeItem={{action "removeCustomItem"}} @addItem={{action "addCustomItem"}} @placeholder="Add a tag" @content={{customFruitNames}} as |item|>
         <strong>{{item}}</strong>
         <em>(fruit)</em>
-      {{/paper-chips}}
+      </PaperChips>
 
       <h2>Chips with Autocomplete</h2>
-      {{#paper-chips
-        readOnly=readOnly
-        removeItem=(action "removeVegetable")
-        addItem=(action "addVegetable")
-        placeholder="Add a vegetable"
-        content=vegetables
-        options=remainingVegetables
-        searchField="name"
-        noMatchesMessage="Not found. Click to add." as |item|}}
+      <PaperChips @readOnly={{readOnly}} @removeItem={{action "removeVegetable"}} @addItem={{action "addVegetable"}} @placeholder="Add a vegetable" @content={{vegetables}} @options={{remainingVegetables}} @searchField="name" @noMatchesMessage="Not found. Click to add." as |item|>
         <strong>{{item.name}}</strong>
         {{#if item.family}}
           <em>{{item.family}}</em>
         {{/if}}
-      {{/paper-chips}}
+      </PaperChips>
 
       <h2>Chips with Autocomplete (requires match)</h2>
-      {{paper-chips
-        readOnly=readOnly
-        removeItem=(action "removeVegeName")
-        addItem=(action "addVegeName")
-        placeholder="Add a vegetable"
-        content=vegeNames
-        options=remainingVegeNames
-        requireMatch=true}}
+      <PaperChips @readOnly={{readOnly}} @removeItem={{action "removeVegeName"}} @addItem={{action "addVegeName"}} @placeholder="Add a vegetable" @content={{vegeNames}} @options={{remainingVegeNames}} @requireMatch={{true}} />
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="chips.example.hbs"}}
+      <CodeSnippet @name="chips.example.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
 
-  {{#paper-card class="chipsdemoContactChips"}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard @class="chipsdemoContactChips">
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Contact chips</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-card-content}}
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperCardContent>
 
       {{! BEGIN-SNIPPET chips.contacts-example }}
       <h2>Contact Chips</h2>
-      {{paper-contact-chips
-        readOnly=readOnly
-        removeItem=(action "removeContact")
-        addItem=(action "addContact")
-        placeholder="Add a contact"
-        content=selectedContacts
-        options=remainingContacts}}
+      <PaperContactChips @readOnly={{readOnly}} @removeItem={{action "removeContact"}} @addItem={{action "addContact"}} @placeholder="Add a contact" @content={{selectedContacts}} @options={{remainingContacts}} />
 
       <blockquote>
         <code>paper-contact-chips</code> expects the name, email address and image
@@ -90,29 +59,17 @@
         autocomplete should search against:
       </blockquote>
 
-      {{paper-contact-chips
-        readOnly=readOnly
-        removeItem=(action "removeAltContact")
-        addItem=(action "addAltContact")
-        placeholder="Add a contact"
-        content=selectedAltContacts
-        options=remainingAltContacts
-        nameField="shortName"
-        emailField="emailAddress"
-        imageField="profileImage"
-        searchField="emailAddress"}}
+      <PaperContactChips @readOnly={{readOnly}} @removeItem={{action "removeAltContact"}} @addItem={{action "addAltContact"}} @placeholder="Add a contact" @content={{selectedAltContacts}} @options={{remainingAltContacts}} @nameField="shortName" @emailField="emailAddress" @imageField="profileImage" @searchField="emailAddress" />
 
-      {{#paper-checkbox
-        value=readOnly
-        onChange=(action (mut readOnly))}}
+      <PaperCheckbox @value={{readOnly}} @onChange={{action (mut readOnly)}}>
         Read Only
-      {{/paper-checkbox}}
+      </PaperCheckbox>
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="chips.contacts-example.hbs"}}
+      <CodeSnippet @name="chips.contacts-example.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/dialog.hbs
+++ b/tests/dummy/app/templates/demo/dialog.hbs
@@ -1,40 +1,40 @@
-{{page-toolbar pageTitle="Dialog" isDemo=true}}
+<PageToolbar @pageTitle="Dialog" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic Usage</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggleSourceCode") iconButton=true}}
-          {{paper-icon icon="code"}}
-        {{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+        <PaperButton @onClick={{action "toggleSourceCode"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+        </PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
 
     <div class="doc-code-example {{if showSourceCode "is-visible"}}">
-      {{code-snippet name="dialog.hbs"}}
+      <CodeSnippet @name="dialog.hbs" />
     </div>
 
     <div class="doc-content-example">
       <div id="paper-dialog-demo"></div>
-      {{#paper-card-content}}
+      <PaperCardContent>
         <p>Open a dialog over the app's content. Press escape or click outside to close the dialog and send focus back to the triggering button.</p>
 
         <div class="layout-row layout-wrap">
-          {{#paper-button raised=true primary=true onClick=(action "openDialogWithParent")}}
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openDialogWithParent"}}>
             Dialog with parent
-          {{/paper-button}}
-          {{#paper-button raised=true primary=true onClick=(action "openDialog")}}
+          </PaperButton>
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openDialog"}}>
             Custom dialog
-          {{/paper-button}}
-          {{#paper-button raised=true primary=true onClick=(action "openPromptDialog")}}
+          </PaperButton>
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openPromptDialog"}}>
             Prompt dialog
-          {{/paper-button}}
-          {{#paper-button raised=true primary=true onClick=(action "openAnimatedDialog")}}
+          </PaperButton>
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openAnimatedDialog"}}>
             Animated dialog
-          {{/paper-button}}
+          </PaperButton>
         </div>
 
         {{#if result}}
@@ -59,108 +59,108 @@
           )
         }}
 
-      {{/paper-card-content}}
+      </PaperCardContent>
     </div>
 
-  {{/paper-card}}
+  </PaperCard>
 
   <span id="bottom-of-card"></span>
 
-{{/doc-content}}
+</DocContent>
 
 {{! BEGIN-SNIPPET dialog }}
 {{#if showDialogWithParent}}
-  {{#paper-dialog class="flex-50" onClose=(action "closeDialogWithParent" "cancel") parent="#paper-dialog-demo" origin=dialogOrigin clickOutsideToClose=true}}
+  <PaperDialog @class="flex-50" @onClose={{action "closeDialogWithParent" "cancel"}} @parent="#paper-dialog-demo" @origin={{dialogOrigin}} @clickOutsideToClose={{true}}>
     <form>
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Mango (Fruit)</h2>
           <span class="flex"></span>
-          {{#paper-button iconButton=true onClick=(action "closeDialogWithParent" "cancel")}}
-            {{paper-icon icon="close"}}
-          {{/paper-button}}
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
+          <PaperButton @iconButton={{true}} @onClick={{action "closeDialogWithParent" "cancel"}}>
+            <PaperIcon @icon="close" />
+          </PaperButton>
+        </PaperToolbarTools>
+      </PaperToolbar>
 
-      {{#paper-dialog-content}}
+      <PaperDialogContent>
         <p>
           This is a dialog rendered into a specific element. Clicking outside the dialog will close it.
         </p>
-      {{/paper-dialog-content}}
+      </PaperDialogContent>
 
-      {{#paper-dialog-actions class="layout-row"}}
+      <PaperDialogActions @class="layout-row">
         <span class="flex"></span>
-        {{#paper-button onClick=(action "closeDialogWithParent" "cancel")}}
+        <PaperButton @onClick={{action "closeDialogWithParent" "cancel"}}>
           Cancel
-        {{/paper-button}}
-        {{#paper-button onClick=(action "closeDialogWithParent" "ok")}}
+        </PaperButton>
+        <PaperButton @onClick={{action "closeDialogWithParent" "ok"}}>
           OK
-        {{/paper-button}}
-      {{/paper-dialog-actions}}
+        </PaperButton>
+      </PaperDialogActions>
     </form>
-  {{/paper-dialog}}
+  </PaperDialog>
 {{/if}}
 
 {{#if showDialog}}
-  {{#paper-dialog class="flex-77" onClose=(action "closeDialog" "cancel") origin=dialogOrigin clickOutsideToClose=true}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperDialog @class="flex-77" @onClose={{action "closeDialog" "cancel"}} @origin={{dialogOrigin}} @clickOutsideToClose={{true}}>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Mango (Fruit)</h2>
         <span class="flex"></span>
-        {{#paper-button iconButton=true onClick=(action "closeDialog" "cancel")}}{{paper-icon icon="close"}}{{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+        <PaperButton @iconButton={{true}} @onClick={{action "closeDialog" "cancel"}}><PaperIcon @icon="close" /></PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
 
-    {{#paper-dialog-content}}
+    <PaperDialogContent>
       <p>
         The mango is a juicy stone fruit belonging to the genus Mangifera, consisting of numerous tropical fruiting trees, cultivated mostly for edible fruit. The majority of these species are found in nature as wild mangoes. They all belong to the flowering plant family Anacardiaceae. The mango is native to South and Southeast Asia, from where it has been distributed worldwide to become one of the most cultivated fruits in the tropics.
       </p>
       <img style="margin: auto; max-width: 100%;" alt="Lush mango tree" src="https://www.stockvault.net/data/2011/03/20/119586/preview16.jpg">
-    {{/paper-dialog-content}}
+    </PaperDialogContent>
 
-    {{#paper-dialog-actions class="layout-row"}}
-      {{#paper-button href="http://en.wikipedia.org/wiki/Mango" target="_blank"}}More on Wikipedia{{/paper-button}}
+    <PaperDialogActions @class="layout-row">
+      <PaperButton @href="http://en.wikipedia.org/wiki/Mango" @target="_blank">More on Wikipedia</PaperButton>
       <span class="flex"></span>
-      {{#paper-button onClick=(action "closeDialog" "cancel")}}Cancel{{/paper-button}}
-      {{#paper-button onClick=(action "closeDialog" "ok")}}OK{{/paper-button}}
-    {{/paper-dialog-actions}}
-  {{/paper-dialog}}
+      <PaperButton @onClick={{action "closeDialog" "cancel"}}>Cancel</PaperButton>
+      <PaperButton @onClick={{action "closeDialog" "ok"}}>OK</PaperButton>
+    </PaperDialogActions>
+  </PaperDialog>
 {{/if}}
 
 {{#if showPromptDialog}}
-  {{#paper-dialog fullscreen=fullscreen onClose=(action "closePromptDialog" "cancel") origin=dialogOrigin}}
+  <PaperDialog @fullscreen={{fullscreen}} @onClose={{action "closePromptDialog" "cancel"}} @origin={{dialogOrigin}}>
 
-    {{#paper-dialog-content}}
+    <PaperDialogContent>
       <h2 class="md-title">What would you name your dog?</h2>
       <p>Bowser is a common name.</p>
-      {{paper-input placeholder="dog name" autofocus=true value=dogName onChange=(action (mut dogName))}}
+      <PaperInput @placeholder="dog name" @autofocus={{true}} @value={{dogName}} @onChange={{action (mut dogName)}} />
       <div>
-        {{#paper-checkbox value=fullscreen onChange=(action (mut fullscreen))}}Display fullscreen at small window size breakpoints{{/paper-checkbox}}
+        <PaperCheckbox @value={{fullscreen}} @onChange={{action (mut fullscreen)}}>Display fullscreen at small window size breakpoints</PaperCheckbox>
       </div>
-    {{/paper-dialog-content}}
+    </PaperDialogContent>
 
-    {{#paper-dialog-actions class="layout-row"}}
+    <PaperDialogActions @class="layout-row">
       <span class="flex"></span>
-      {{#paper-button primary=true onClick=(action "closePromptDialog" "cancel")}}I'm a cat person{{/paper-button}}
-      {{#paper-button primary=true onClick=(action "closePromptDialog" "ok" dogName)}}Okay!{{/paper-button}}
-    {{/paper-dialog-actions}}
+      <PaperButton @primary={{true}} @onClick={{action "closePromptDialog" "cancel"}}>I'm a cat person</PaperButton>
+      <PaperButton @primary={{true}} @onClick={{action "closePromptDialog" "ok" dogName}}>Okay!</PaperButton>
+    </PaperDialogActions>
 
-  {{/paper-dialog}}
+  </PaperDialog>
 {{/if}}
 
 {{#if showAnimatedDialog}}
-  {{#paper-dialog fullscreen=fullscreen onClose=(action "closeAnimatedDialog") openFrom="#paper-dialog-demo" closeTo="#bottom-of-card"}}
+  <PaperDialog @fullscreen={{fullscreen}} @onClose={{action "closeAnimatedDialog"}} @openFrom="#paper-dialog-demo" @closeTo="#bottom-of-card">
 
-    {{#paper-dialog-content}}
+    <PaperDialogContent>
       <h2 class="md-title">This dialog is animated!</h2>
       <p>It opened from above, but it will close to below.</p>
-    {{/paper-dialog-content}}
+    </PaperDialogContent>
 
-    {{#paper-dialog-actions class="layout-row"}}
+    <PaperDialogActions @class="layout-row">
       <span class="flex"></span>
-      {{#paper-button primary=true onClick=(action "closeAnimatedDialog")}}Okay!{{/paper-button}}
-    {{/paper-dialog-actions}}
+      <PaperButton @primary={{true}} @onClick={{action "closeAnimatedDialog"}}>Okay!</PaperButton>
+    </PaperDialogActions>
 
-  {{/paper-dialog}}
+  </PaperDialog>
 {{/if}}
 {{! END-SNIPPET }}

--- a/tests/dummy/app/templates/demo/divider.hbs
+++ b/tests/dummy/app/templates/demo/divider.hbs
@@ -1,69 +1,69 @@
-{{page-toolbar pageTitle="Divider" isDemo=true}}
+<PageToolbar @pageTitle="Divider" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Full Bleed</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggleSourceCodeFull") iconButton=true}}
-          {{paper-icon icon="code"}}
-        {{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-content}}
+        <PaperButton @onClick={{action "toggleSourceCodeFull"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+        </PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperContent>
       <div class="doc-code-example {{if showSourceCodeFull "is-visible"}}">
-        {{code-snippet name="divider.full.hbs"}}
+        <CodeSnippet @name="divider.full.hbs" />
       </div>
       {{! BEGIN-SNIPPET divider.full }}
-      {{#paper-list}}
+      <PaperList>
         {{#each messages as |item|}}
-          {{#paper-item class="md-3-line"}}
+          <PaperItem @class="md-3-line">
             <div class="md-list-item-text">
               <h3>{{item.what}}</h3>
               <h4>{{item.who}}</h4>
               <p>{{item.notes}}</p>
             </div>
-            {{paper-divider}}
-            {{#paper-button}}Respond{{/paper-button}}
-          {{/paper-item}}
+            <PaperDivider />
+            <PaperButton>Respond</PaperButton>
+          </PaperItem>
         {{/each}}
-      {{/paper-list}}
+      </PaperList>
       {{! END-SNIPPET }}
-    {{/paper-content}}
+    </PaperContent>
 
-  {{/paper-card}}
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Inset</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggleSourceCodeInset") iconButton=true}}
-          {{paper-icon icon="code"}}
-        {{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-content}}
+        <PaperButton @onClick={{action "toggleSourceCodeInset"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+        </PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperContent>
       <div class="doc-code-example {{if showSourceCodeInset "is-visible"}}">
-        {{code-snippet name="divider.inset.hbs"}}
+        <CodeSnippet @name="divider.inset.hbs" />
       </div>
       {{! BEGIN-SNIPPET divider.inset }}
-      {{#paper-list classNames="list-demo"}}
+      <PaperList @classNames="list-demo">
         {{#each messages as |item|}}
-          {{#paper-item class="md-3-line"}}
+          <PaperItem @class="md-3-line">
             <img src="{{item.face}}?{{$index}}" class="face" alt={{item.who}}>
             <div class="md-list-item-text">
               <h3>{{item.what}}</h3>
               <h4>{{item.who}}</h4>
               <p>{{item.notes}}</p>
             </div>
-            {{paper-divider inset=true}}
-          {{/paper-item}}
+            <PaperDivider @inset={{true}} />
+          </PaperItem>
         {{/each}}
-      {{/paper-list}}
+      </PaperList>
       {{! END-SNIPPET }}
-    {{/paper-content}}
-  {{/paper-card}}
-{{/doc-content}}
+    </PaperContent>
+  </PaperCard>
+</DocContent>

--- a/tests/dummy/app/templates/demo/grid-list.hbs
+++ b/tests/dummy/app/templates/demo/grid-list.hbs
@@ -1,103 +1,94 @@
-{{page-toolbar pageTitle="Grid List" isDemo=true}}
+<PageToolbar @pageTitle="Grid List" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   <h2>Basic Usage</h2>
   {{! BEGIN-SNIPPET grid-list.basic-usage }}
-  {{#paper-content class="md-whiteframe-z1 grid-list-demo1"}}
+  <PaperContent @class="md-whiteframe-z1 grid-list-demo1">
 
-    {{#paper-grid-list
-      cols="1 md-2 gt-md-6"
-      rowHeight="gt-md-1:1 2:2"
-      gutter="12px gt-sm-8px" as |grid|}}
+    <PaperGridList @cols="1 md-2 gt-md-6" @rowHeight="gt-md-1:1 2:2" @gutter="12px gt-sm-8px" as |grid|>
 
-      {{#grid.tile class="gray" rowspan="2" colspan="sm-1 gt-sm-2" as |tile|}}
-        {{#tile.footer}}
+      <grid.tile @class="gray" @rowspan="2" @colspan="sm-1 gt-sm-2" as |tile|>
+        <tile.footer>
           <h3>#1: (3r x 2c)</h3>
-        {{/tile.footer}}
-      {{/grid.tile}}
+        </tile.footer>
+      </grid.tile>
 
-      {{#grid.tile class="green" as |tile|}}
-        {{#tile.footer}}
+      <grid.tile @class="green" as |tile|>
+        <tile.footer>
           <h3>#2: (1r x 1c)</h3>
-        {{/tile.footer}}
-      {{/grid.tile}}
+        </tile.footer>
+      </grid.tile>
 
-      {{#grid.tile class="yellow" as |tile|}}
-        {{#tile.footer}}
+      <grid.tile @class="yellow" as |tile|>
+        <tile.footer>
           <h3>#3: (1r x 1c)</h3>
-        {{/tile.footer}}
-      {{/grid.tile}}
+        </tile.footer>
+      </grid.tile>
 
-      {{#grid.tile class="blue" rowspan="2" as |tile|}}
-        {{#tile.footer}}
+      <grid.tile @class="blue" @rowspan="2" as |tile|>
+        <tile.footer>
           <h3>#4: (2r x 1c)</h3>
-        {{/tile.footer}}
-      {{/grid.tile}}
+        </tile.footer>
+      </grid.tile>
 
-      {{#grid.tile class="red" rowspan="2" colspan="sm-1 gt-sm-2" as |tile|}}
-        {{#tile.footer}}
+      <grid.tile @class="red" @rowspan="2" @colspan="sm-1 gt-sm-2" as |tile|>
+        <tile.footer>
           <h3>#5: (2r x 2c)</h3>
-        {{/tile.footer}}
-      {{/grid.tile}}
+        </tile.footer>
+      </grid.tile>
 
-      {{#grid.tile class="green" rowspan="2" as |tile|}}
-        {{#tile.footer}}
+      <grid.tile @class="green" @rowspan="2" as |tile|>
+        <tile.footer>
           <h3>#6: (2r x 1c)</h3>
-        {{/tile.footer}}
-      {{/grid.tile}}
+        </tile.footer>
+      </grid.tile>
 
-    {{/paper-grid-list}}
+    </PaperGridList>
 
-  {{/paper-content}}
+  </PaperContent>
   {{ END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="grid-list.basic-usage.hbs"}}
+  <CodeSnippet @name="grid-list.basic-usage.hbs" />
 
   <h2>Dynamic Tiles</h2>
   {{! BEGIN-SNIPPET grid-list.dynamic-tiles }}
-  {{#paper-content class="md-whiteframe-z1 grid-list-demo-dynamicTiles"}}
-    {{#paper-grid-list
-      cols="sm-2 md-4 gt-md-6"
-      rowHeight="4:3 gt-md-1:1"
-      gutter="8px gt-sm-4px" as |grid|}}
+  <PaperContent @class="md-whiteframe-z1 grid-list-demo-dynamicTiles">
+    <PaperGridList @cols="sm-2 md-4 gt-md-6" @rowHeight="4:3 gt-md-1:1" @gutter="8px gt-sm-4px" as |grid|>
 
       {{#each tiles as |dynamicTile|}}
-        {{#grid.tile rowspan=dynamicTile.span.row colspan=(concat dynamicTile.span.col " xs-1")  class=dynamicTile.background as |tile|}}
+        <grid.tile @rowspan={{dynamicTile.span.row}} @colspan={{concat dynamicTile.span.col " xs-1"}} @class={{dynamicTile.background}} as |tile|>
           <md-icon></md-icon>
-          {{#tile.footer}}
+          <tile.footer>
             <h3>{{dynamicTile.title}}</h3>
-          {{/tile.footer}}
-        {{/grid.tile}}
+          </tile.footer>
+        </grid.tile>
       {{/each}}
 
-    {{/paper-grid-list}}
-  {{/paper-content}}
+    </PaperGridList>
+  </PaperContent>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="grid-list.dynamic-tiles.hbs"}}
+  <CodeSnippet @name="grid-list.dynamic-tiles.hbs" />
 
   <h2>Responsive and Animated Usage</h2>
   {{! BEGIN-SNIPPET grid-list.responsive }}
-  {{#paper-content class="md-whiteframe-z1 grid-list-demo-responsiveTiles"}}
+  <PaperContent @class="md-whiteframe-z1 grid-list-demo-responsiveTiles">
 
-    {{#paper-grid-list
-      cols="3 md-8 gt-md-12"
-      rowHeight="4:3 gt-md-1:1"
-      gutter="4px md-8px gt-md-16px" as |grid|}}
+    <PaperGridList @cols="3 md-8 gt-md-12" @rowHeight="4:3 gt-md-1:1" @gutter="4px md-8px gt-md-16px" as |grid|>
 
       {{#each colorTiles as |tile|}}
 
-        {{#grid.tile colspan=tile.colspan rowspan=tile.rowspan class=tile.style}}
-        {{/grid.tile}}
+        <grid.tile @colspan={{tile.colspan}} @rowspan={{tile.rowspan}} @class={{tile.style}}>
+        </grid.tile>
 
       {{/each}}
-    {{/paper-grid-list}}
-  {{/paper-content}}
+    </PaperGridList>
+  </PaperContent>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="grid-list.responsive.hbs"}}
+  <CodeSnippet @name="grid-list.responsive.hbs" />
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/icons.hbs
+++ b/tests/dummy/app/templates/demo/icons.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Icons" isDemo=true}}
+<PageToolbar @pageTitle="Icons" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
   <h2>Available Icons</h2>
   <p>
@@ -16,7 +16,7 @@
     {{paper-icon "check-circle"}}
     {{! END-SNIPPET }}
   </div>
-  {{code-snippet name="icons.basic-usage.hbs"}}
+  <CodeSnippet @name="icons.basic-usage.hbs" />
 
   <h3>Changing Sizes</h3>
   <div class="layout-row">
@@ -28,7 +28,7 @@
     {{paper-icon "check-circle" size=48}}
     {{! END-SNIPPET }}
   </div>
-  {{code-snippet name="icons.sizes.hbs"}}
+  <CodeSnippet @name="icons.sizes.hbs" />
 
   <h3>Spinners</h3>
   <div>
@@ -37,5 +37,5 @@
     {{paper-icon "rotate-left" reverseSpin=true}}
     {{! END-SNIPPET }}
   </div>
-  {{code-snippet name="icons.spinners.hbs"}}
-{{/doc-content}}
+  <CodeSnippet @name="icons.spinners.hbs" />
+</DocContent>

--- a/tests/dummy/app/templates/demo/input.hbs
+++ b/tests/dummy/app/templates/demo/input.hbs
@@ -1,95 +1,53 @@
-{{page-toolbar pageTitle="Input" isDemo=true}}
+<PageToolbar @pageTitle="Input" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   {{! BEGIN-SNIPPET input.basic-usage}}
   <div class="layout layout-sm-column">
-    {{paper-input class="flex-30" label="Name" placeholder="Enter name" value=name onChange=(action (mut name))}}
-    {{paper-input class="flex-30" label="E-mail" type="email" value=email onChange=(action (mut email))}}
-    {{paper-input class="flex-40" label="Password" type="password" value=password onChange=(action (mut password))}}
+    <PaperInput @class="flex-30" @label="Name" @placeholder="Enter name" @value={{name}} @onChange={{action (mut name)}} />
+    <PaperInput @class="flex-30" @label="E-mail" @type="email" @value={{email}} @onChange={{action (mut email)}} />
+    <PaperInput @class="flex-40" @label="Password" @type="password" @value={{password}} @onChange={{action (mut password)}} />
   </div>
   <div class="layout layout-sm-column">
-    {{paper-input class="flex" label="Submission date" type="date" value=date onChange=(action (mut date))}}
-    {{paper-input class="flex" label="Company (disabled)" type="text" value="Google" disabled=true onChange=(action (mut foo))}}
+    <PaperInput @class="flex" @label="Submission date" @type="date" @value={{date}} @onChange={{action (mut date)}} />
+    <PaperInput @class="flex" @label="Company (disabled)" @type="text" @value="Google" @disabled={{true}} @onChange={{action (mut foo)}} />
   </div>
 
-  {{paper-input textarea=true block=true label="Biography" maxlength=150 passThru=(hash rows=5 maxRows=5)
-    value=biography onChange=(action (mut biography))}}
+  <PaperInput @textarea={{true}} @block={{true}} @label="Biography" @maxlength={{150}} @passThru={{hash rows=5 maxRows=5}} @value={{biography}} @onChange={{action (mut biography)}} />
   <p>Name: {{name}}</p>
   <p>Email: {{email}}</p>
 
   <h3>Input Errors</h3>
   <p>
-    {{paper-input
-      label="Address"
-      value=address
-      onChange=(action (mut address))
-      required=true
-      errorMessages=(hash
+    <PaperInput @label="Address" @value={{address}} @onChange={{action (mut address)}} @required={{true}} @errorMessages={{hash
         required="Address is required."
-      )
-    }}
-    {{paper-input
-      type="number"
-      label="Maximum Value"
-      value=maxNumber
-      onChange=(action (mut maxNumber))
-      max="5"
-      errorMessages=(hash
+      }} />
+    <PaperInput @type="number" @label="Maximum Value" @value={{maxNumber}} @onChange={{action (mut maxNumber)}} @max="5" @errorMessages={{hash
         max="Enter 5 or less."
-      )
-    }}
-    {{paper-input
-      type="number"
-      label="Minimum Value"
-      value=minNumber
-      onChange=(action (mut minNumber))
-      min="1"
-      errorMessages=(hash
+      }} />
+    <PaperInput @type="number" @label="Minimum Value" @value={{minNumber}} @onChange={{action (mut minNumber)}} @min="1" @errorMessages={{hash
         min="Enter at least 1."
-      )
-    }}
-    {{paper-input
-      label="Maximum Character Length"
-      value=maxLength
-      onChange=(action (mut maxLength))
-      required=true
-      maxlength=10
-      errorMessages=(hash
+      }} />
+    <PaperInput @label="Maximum Character Length" @value={{maxLength}} @onChange={{action (mut maxLength)}} @required={{true}} @maxlength={{10}} @errorMessages={{hash
         maxlength="Maximum length exceeded."
-      )
-    }}
-    {{paper-input
-      label="All Constraints"
-      value=allConstraints
-      onChange=(action (mut allConstraints))
-      required=true
-      min="2"
-      max="10"
-      maxlength="2"
-      errorMessages=(hash
+      }} />
+    <PaperInput @label="All Constraints" @value={{allConstraints}} @onChange={{action (mut allConstraints)}} @required={{true}} @min="2" @max="10" @maxlength="2" @errorMessages={{hash
         maxlength="Max length exceeded."
-      )
-    }}
-    {{paper-input
-      label="Required asterisk only"
-      value=requiredStyle
-      onChange=(action (mut requiredStyle))
-      required="style"
-    }}
+      }} />
+    <PaperInput @label="Required asterisk only" @value={{requiredStyle}} @onChange={{action (mut requiredStyle)}} @required="style" />
   </p>
 
   <h3>Icons</h3>
   <p>
-    {{paper-input label="Name" value=name onChange=(action (mut name)) icon="person"}}
-    {{paper-input placeholder="Phone Number" type="text" value=user.phone onChange=(action (mut user.phone)) icon="phone"}}
-    {{paper-input label="Email (no messages)" type="email" value=user.email onChange=(action (mut user.email)) icon="email" required=true hideAllMessages=true}}
-    {{paper-input placeholder="Address" type="text" value=user.address onChange=(action (mut user.address)) icon="place"}}
-    {{paper-input label="Name on right" type="text" value=name2 onChange=(action (mut name2)) iconRight="person"}}
+    <PaperInput @label="Name" @value={{name}} @onChange={{action (mut name)}} @icon="person" />
+    <PaperInput @placeholder="Phone Number" @type="text" @value={{user.phone}} @onChange={{action (mut user.phone)}} @icon="phone" />
+    <PaperInput @label="Email (no messages)" @type="email" @value={{user.email}} @onChange={{action (mut user.email)}} @icon="email" @required={{true}} @hideAllMessages={{true}} />
+    <PaperInput @placeholder="Address" @type="text" @value={{user.address}} @onChange={{action (mut user.address)}} @icon="place" />
+    <PaperInput @label="Name on right" @type="text" @value={{name2}} @onChange={{action (mut name2)}} @iconRight="person" />
   </p>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="input.basic-usage.hbs"}}
+  <CodeSnippet @name="input.basic-usage.hbs" />
 
   <p>
     <strong>About Required.</strong>
@@ -109,16 +67,10 @@
   </p>
   <p>
     {{! BEGIN-SNIPPET input.attributes }}
-    {{paper-input
-      value=numberTest
-      onChange=(action (mut numberTest))
-      label="Number of bagels"
-      type="number"
-      passThru=(hash min="0" step="13" )
-    }}
+    <PaperInput @value={{numberTest}} @onChange={{action (mut numberTest)}} @label="Number of bagels" @type="number" @passThru={{hash min="0" step="13" }} />
     {{! END-SNIPPET }}
 
-    {{code-snippet name="input.attributes.hbs"}}
+    <CodeSnippet @name="input.attributes.hbs" />
   </p>
 
   <h4>Available Attributes for Text Fields</h4>
@@ -173,19 +125,12 @@
   </p>
   <p>
     {{! BEGIN-SNIPPET input.actions }}
-    {{paper-input
-      label="Event demonstration"
-      value=eventTest
-      onChange=(action (mut eventTest))
-      onFocus=(action "focusReceived")
-      onBlur=(action "blurReceived")
-      onKeyDown=(action "keyDownReceived")
-    }}
+    <PaperInput @label="Event demonstration" @value={{eventTest}} @onChange={{action (mut eventTest)}} @onFocus={{action "focusReceived"}} @onBlur={{action "blurReceived"}} @onKeyDown={{action "keyDownReceived"}} />
     {{! END-SNIPPET }}
     {{#if eventName}}
       <div>The leaf controller for this route received the sent <strong>{{eventName}}</strong> action.</div>
     {{/if}}
-    {{code-snippet name="input.actions.hbs"}}
+    <CodeSnippet @name="input.actions.hbs" />
   </p>
 
   {{#paper-api
@@ -206,17 +151,13 @@
     </p>
     <div>
       {{! BEGIN-SNIPPET input.textHelper }}
-      {{#paper-input
-        value=emailValue
-        onChange=(action (mut emailValue))
-        label="Email"
-        type="email" as |input|}}
+      <PaperInput @value={{emailValue}} @onChange={{action (mut emailValue)}} @label="Email" @type="email" as |input|>
         {{#unless input.hasValue}}
           <div class="hint">How can we reach you?</div>
         {{/unless}}
-      {{/paper-input}}
+      </PaperInput>
       {{! END-SNIPPET }}
-      {{code-snippet name="input.textHelper.hbs"}}
+      <CodeSnippet @name="input.textHelper.hbs" />
     </div>
   {{/paper-api}}
 
@@ -237,26 +178,26 @@
   </p>
   <p>
     {{! BEGIN-SNIPPET input.custom-validations }}
-    {{paper-input label="E-mail" type="email" value=customemail onChange=(action (mut customemail)) customValidations=emailValidation}}
+    <PaperInput @label="E-mail" @type="email" @value={{customemail}} @onChange={{action (mut customemail)}} @customValidations={{emailValidation}} />
     {{! END-SNIPPET }}
   </p>
 
   <h3>Template</h3>
-  {{code-snippet name="input.custom-validations.hbs"}}
+  <CodeSnippet @name="input.custom-validations.hbs" />
   <p>
     Define your <code>emailValidation</code> object in your controller.
-    {{code-snippet name="input.controller.email-validation.js"}}
+    <CodeSnippet @name="input.controller.email-validation.js" />
   </p>
   <p>
     You may also define multiple custom constraints by using an array of validation objects.
   </p>
   <p>
     {{! BEGIN-SNIPPET input.multiple-constraints }}
-    {{paper-input class="md-block" label="Value should be even and equal 4." type="email" value=customMultiple onChange=(action (mut customMultiple)) customValidations=multipleConstraints}}
+    <PaperInput @class="md-block" @label="Value should be even and equal 4." @type="email" @value={{customMultiple}} @onChange={{action (mut customMultiple)}} @customValidations={{multipleConstraints}} />
     {{! END-SNIPPET }}
   </p>
-  {{code-snippet name="input.multiple-constraints.hbs"}}
-  {{code-snippet name="input.controller.multiple-constraints.js"}}
+  <CodeSnippet @name="input.multiple-constraints.hbs" />
+  <CodeSnippet @name="input.controller.multiple-constraints.js" />
 
   <h2>Setting validation messages from external validations</h2>
   <p>
@@ -269,49 +210,22 @@
     <code>\{{paper-input}}</code> helper.
   </p>
   {{! BEGIN-SNIPPET input.external-validations }}
-  {{#paper-card as |card|}}
-    {{#card.content}}
+  <PaperCard as |card|>
+    <card.content>
       <div class="layout layout-sm-row">
-        {{paper-input
-          class="flex-50"
-          label="User name"
-          value=model.username
-          onChange=(action (mut model.username))
-          errors=model.validations.attrs.username.messages
-        }}
+        <PaperInput @class="flex-50" @label="User name" @value={{model.username}} @onChange={{action (mut model.username)}} @errors={{model.validations.attrs.username.messages}} />
       </div>
       <div class="layout layout-sm-row">
-        {{paper-input
-          label="Password"
-          class="flex-34"
-          type="password"
-          value=model.password
-          onChange=(action (mut model.password))
-          errors=model.validations.attrs.password.messages
-        }}
-        {{paper-input
-          label="E-mail"
-          class="flex-33"
-          type="email"
-          value=model.email
-          onChange=(action (mut model.email))
-          errors=model.validations.attrs.email.messages
-        }}
-        {{paper-input
-          label="Retype your e-mail"
-          class="flex-33"
-          type="email"
-          value=model.emailConfirmation
-          onChange=(action (mut model.emailConfirmation))
-          errors=model.validations.attrs.emailConfirmation.messages
-        }}
+        <PaperInput @label="Password" @class="flex-34" @type="password" @value={{model.password}} @onChange={{action (mut model.password)}} @errors={{model.validations.attrs.password.messages}} />
+        <PaperInput @label="E-mail" @class="flex-33" @type="email" @value={{model.email}} @onChange={{action (mut model.email)}} @errors={{model.validations.attrs.email.messages}} />
+        <PaperInput @label="Retype your e-mail" @class="flex-33" @type="email" @value={{model.emailConfirmation}} @onChange={{action (mut model.emailConfirmation)}} @errors={{model.validations.attrs.emailConfirmation.messages}} />
       </div>
-    {{/card.content}}
-  {{/paper-card}}
+    </card.content>
+  </PaperCard>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="input.external-validations.hbs"}}
+  <CodeSnippet @name="input.external-validations.hbs" />
 
   <p>
     The <code>errors</code> argument can either be an array of messages or an array of
@@ -320,4 +234,4 @@
     The latter format is compatible with errors from <code>ember-data</code>.
   </p>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/list.hbs
+++ b/tests/dummy/app/templates/demo/list.hbs
@@ -1,46 +1,46 @@
-{{page-toolbar pageTitle="List" isDemo=true}}
+<PageToolbar @pageTitle="List" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic Usage</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-content}}
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperContent>
       {{! BEGIN-SNIPPET list }}
-      {{#paper-list}}
-        {{#paper-subheader}}3 line item{{/paper-subheader}}
+      <PaperList>
+        <PaperSubheader>3 line item</PaperSubheader>
         {{#each listData as |item|}}
-          {{#paper-item class="md-3-line"}}
+          <PaperItem @class="md-3-line">
             <img src={{item.img}} alt={{item.name}} class="md-avatar">
             <div class="md-list-item-text">
               <h3>{{item.name}}</h3>
               <h4>{{item.email}}</h4>
               <p>Some longer notes here could be here. But they aren't.</p>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}2 line item{{/paper-subheader}}
+        <PaperSubheader>2 line item</PaperSubheader>
         {{#each listData as |item|}}
-          {{#paper-item class="md-2-line"}}
+          <PaperItem @class="md-2-line">
             <img src={{item.img}} alt={{item.name}} class="md-avatar">
             <div class="md-list-item-text">
               <h3>{{item.name}}</h3>
               <p>{{item.email}}</p>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}3 line item, long paragraph{{/paper-subheader}}
+        <PaperSubheader>3 line item, long paragraph</PaperSubheader>
         {{#each listData as |item|}}
-          {{#paper-item class="md-3-line md-long-text"}}
+          <PaperItem @class="md-3-line md-long-text">
             <img src={{item.img}} alt={{item.name}} class="md-avatar">
             <div class="md-list-item-text">
               <h3>{{item.name}}</h3>
@@ -50,183 +50,176 @@
                 velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
               </p>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Icons{{/paper-subheader}}
+        <PaperSubheader>Icons</PaperSubheader>
         {{#each phoneNumbers as |phone|}}
-          {{#paper-item class="md-2-line"}}
+          <PaperItem @class="md-2-line">
             {{paper-icon "phone" class="md-avatar-icon"}}
             <div class="md-list-item-text">
               <h3>{{phone.number}}</h3>
               <p>{{phone.type}}</p>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-      {{/paper-list}}
+      </PaperList>
       {{! END-SNIPPET }}
-    {{/paper-content}}
-  {{/paper-card}}
+    </PaperContent>
+  </PaperCard>
 
   <h3>Template</h3>
-  {{code-snippet name="list.hbs"}}
+  <CodeSnippet @name="list.hbs" />
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>List Controls</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-content}}
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperContent>
       {{! BEGIN-SNIPPET list-controls }}
-      {{#paper-list}}
+      <PaperList>
 
-        {{#paper-subheader}}Single Action Checkboxes{{/paper-subheader}}
+        <PaperSubheader>Single Action Checkboxes</PaperSubheader>
         {{#each toppings as |topping|}}
-          {{#paper-item as |controls|}}
+          <PaperItem as |controls|>
             <p>{{topping.name}}</p>
             <div class="md-secondary-container">
-              {{controls.checkbox
-                value=topping.enabled
-                secondary=true
-                onChange=(action (mut topping.enabled))}}
+              <controls.checkbox @value={{topping.enabled}} @secondary={{true}} @onChange={{action (mut topping.enabled)}} />
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Secondary Buttons{{/paper-subheader}}
-        {{#paper-item as |controls|}}
+        <PaperSubheader>Secondary Buttons</PaperSubheader>
+        <PaperItem as |controls|>
           <p>Clicking the button to the right will fire the secondary action</p>
           <div class="md-secondary-container">
-            {{#controls.button secondary=true onClick=(action "transitionTo" "more info")}}
+            <controls.button @secondary={{true}} @onClick={{action "transitionTo" "more info"}}>
               More Info
-            {{/controls.button}}
+            </controls.button>
           </div>
-        {{/paper-item}}
-        {{#paper-item onClick=(action "transitionTo" "primary action") as |controls|}}
+        </PaperItem>
+        <PaperItem @onClick={{action "transitionTo" "primary action"}} as |controls|>
           <p>Click anywhere to fire the primary action, or the button to fire the secondary</p>
           <div class="md-secondary-container">
-            {{#controls.button secondary=true onClick=(action "transitionTo" "secondary action")}}
+            <controls.button @secondary={{true}} @onClick={{action "transitionTo" "secondary action"}}>
               More Info
-            {{/controls.button}}
+            </controls.button>
           </div>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Clickable Items with Secondary Controls{{/paper-subheader}}
-        {{#paper-item onClick=(action "transitionToWifiMenu") as |controls|}}
+        <PaperSubheader>Clickable Items with Secondary Controls</PaperSubheader>
+        <PaperItem @onClick={{action "transitionToWifiMenu"}} as |controls|>
           {{paper-icon "network-wifi"}}
           <p>Wi-Fi</p>
           <div class="md-secondary-container">
-            {{controls.switch secondary=true value=wifiEnabled onChange=(action (mut wifiEnabled))}}
+            <controls.switch @secondary={{true}} @value={{wifiEnabled}} @onChange={{action (mut wifiEnabled)}} />
           </div>
-        {{/paper-item}}
-        {{#paper-item onClick=(action "transitionToBluetoothMenu") as |controls|}}
+        </PaperItem>
+        <PaperItem @onClick={{action "transitionToBluetoothMenu"}} as |controls|>
           {{paper-icon "bluetooth"}}
           <p>Bluetooth</p>
           <div class="md-secondary-container">
-            {{controls.switch secondary=true value=bluetoothEnabled onChange=(action (mut bluetoothEnabled))}}
+            <controls.switch @secondary={{true}} @value={{bluetoothEnabled}} @onChange={{action (mut bluetoothEnabled)}} />
           </div>
-        {{/paper-item}}
-        {{#paper-item onClick=(action "transitionToDataUsage")}}
+        </PaperItem>
+        <PaperItem @onClick={{action "transitionToDataUsage"}}>
           {{paper-icon "data-usage"}}
           <p>Data Usage</p>
-        {{/paper-item}}
+        </PaperItem>
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Checkbox with Secondary Action{{/paper-subheader}}
+        <PaperSubheader>Checkbox with Secondary Action</PaperSubheader>
         {{#each messageData as |item|}}
-          {{#paper-item as |controls|}}
-            {{controls.checkbox value=item.checked onChange=(action (mut item.checked))}}
+          <PaperItem as |controls|>
+            <controls.checkbox @value={{item.checked}} @onChange={{action (mut item.checked)}} />
             <p>{{item.message}}</p>
             <div class="md-secondary-container">
-              {{#controls.button secondary=true iconButton=true onClick=(action "secondaryMessageClick" item)}}
+              <controls.button @secondary={{true}} @iconButton={{true}} @onClick={{action "secondaryMessageClick" item}}>
                 {{paper-icon "message"}}
-              {{/controls.button}}
+              </controls.button>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Avatar with Secondary Action Icon{{/paper-subheader}}
+        <PaperSubheader>Avatar with Secondary Action Icon</PaperSubheader>
         {{#each listData as |item|}}
-          {{#paper-item onClick=(action "goToPerson" item) as |controls|}}
+          <PaperItem @onClick={{action "goToPerson" item}} as |controls|>
             <img src={{item.img}} alt={{item.name}} class="md-avatar">
             <p>{{item.name}}</p>
             <div class="md-secondary-container">
-              {{controls.checkbox value=item.checked onChange=(action (mut item.checked))}}
-              {{#controls.button secondary=true iconButton=true onClick=(action "secondaryMessageClick" item)}}
+              <controls.checkbox @value={{item.checked}} @onChange={{action (mut item.checked)}} />
+              <controls.button @secondary={{true}} @iconButton={{true}} @onClick={{action "secondaryMessageClick" item}}>
                 {{paper-icon "email"}}
-              {{/controls.button}}
-              {{#controls.button secondary=true iconButton=true onClick=(action "secondaryMessageClick" item)}}
+              </controls.button>
+              <controls.button @secondary={{true}} @iconButton={{true}} @onClick={{action "secondaryMessageClick" item}}>
                 {{paper-icon "message"}}
-              {{/controls.button}}
+              </controls.button>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Clickable Avatars{{/paper-subheader}}
+        <PaperSubheader>Clickable Avatars</PaperSubheader>
         {{#each listData as |item|}}
-          {{#paper-item class="md-3-line" onClick=(action "goToPerson" item)}}
+          <PaperItem @class="md-3-line" @onClick={{action "goToPerson" item}}>
             <img src={{item.img}} alt={{item.name}} class="md-avatar">
             <div class="md-list-item-text">
               <h3>{{item.name}}</h3>
               <h4>{{item.email}}</h4>
               <p>Some notes here.</p>
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-        {{paper-divider}}
+        <PaperDivider />
 
-        {{#paper-subheader}}Avatar with Secondary Action Icon{{/paper-subheader}}
+        <PaperSubheader>Avatar with Secondary Action Icon</PaperSubheader>
         {{#each listData as |item|}}
-          {{#paper-item class="md-3-line" onClick=(action "goToPerson" item) as |controls|}}
+          <PaperItem @class="md-3-line" @onClick={{action "goToPerson" item}} as |controls|>
             <img src={{item.img}} alt={{item.name}} class="md-avatar">
             <div class="md-list-item-text">
               <h3>{{item.name}}</h3>
               <h4>{{item.email}}</h4>
               <p>Some notes here.</p>
             </div>
-            {{#controls.button secondary=true iconButton=true onClick=(action "secondaryPersonClick" item)}}
+            <controls.button @secondary={{true}} @iconButton={{true}} @onClick={{action "secondaryPersonClick" item}}>
               {{paper-icon "phone"}}
-            {{/controls.button}}
-          {{/paper-item}}
+            </controls.button>
+          </PaperItem>
         {{/each}}
 
-        {{#paper-subheader}}Single Action Radios{{/paper-subheader}}
+        <PaperSubheader>Single Action Radios</PaperSubheader>
         {{#each toppings as |topping|}}
-          {{#paper-item as |controls|}}
+          <PaperItem as |controls|>
             <p>{{topping.name}}</p>
             <div class="md-secondary-container">
-              {{controls.radio
-                groupValue=radioSelectedTopping
-                value=topping
-                secondary=true
-                onChange=(action (mut radioSelectedTopping))}}
+              <controls.radio @groupValue={{radioSelectedTopping}} @value={{topping}} @secondary={{true}} @onChange={{action (mut radioSelectedTopping)}} />
             </div>
-          {{/paper-item}}
+          </PaperItem>
         {{/each}}
 
-      {{/paper-list}}
+      </PaperList>
       {{! END-SNIPPET }}
-    {{/paper-content}}
-  {{/paper-card}}
+    </PaperContent>
+  </PaperCard>
 
   <h3>Template</h3>
-  {{code-snippet name="list-controls.hbs"}}
+  <CodeSnippet @name="list-controls.hbs" />
 
-{{/doc-content}}
+</DocContent>
 
 
 

--- a/tests/dummy/app/templates/demo/menu.hbs
+++ b/tests/dummy/app/templates/demo/menu.hbs
@@ -1,15 +1,15 @@
-{{page-toolbar pageTitle="Menu" isDemo=true}}
+<PageToolbar @pageTitle="Menu" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic Usage</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-card-content}}
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperCardContent>
       <h2>Simple dropdown menu</h2>
 
       <p>
@@ -19,47 +19,47 @@
 
       <div class="layout-column layout-align-center-center">
         {{! BEGIN-SNIPPET menu.simple-dropdown }}
-        {{#paper-menu as |menu|}}
+        <PaperMenu as |menu|>
 
-          {{#menu.trigger}}
-            {{#paper-button iconButton=true}}
+          <menu.trigger>
+            <PaperButton @iconButton={{true}}>
               {{paper-icon "local_phone"}}
-            {{/paper-button}}
-          {{/menu.trigger}}
+            </PaperButton>
+          </menu.trigger>
 
-          {{#menu.content width=4 as |content|}}
+          <menu.content @width={{4}} as |content|>
             {{#each items as |item|}}
-              {{#content.menu-item onClick=(action this.openSomething)}}
+              <content.menu-item @onClick={{action this.openSomething}}>
                 {{paper-icon item.icon}}
                 <span>{{item.title}}</span>
-              {{/content.menu-item}}
+              </content.menu-item>
             {{/each}}
 
-            {{#content.menu-item onClick=(action this.openSomething) disabled=true}}
+            <content.menu-item @onClick={{action this.openSomething}} @disabled={{true}}>
               {{paper-icon "adb"}}
               <span>This is disabled.</span>
-            {{/content.menu-item}}
+            </content.menu-item>
 
-            {{paper-divider}}
+            <PaperDivider />
 
             {{#each items as |item|}}
-              {{#content.menu-item onClick=(action this.openSomething)}}
+              <content.menu-item @onClick={{action this.openSomething}}>
                 {{paper-icon item.icon}} {{item.title}}
-              {{/content.menu-item}}
+              </content.menu-item>
             {{/each}}
-          {{/menu.content}}
-        {{/paper-menu}}
+          </menu.content>
+        </PaperMenu>
         {{! END-SNIPPET }}
       </div>
 
       <h3>Template</h3>
-      {{code-snippet name="menu.simple-dropdown.hbs"}}
+      <CodeSnippet @name="menu.simple-dropdown.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-card-content}}
+  <PaperCard>
+    <PaperCardContent>
       <h2>Menu Position Modes</h2>
 
       <p>
@@ -73,75 +73,75 @@
         <div class="menus layout-fill layout-wrap layout-row layout-align-space-between-center">
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p>Target Mode Positioning (default)</p>
-            {{#paper-menu isOpen=menuTwoIsOpen as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu @isOpen={{menuTwoIsOpen}} as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content as |content|}}
+              <menu.content as |content|>
                 {{#each items as |item|}}
-                  {{#content.menu-item onClick=(action this.openSomething)}}
+                  <content.menu-item @onClick={{action this.openSomething}}>
                     {{paper-icon item.icon class="md-menu-align-target"}}
                     <span>{{item.title}}</span>
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
+              </menu.content>
 
-            {{/paper-menu}}
+            </PaperMenu>
           </div>
 
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p>Target mode with <code class="paper">offset</code></p>
-            {{#paper-menu isOpen=menuThreeIsOpen offset="0 50" as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu @isOpen={{menuThreeIsOpen}} @offset="0 50" as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content as |content|}}
+              <menu.content as |content|>
                 {{#each items as |item|}}
-                  {{#content.menu-item onClick=(action this.openSomething)}}
+                  <content.menu-item @onClick={{action this.openSomething}}>
                     {{paper-icon item.icon class="md-menu-align-target"}}
                     <span>{{item.title}}</span>
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
-            {{/paper-menu}}
+              </menu.content>
+            </PaperMenu>
           </div>
 
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p><code class="paper">position="target-right target"</code></p>
-            {{#paper-menu isOpen=menuFourIsOpen position="target-right target" as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu @isOpen={{menuFourIsOpen}} @position="target-right target" as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content as |content|}}
+              <menu.content as |content|>
                 {{#each items as |item|}}
-                  {{#content.menu-item onClick=(action this.openSomething)}}
+                  <content.menu-item @onClick={{action this.openSomething}}>
                     <p style="width: 190px;">{{item.title}}</p>
                     {{paper-icon item.icon class="md-menu-align-target"}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
                 {{#each items as |item|}}
-                  {{#content.menu-item onClick=(action this.openSomething)}}
+                  <content.menu-item @onClick={{action this.openSomething}}>
                     <p style="width: 190px;">{{item.title}}</p>
                     {{paper-icon item.icon class="md-menu-align-target"}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
                 {{#each items as |item|}}
-                  {{#content.menu-item onClick=(action this.openSomething)}}
+                  <content.menu-item @onClick={{action this.openSomething}}>
                     <p style="width: 190px;">{{item.title}}</p>
                     {{paper-icon item.icon class="md-menu-align-target"}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
-            {{/paper-menu}}
+              </menu.content>
+            </PaperMenu>
           </div>
         </div>
         {{! END-SNIPPET }}
@@ -155,15 +155,15 @@
         classes to specify where it should position itself in respect to origin and align-target.
       </p>
 
-      {{code-snippet name="menu.position-modes.hbs"}}
+      <CodeSnippet @name="menu.position-modes.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
 
 
-  {{#paper-card}}
-    {{#paper-card-content}}
+  <PaperCard>
+    <PaperCardContent>
       <h2>Different Widths</h2>
 
       <p>
@@ -177,73 +177,73 @@
         <div class="menus layout-fill layout-wrap layout-row layout-align-space-between-center">
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p>Wide menu (<code class="paper">width=6</code>)</p>
-            {{#paper-menu as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content width=6 as |content|}}
+              <menu.content @width={{6}} as |content|>
                 {{#each options as |item|}}
-                  {{#content.menu-item onClick=(action "openSomething")}}
+                  <content.menu-item @onClick={{action "openSomething"}}>
                     <span class="md-menu-align-target">Option</span> {{item}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
-            {{/paper-menu}}
+              </menu.content>
+            </PaperMenu>
           </div>
 
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p>Medium menu (<code class="paper">width=4</code>)</p>
-            {{#paper-menu as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content width=4 as |content|}}
+              <menu.content @width={{4}} as |content|>
                 {{#each options as |item|}}
-                  {{#content.menu-item onClick=(action "openSomething")}}
+                  <content.menu-item @onClick={{action "openSomething"}}>
                     <span class="md-menu-align-target">Option</span> {{item}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
-            {{/paper-menu}}
+              </menu.content>
+            </PaperMenu>
           </div>
 
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p>Small menu (<code class="paper">width=2</code>)</p>
-            {{#paper-menu as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content width=2 as |content|}}
+              <menu.content @width={{2}} as |content|>
                 {{#each options as |item|}}
-                  {{#content.menu-item onClick=(action "openSomething")}}
+                  <content.menu-item @onClick={{action "openSomething"}}>
                     <span class="md-menu-align-target">Option</span> {{item}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
-            {{/paper-menu}}
+              </menu.content>
+            </PaperMenu>
           </div>
         </div>
         {{! END-SNIPPET }}
       </div>
 
       <h3>Template</h3>
-      {{code-snippet name="menu.different-widths.hbs"}}
+      <CodeSnippet @name="menu.different-widths.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
 
-  {{#paper-card}}
-    {{#paper-card-content}}
+  <PaperCard>
+    <PaperCardContent>
       <h2>Dense menu</h2>
 
       <p>
@@ -256,30 +256,30 @@
         <div class="menus layout-fill layout-wrap layout-row layout-align-space-between-center">
           <div class="layout-column flex-33 flex-sm-100 layout-align-center-center">
             <p>Dense menu (<code class="paper">dense=true</code>)</p>
-            {{#paper-menu as |menu|}}
-              {{#menu.trigger}}
-                {{#paper-button onClick=null iconButton=true}}
+            <PaperMenu as |menu|>
+              <menu.trigger>
+                <PaperButton @onClick={{null}} @iconButton={{true}}>
                   {{paper-icon "local_phone" class="md-menu-origin"}}
-                {{/paper-button}}
-              {{/menu.trigger}}
+                </PaperButton>
+              </menu.trigger>
 
-              {{#menu.content dense=true as |content|}}
+              <menu.content @dense={{true}} as |content|>
                 {{#each options as |item|}}
-                  {{#content.menu-item onClick=(action "openSomething")}}
+                  <content.menu-item @onClick={{action "openSomething"}}>
                     <span class="md-menu-align-target">Option</span> {{item}}
-                  {{/content.menu-item}}
+                  </content.menu-item>
                 {{/each}}
-              {{/menu.content}}
-            {{/paper-menu}}
+              </menu.content>
+            </PaperMenu>
           </div>
         </div>
         {{! END-SNIPPET }}
       </div>
 
       <h3>Template</h3>
-      {{code-snippet name="menu.dense.hbs"}}
+      <CodeSnippet @name="menu.dense.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
+    </PaperCardContent>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/progress-circular.hbs
+++ b/tests/dummy/app/templates/demo/progress-circular.hbs
@@ -1,68 +1,68 @@
-{{page-toolbar pageTitle="Progress Circular" isDemo=true}}
+<PageToolbar @pageTitle="Progress Circular" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   <h2>Basic Usage</h2>
   <h3>Determinate</h3>
   <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
   <div class="layout-column layout-gt-sm-row layout-align-space-around">
     {{! BEGIN-SNIPPET progress-circular.determinate }}
-    {{paper-progress-circular value=determinateValue}}
+    <PaperProgressCircular @value={{determinateValue}} />
     {{! END-SNIPPET }}
   </div>
-  {{code-snippet name="progress-circular.determinate.hbs"}}
+  <CodeSnippet @name="progress-circular.determinate.hbs" />
   <h3>Indeterminate</h3>
   <p>For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
   <div class="layout-column layout-gt-sm-row layout-align-space-around">
     {{! BEGIN-SNIPPET progress-circular.indeterminate }}
-    {{paper-progress-circular}}
+    <PaperProgressCircular />
     {{! END-SNIPPET }}
   </div>
-  {{code-snippet name="progress-circular.indeterminate.hbs"}}
+  <CodeSnippet @name="progress-circular.indeterminate.hbs" />
 
   <h3>Theming</h3>
 
   <div class="layout-column layout-gt-sm-row layout-align-space-around layout-align-center">
     {{! BEGIN-SNIPPET progress-circular.theming }}
-    {{paper-progress-circular class="md-hue-2" diameter=25}}
-    {{paper-progress-circular accent=true diameter=40}}
-    {{paper-progress-circular accent=true class="md-hue-1" diameter=60}}
-    {{paper-progress-circular warn=true class="md-hue-3" diameter=70}}
-    {{paper-progress-circular warn=true diameter=96}}
+    <PaperProgressCircular @class="md-hue-2" @diameter={{25}} />
+    <PaperProgressCircular @accent={{true}} @diameter={{40}} />
+    <PaperProgressCircular @accent={{true}} @class="md-hue-1" @diameter={{60}} />
+    <PaperProgressCircular @warn={{true}} @class="md-hue-3" @diameter={{70}} />
+    <PaperProgressCircular @warn={{true}} @diameter={{96}} />
     {{! END-SNIPPET }}
   </div>
-  {{code-snippet name="progress-circular.theming.hbs"}}
+  <CodeSnippet @name="progress-circular.theming.hbs" />
 
   <h3>Playground</h3>
 
   <div class="layout-column layout-gt-sm-row">
     {{! BEGIN-SNIPPET progress-circular.playground }}
     <div class="flex layout-row layout-align-space-around layout-align-center">
-      {{paper-progress-circular value=sliderValue diameter=sliderDiameter strokeRatio=strokeRatio disabled=isDisabled}}
+      <PaperProgressCircular @value={{sliderValue}} @diameter={{sliderDiameter}} @strokeRatio={{strokeRatio}} @disabled={{isDisabled}} />
     </div>
     <div class="flex flex-gt-sm-33">
-      {{#paper-checkbox value=isIndeterminate onChange=(action "setIndeterminate")}}
+      <PaperCheckbox @value={{isIndeterminate}} @onChange={{action "setIndeterminate"}}>
         Indeterminate
-      {{/paper-checkbox}}
-      {{#paper-checkbox value=isDisabled onChange=(action (mut isDisabled))}}
+      </PaperCheckbox>
+      <PaperCheckbox @value={{isDisabled}} @onChange={{action (mut isDisabled)}}>
         Disabled
-      {{/paper-checkbox}}
+      </PaperCheckbox>
       <div class="layout layout-align-center-center slider-container">
         <span class="flex">Value ({{if sliderValue sliderValue "null"}})</span>
-        {{paper-slider class="flex" value=sliderValue min=0 max=100 onChange=(action "setValue")}}
+        <PaperSlider @class="flex" @value={{sliderValue}} @min={{0}} @max={{100}} @onChange={{action "setValue"}} />
       </div>
 
       <div class="layout layout-align-center-center slider-container">
         <span class="flex">Diameter ({{sliderDiameter}})</span>
-        {{paper-slider class="flex" value=sliderDiameter min=0 max=300 onChange=(action (mut sliderDiameter))}}
+        <PaperSlider @class="flex" @value={{sliderDiameter}} @min={{0}} @max={{300}} @onChange={{action (mut sliderDiameter)}} />
       </div>
 
       <div class="layout layout-align-center-center slider-container">
         <span class="flex">Stroke ratio ({{strokeRatio}})</span>
-        {{paper-slider class="flex" value=strokeRatio min=0 max=0.5 step=0.0025 onChange=(action (mut strokeRatio))}}
+        <PaperSlider @class="flex" @value={{strokeRatio}} @min={{0}} @max={{0.5}} @step={{0.0025}} @onChange={{action (mut strokeRatio)}} />
       </div>
 
     </div>
     {{! END-SNIPPET }}
   </div>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/progress-linear.hbs
+++ b/tests/dummy/app/templates/demo/progress-linear.hbs
@@ -1,33 +1,33 @@
-{{page-toolbar pageTitle="Progress Linear" isDemo=true}}
+<PageToolbar @pageTitle="Progress Linear" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   <h2>Basic Usage</h2>
 
   <h3>Determinate mode</h3>
   <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
   {{! BEGIN-SNIPPET progress-linear.determinate }}
-  {{paper-progress-linear value=determinateValue}}
+  <PaperProgressLinear @value={{determinateValue}} />
   {{! END-SNIPPET }}
-  {{code-snippet name="progress-linear.determinate.hbs"}}
+  <CodeSnippet @name="progress-linear.determinate.hbs" />
 
   <h3>Indeterminate mode</h3>
   <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator:</p>
   {{! BEGIN-SNIPPET progress-linear.indeterminate }}
-  {{paper-progress-linear}}
+  <PaperProgressLinear />
   {{! END-SNIPPET }}
-  {{code-snippet name="progress-linear.indeterminate.hbs"}}
+  <CodeSnippet @name="progress-linear.indeterminate.hbs" />
 
   <h3>Buffer mode</h3>
   <p>For operations where the user wants to indicate some activity or loading from the server, use the buffer indicator:</p>
   {{! BEGIN-SNIPPET progress-linear.buffer }}
-  {{paper-progress-linear warn=true value=determinateValue bufferValue=determinateValue2}}
+  <PaperProgressLinear @warn={{true}} @value={{determinateValue}} @bufferValue={{determinateValue2}} />
   {{! END-SNIPPET }}
-  {{code-snippet name="progress-linear.buffer.hbs"}}
+  <CodeSnippet @name="progress-linear.buffer.hbs" />
 
   <h3>Query mode</h3>
   <p>For situations where the user wants to indicate pre-loading (until the loading can actually be made), use the query indicator:</p>
   {{! BEGIN-SNIPPET progress-linear.query }}
-  {{paper-progress-linear accent=true mode=mode value=determinateValue}}
+  <PaperProgressLinear @accent={{true}} @mode={{mode}} @value={{determinateValue}} />
   {{! END-SNIPPET }}
-  {{code-snippet name="progress-linear.query.hbs"}}
-{{/doc-content}}
+  <CodeSnippet @name="progress-linear.query.hbs" />
+</DocContent>

--- a/tests/dummy/app/templates/demo/radio.hbs
+++ b/tests/dummy/app/templates/demo/radio.hbs
@@ -1,29 +1,24 @@
-{{page-toolbar pageTitle="Radio" isDemo=true}}
-{{#doc-content}}
-  {{#paper-card class="radio-button-demo"}}
-    {{#paper-card-content}}
+<PageToolbar @pageTitle="Radio" @isDemo={{true}} />
+<DocContent>
+  <PaperCard @class="radio-button-demo">
+    <PaperCardContent>
       <h2>Basic Usage</h2>
       <p>
         Stand alone
       </p>
       <div class="layout-row layout-align-space-around">
         {{! BEGIN-SNIPPET radio.standalone-usage }}
-        {{#paper-radio toggle=true value="Toggable" groupValue=toggleValue
-          onChange=(action (mut toggleValue))}}
+        <PaperRadio @toggle={{true}} @value="Toggable" @groupValue={{toggleValue}} @onChange={{action (mut toggleValue)}}>
           Toggable
-        {{/paper-radio}}
-        {{paper-radio label="Blockless"
-          toggle=true
-          value="Blockless"
-          groupValue=blocklessValue
-          onChange=(action (mut blocklessValue))}}
-        {{#paper-radio value=false disabled=true onChange=null}}
+        </PaperRadio>
+        <PaperRadio @label="Blockless" @toggle={{true}} @value="Blockless" @groupValue={{blocklessValue}} @onChange={{action (mut blocklessValue)}} />
+        <PaperRadio @value={{false}} @disabled={{true}} @onChange={{null}}>
           Disabled
-        {{/paper-radio}}
+        </PaperRadio>
         {{! END-SNIPPET }}
       </div>
       <h3>Template</h3>
-      {{code-snippet name="radio.standalone-usage.hbs"}}
+      <CodeSnippet @name="radio.standalone-usage.hbs" />
       <hr>
 
       <p>
@@ -31,49 +26,45 @@
       </p>
 
       {{! BEGIN-SNIPPET radio.basic-group-usage}}
-      {{#paper-radio-group
-        groupValue=(readonly selectedFruit)
-        onChange=(action (mut selectedFruit)) as |group|}}
-        {{#group.radio value="Apple" primary=true}} Apple {{/group.radio}}
-        {{#group.radio value="Banana" warn=true}} Banana {{/group.radio}}
-        {{#group.radio value="Mango"}} Mango {{/group.radio}}
-      {{/paper-radio-group}}
+      <PaperRadioGroup @groupValue={{readonly selectedFruit}} @onChange={{action (mut selectedFruit)}} as |group|>
+        <group.radio @value="Apple" @primary={{true}}> Apple </group.radio>
+        <group.radio @value="Banana" @warn={{true}}> Banana </group.radio>
+        <group.radio @value="Mango"> Mango </group.radio>
+      </PaperRadioGroup>
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="radio.basic-group-usage.hbs"}}
+      <CodeSnippet @name="radio.basic-group-usage.hbs" />
       <hr>
 
       <p>
         Graphic radio buttons
       </p>
       {{! BEGIN-SNIPPET radio.images }}
-      {{#paper-radio-group
-        groupValue=selectedGraphic
-        onChange=(action (mut selectedGraphic)) as |group|}}
+      <PaperRadioGroup @groupValue={{selectedGraphic}} @onChange={{action (mut selectedGraphic)}} as |group|>
 
-        {{#group.label}}
+        <group.label>
           <p>Selected Value: <span class="radio-value">{{selectedGraphic}}</span></p>
-        {{/group.label}}
+        </group.label>
 
-        {{#group.radio value="graphic-1" primary=true}}
+        <group.radio @value="graphic-1" @primary={{true}}>
           <img src="http://tinyurl.com/zwvmqz8" alt="example1">
-        {{/group.radio}}
+        </group.radio>
 
-        {{#group.radio value="graphic-2" warn=true}}
+        <group.radio @value="graphic-2" @warn={{true}}>
           <img src="http://tinyurl.com/jdcepzm" alt="example2">
-        {{/group.radio}}
+        </group.radio>
 
-        {{#group.radio value="graphic-3"}}
+        <group.radio @value="graphic-3">
           <img src="http://tinyurl.com/j55t8cd" alt="example3">
-        {{/group.radio}}
+        </group.radio>
 
-      {{/paper-radio-group}}
+      </PaperRadioGroup>
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="radio.images.hbs"}}
+      <CodeSnippet @name="radio.images.hbs" />
 
-    {{/paper-card-content}}
-  {{/paper-card}}
-{{/doc-content}}
+    </PaperCardContent>
+  </PaperCard>
+</DocContent>

--- a/tests/dummy/app/templates/demo/select.hbs
+++ b/tests/dummy/app/templates/demo/select.hbs
@@ -1,30 +1,24 @@
-{{page-toolbar pageTitle="Select" isDemo=true}}
+<PageToolbar @pageTitle="Select" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   <h2>Basic Usage</h2>
 
   <p>Enter an address</p>
   <div class="layout-row">
     {{! BEGIN-SNIPPET select.basic-usage }}
-    {{paper-input label="Street Name" value=street onChange=(action (mut street))}}
-    {{paper-input label="City" value=city onChange=(action (mut city))}}
-    {{#paper-select
-      disabled=disableSelect
-      label="State"
-      options=states
-      selected=userState
-      onChange=(action (mut userState))
-      as |state|}}
+    <PaperInput @label="Street Name" @value={{street}} @onChange={{action (mut street)}} />
+    <PaperInput @label="City" @value={{city}} @onChange={{action (mut city)}} />
+    <PaperSelect @disabled={{disableSelect}} @label="State" @options={{states}} @selected={{userState}} @onChange={{action (mut userState)}} as |state|>
       {{state.abbrev}}
-    {{/paper-select}}
+    </PaperSelect>
     {{! END-SNIPPET }}
   </div>
 
   <p>
-    {{paper-checkbox label="Disable select" value=disableSelect onChange=(action (mut disableSelect))}}
+    <PaperCheckbox @label="Disable select" @value={{disableSelect}} @onChange={{action (mut disableSelect)}} />
   </p>
   <h3>Template</h3>
-  {{code-snippet name="select.basic-usage.hbs"}}
+  <CodeSnippet @name="select.basic-usage.hbs" />
   <p>Paper select is based on Ember power select, advanced documentation can be found <a href="https://ember-power-select.com/docs">here</a>.</p>
   {{#paper-api
       (p-section
@@ -42,17 +36,17 @@
   <p>Pick your pizza below</p>
   <div class="layout-row">
     {{! BEGIN-SNIPPET select.option-groups }}
-    {{#paper-select options=sizes label="Size" required=true selected=pizzaSize onChange=(action (mut pizzaSize)) as |size|}}
+    <PaperSelect @options={{sizes}} @label="Size" @required={{true}} @selected={{pizzaSize}} @onChange={{action (mut pizzaSize)}} as |size|>
       {{size}}
-    {{/paper-select}}
-    {{#paper-select options=groupedToppings label="Topping" selected=topping onChange=(action (mut topping)) as |topping|}}
+    </PaperSelect>
+    <PaperSelect @options={{groupedToppings}} @label="Topping" @selected={{topping}} @onChange={{action (mut topping)}} as |topping|>
       {{topping}}
-    {{/paper-select}}
+    </PaperSelect>
     {{! END-SNIPPET }}
   </div>
 
   <h3>Template</h3>
-  {{code-snippet name="select.option-groups.hbs"}}
+  <CodeSnippet @name="select.option-groups.hbs" />
 
   <h2>Options with async search</h2>
 
@@ -62,14 +56,9 @@
     </p>
     <div class="layout-column layout-align-center-center" style="height: 130px;">
       {{! BEGIN-SNIPPET select.async-search }}
-      {{#paper-select
-        placeholder="Assign to a user"
-        selected=selectedUser
-        options=users
-        onChange=(action (mut selectedUser))
-        as |user|}}
+      <PaperSelect @placeholder="Assign to a user" @selected={{selectedUser}} @options={{users}} @onChange={{action (mut selectedUser)}} as |user|>
         {{user.name}}
-      {{/paper-select}}
+      </PaperSelect>
 
       {{#if selectedUser}}
         <p>You have selected the user <code>{{selectedUser.name}}</code></p>
@@ -78,7 +67,7 @@
     </div>
   </div>
   <h3>Template</h3>
-  {{code-snippet name="select.async-search.hbs"}}
+  <CodeSnippet @name="select.async-search.hbs" />
 
 
   <h2>Select with Search</h2>
@@ -86,18 +75,9 @@
   <div class="layout-column layout-align-center-center">
     <div class="layout-column layout-align-center-center" style="height: 130px;">
       {{! BEGIN-SNIPPET select.select-header }}
-      {{#paper-select
-        placeholder="Vegetable"
-        selected=selectedVegetable
-        options=vegetables
-        searchField="name"
-        searchPlaceholder="Search for a vegetable.."
-        searchEnabled=true
-        onChange=(action (mut selectedVegetable))
-        as |vegetable|
-      }}
+      <PaperSelect @placeholder="Vegetable" @selected={{selectedVegetable}} @options={{vegetables}} @searchField="name" @searchPlaceholder="Search for a vegetable.." @searchEnabled={{true}} @onChange={{action (mut selectedVegetable)}} as |vegetable|>
         {{vegetable.name}}
-      {{/paper-select}}
+      </PaperSelect>
 
       {{! END-SNIPPET }}
     </div>
@@ -105,7 +85,7 @@
 
   <h3>Template</h3>
 
-  {{code-snippet name="select.select-header.hbs"}}
+  <CodeSnippet @name="select.select-header.hbs" />
 
   {{#paper-api
       (p-section
@@ -116,4 +96,4 @@
         title="Select Search Helpers"
   }}
   {{/paper-api}}
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/sidenav.hbs
+++ b/tests/dummy/app/templates/demo/sidenav.hbs
@@ -1,40 +1,36 @@
-{{page-toolbar pageTitle="Sidenav" isDemo=true}}
+<PageToolbar @pageTitle="Sidenav" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar as |toolbar|}}
-      {{#toolbar.tools}}
+  <PaperCard>
+    <PaperToolbar as |toolbar|>
+      <toolbar.tools>
         <h2>Basic Usage</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggle" "showSourceCode") iconButton=true}}
-          {{paper-icon icon="code"}}
-        {{/paper-button}}
-      {{/toolbar.tools}}
-    {{/paper-toolbar}}
+        <PaperButton @onClick={{action "toggle" "showSourceCode"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+        </PaperButton>
+      </toolbar.tools>
+    </PaperToolbar>
 
     <div class="doc-code-example {{if showSourceCode "is-visible"}}">
-      {{code-snippet name="sidenav.basic-usage.hbs"}}
+      <CodeSnippet @name="sidenav.basic-usage.hbs" />
     </div>
 
     <div class="doc-content-example">
       {{! BEGIN-SNIPPET sidenav.basic-usage }}
-      {{#paper-sidenav-container class="inner-sidenav"}}
+      <PaperSidenavContainer @class="inner-sidenav">
 
-        {{#paper-sidenav
-          class="md-whiteframe-z2"
-          name="left"
-          open=leftSideBarOpen
-          onToggle=(action (mut leftSideBarOpen))}}
-          {{#paper-toolbar as |toolbar|}}
-            {{#toolbar.tools}}Left Sidenav{{/toolbar.tools}}
-          {{/paper-toolbar}}
-          {{#paper-content padding=true}}
+        <PaperSidenav @class="md-whiteframe-z2" @name="left" @open={{leftSideBarOpen}} @onToggle={{action (mut leftSideBarOpen)}}>
+          <PaperToolbar as |toolbar|>
+            <toolbar.tools>Left Sidenav</toolbar.tools>
+          </PaperToolbar>
+          <PaperContent @padding={{true}}>
             Çup?
-          {{/paper-content}}
-        {{/paper-sidenav}}
+          </PaperContent>
+        </PaperSidenav>
 
-        {{#paper-card-content class="flex"}}
+        <PaperCardContent @class="flex">
           <div class="layout-fill layout-align-start-center layout-column" style="height: 500px">
             <p>
               The left sidenav will "lock open" on a medium (>=960px wide) device.
@@ -47,76 +43,65 @@
               Right sidenav is <strong>{{if rightSideBarOpen "opened" "closed"}}</strong>.
             </p>
 
-            {{#paper-sidenav-toggle name="left" as |toggleAction|}}
-              {{#paper-button raised=true classNames="hide-gt-sm" onClick=(action toggleAction)}}
+            <PaperSidenavToggle @name="left" as |toggleAction|>
+              <PaperButton @raised={{true}} @classNames="hide-gt-sm" @onClick={{action toggleAction}}>
                 Toggle left sidenav
-              {{/paper-button}}
-            {{/paper-sidenav-toggle}}
+              </PaperButton>
+            </PaperSidenavToggle>
 
-            {{#paper-sidenav-toggle name="right" as |toggleAction|}}
-              {{#paper-button raised=true onClick=(action toggleAction)}}
+            <PaperSidenavToggle @name="right" as |toggleAction|>
+              <PaperButton @raised={{true}} @onClick={{action toggleAction}}>
                 Toggle right sidenav
-              {{/paper-button}}
-            {{/paper-sidenav-toggle}}
+              </PaperButton>
+            </PaperSidenavToggle>
 
           </div>
-        {{/paper-card-content}}
+        </PaperCardContent>
 
-        {{#paper-sidenav
-          class="md-whiteframe-z2"
-          name="right"
-          position="right"
-          open=rightSideBarOpen
-          lockedOpen=false
-          onToggle=(action (mut rightSideBarOpen))}}
-          {{#paper-toolbar as |toolbar|}}
-            {{#toolbar.tools}}Right Sidenav{{/toolbar.tools}}
-          {{/paper-toolbar}}
-          {{#paper-content padding=true}}
+        <PaperSidenav @class="md-whiteframe-z2" @name="right" @position="right" @open={{rightSideBarOpen}} @lockedOpen={{false}} @onToggle={{action (mut rightSideBarOpen)}}>
+          <PaperToolbar as |toolbar|>
+            <toolbar.tools>Right Sidenav</toolbar.tools>
+          </PaperToolbar>
+          <PaperContent @padding={{true}}>
             Çup? I'm on the right side.
-          {{/paper-content}}
-        {{/paper-sidenav}}
+          </PaperContent>
+        </PaperSidenav>
 
-      {{/paper-sidenav-container}}
+      </PaperSidenavContainer>
       {{! END-SNIPPET sidenav.basic-usage }}
     </div>
 
-  {{/paper-card}}
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-toolbar as |toolbar|}}
-      {{#toolbar.tools}}
+  <PaperCard>
+    <PaperToolbar as |toolbar|>
+      <toolbar.tools>
         <h2>Persistent Sidenav</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggle" "persistentCode") iconButton=true}}
+        <PaperButton @onClick={{action "toggle" "persistentCode"}} @iconButton={{true}}>
           {{paper-icon "code"}}
-        {{/paper-button}}
-      {{/toolbar.tools}}
-    {{/paper-toolbar}}
+        </PaperButton>
+      </toolbar.tools>
+    </PaperToolbar>
 
     <div class="doc-code-example {{if persistentCode "is-visible"}}">
-      {{code-snippet name="sidenav.persistent.hbs"}}
+      <CodeSnippet @name="sidenav.persistent.hbs" />
     </div>
 
     <div class="doc-content-example">
       {{! BEGIN-SNIPPET sidenav.persistent }}
-      {{#paper-sidenav-container class="inner-sidenav"}}
+      <PaperSidenavContainer @class="inner-sidenav">
 
-        {{#paper-sidenav
-          class="md-whiteframe-z2"
-          name="left2"
-          open=leftSideBarOpen2
-          lockedOpen=leftSideBarLockedOpen
-          onToggle=(action (mut leftSideBarOpen2))}}
-          {{#paper-toolbar as |toolbar|}}
-            {{#toolbar.tools}}Left Sidenav{{/toolbar.tools}}
-          {{/paper-toolbar}}
-          {{#paper-content padding=true}}
+        <PaperSidenav @class="md-whiteframe-z2" @name="left2" @open={{leftSideBarOpen2}} @lockedOpen={{leftSideBarLockedOpen}} @onToggle={{action (mut leftSideBarOpen2)}}>
+          <PaperToolbar as |toolbar|>
+            <toolbar.tools>Left Sidenav</toolbar.tools>
+          </PaperToolbar>
+          <PaperContent @padding={{true}}>
             Çup?
-          {{/paper-content}}
-        {{/paper-sidenav}}
+          </PaperContent>
+        </PaperSidenav>
 
-        {{#paper-card-content class="flex"}}
+        <PaperCardContent @class="flex">
           <div class="layout-fill layout-align-start-center layout-column" style="height: 500px">
             <p>
               Another way of using the sidenav is to toggle the <code>lockedOpen</code> state.
@@ -126,18 +111,18 @@
               Left sidenav is <strong>{{if leftSideBarLockedOpen "locked" "unlocked"}}</strong>.
             </p>
 
-            {{#paper-button raised=true onClick=(action "toggle" "leftSideBarLockedOpen")}}
+            <PaperButton @raised={{true}} @onClick={{action "toggle" "leftSideBarLockedOpen"}}>
               {{if leftSideBarLockedOpen "Unlock" "Lock"}} left sidenav
-            {{/paper-button}}
+            </PaperButton>
 
           </div>
-        {{/paper-card-content}}
+        </PaperCardContent>
 
-      {{/paper-sidenav-container}}
+      </PaperSidenavContainer>
       {{! END-SNIPPET sidenav.persistent }}
     </div>
 
-  {{/paper-card}}
+  </PaperCard>
 
   {{paper-api
     (p-section
@@ -152,4 +137,4 @@
     )
   }}
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/slider.hbs
+++ b/tests/dummy/app/templates/demo/slider.hbs
@@ -1,13 +1,13 @@
-{{page-toolbar pageTitle="Slider" isDemo=true}}
+<PageToolbar @pageTitle="Slider" @isDemo={{true}} />
 
-{{#doc-content class="slider-demo"}}
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+<DocContent @class="slider-demo">
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic Usage</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
-    {{#paper-card-content class="flex"}}
+      </PaperToolbarTools>
+    </PaperToolbar>
+    <PaperCardContent @class="flex">
       {{! BEGIN-SNIPPET slider }}
       <h2>
         RGB <span style={{colorStyle}}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
@@ -15,20 +15,20 @@
 
       <div class="layout layout-align-center-center slider-container">
         <span>R</span>
-        {{paper-slider class="flex" min=0 max=255 value=color.red onChange=(action (mut color.red))}}
-        {{paper-input type="number" value=color.red onChange=(action (mut color.red))}}
+        <PaperSlider @class="flex" @min={{0}} @max={{255}} @value={{color.red}} @onChange={{action (mut color.red)}} />
+        <PaperInput @type="number" @value={{color.red}} @onChange={{action (mut color.red)}} />
       </div>
 
       <div class="layout layout-align-center-center slider-container">
         <span>G</span>
-        {{paper-slider class="flex md-accent" min=0 max=255 value=color.green onChange=(action (mut color.green))}}
-        {{paper-input type="number" value=color.green  onChange=(action (mut color.green))}}
+        <PaperSlider @class="flex md-accent" @min={{0}} @max={{255}} @value={{color.green}} @onChange={{action (mut color.green)}} />
+        <PaperInput @type="number" @value={{color.green}} @onChange={{action (mut color.green)}} />
       </div>
 
       <div class="layout layout-align-center-center slider-container">
         <span>B</span>
-        {{paper-slider class="flex md-primary" min=0 max=255 value=color.blue onChange=(action (mut color.blue))}}
-        {{paper-input type="number" value=color.blue onChange=(action (mut color.blue))}}
+        <PaperSlider @class="flex md-primary" @min={{0}} @max={{255}} @value={{color.blue}} @onChange={{action (mut color.blue)}} />
+        <PaperInput @type="number" @value={{color.blue}} @onChange={{action (mut color.blue)}} />
       </div>
 
       <h2>Rating: {{rating}}/5 - demo of theming classes</h2>
@@ -36,38 +36,38 @@
         <div class="layout flex-10 layout-align-center-center">
           <span>default</span>
         </div>
-        {{paper-slider class="flex" discrete=true value=rating1 step=1 min=1 max=5 onChange=(action (mut rating1))}}
+        <PaperSlider @class="flex" @discrete={{true}} @value={{rating1}} @step={{1}} @min={{1}} @max={{5}} @onChange={{action (mut rating1)}} />
       </div>
       <div class="layout layout-align-center-center slider-container">
         <div class="layout flex-10 layout-align-center-center">
           <span>md-warn</span>
         </div>
-        {{paper-slider class="flex" warn=true discrete=true value=rating2 step=1 min=1 max=5 onChange=(action (mut rating2))}}
+        <PaperSlider @class="flex" @warn={{true}} @discrete={{true}} @value={{rating2}} @step={{1}} @min={{1}} @max={{5}} @onChange={{action (mut rating2)}} />
       </div>
       <div class="layout layout-align-center-center slider-container">
         <div class="layout flex-10 layout-align-center-center">
           <span>md-primary</span>
         </div>
-        {{paper-slider class="flex" primary=true discrete=true value=rating3 step=1 min=1 max=5 onChange=(action (mut rating3))}}
+        <PaperSlider @class="flex" @primary={{true}} @discrete={{true}} @value={{rating3}} @step={{1}} @min={{1}} @max={{5}} @onChange={{action (mut rating3)}} />
       </div>
 
       <h2>Disabled</h2>
       <div class="layout layout-align-center-center slider-container">
-        {{paper-icon icon="brightness-low"}}
-        {{paper-slider class="flex" value=disabled1 disabled=isSliderDisabled onChange=(action (mut disabled1))}}
-        {{paper-input type="number" value=disabled1 onChange=(action (mut disabled1))}}
+        <PaperIcon @icon="brightness-low" />
+        <PaperSlider @class="flex" @value={{disabled1}} @disabled={{isSliderDisabled}} @onChange={{action (mut disabled1)}} />
+        <PaperInput @type="number" @value={{disabled1}} @onChange={{action (mut disabled1)}} />
       </div>
-      {{paper-checkbox value=isSliderDisabled onChange=(action (mut isSliderDisabled))}}
-      {{paper-slider value=disabled2 disabled=true}}
+      <PaperCheckbox @value={{isSliderDisabled}} @onChange={{action (mut isSliderDisabled)}} />
+      <PaperSlider @value={{disabled2}} @disabled={{true}} />
 
       <h2>Disabled, Discrete</h2>
-      {{paper-slider value=discreteDisabled1 disabled=true discrete=true step=3 min=0 max=10}}
-      {{paper-slider value=discreteDisabled2 disabled=true discrete=true step=10}}
+      <PaperSlider @value={{discreteDisabled1}} @disabled={{true}} @discrete={{true}} @step={{3}} @min={{0}} @max={{10}} />
+      <PaperSlider @value={{discreteDisabled2}} @disabled={{true}} @discrete={{true}} @step={{10}} />
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="slider.hbs"}}
-    {{/paper-card-content}}
-  {{/paper-card}}
+      <CodeSnippet @name="slider.hbs" />
+    </PaperCardContent>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/speed-dial.hbs
+++ b/tests/dummy/app/templates/demo/speed-dial.hbs
@@ -1,93 +1,91 @@
-{{page-toolbar pageTitle="Speed Dial" isDemo=true}}
+<PageToolbar @pageTitle="Speed Dial" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   <div class="md-padding">
-    {{#paper-card}}
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+    <PaperCard>
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Basic Usage</h2>
           <span class="flex"></span>
-          {{#paper-button onClick=(action "toggle" "showBasicUsageSourceCode") iconButton=true}}
+          <PaperButton @onClick={{action "toggle" "showBasicUsageSourceCode"}} @iconButton={{true}}>
             {{paper-icon "code"}}
-          {{/paper-button}}
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
+          </PaperButton>
+        </PaperToolbarTools>
+      </PaperToolbar>
 
       <div class="doc-code-example {{if showBasicUsageSourceCode "is-visible"}}">
-        {{code-snippet name="speed-dial-basic-usage.hbs"}}
+        <CodeSnippet @name="speed-dial-basic-usage.hbs" />
       </div>
 
       <div class="doc-content-example">
-        {{#paper-content}}
+        <PaperContent>
           <div class="layout-align-center-center layout-row" style="min-height: 300px; overflow: hidden">
             {{! BEGIN-SNIPPET speed-dial-basic-usage}}
-            {{#paper-speed-dial
-              animation=animation direction=direction
-              open=open onToggle=(action (mut open)) as |dial|}}
-              {{#dial.trigger}}
-                {{#paper-button fab=true}}
+            <PaperSpeedDial @animation={{animation}} @direction={{direction}} @open={{open}} @onToggle={{action (mut open)}} as |dial|>
+              <dial.trigger>
+                <PaperButton @fab={{true}}>
                   {{paper-icon "menu"}}
-                {{/paper-button}}
-              {{/dial.trigger}}
+                </PaperButton>
+              </dial.trigger>
 
-              {{#dial.actions as |actions|}}
-                {{#actions.action}}
-                  {{#paper-button mini=true onClick=(action (mut showDialog) true)}}
+              <dial.actions as |actions|>
+                <actions.action>
+                  <PaperButton @mini={{true}} @onClick={{action (mut showDialog) true}}>
                     {{paper-icon "people"}}
-                  {{/paper-button}}
-                {{/actions.action}}
+                  </PaperButton>
+                </actions.action>
 
-                {{#actions.action}}
-                  {{#paper-button mini=true onClick=(action (mut showDialog) true)}}
+                <actions.action>
+                  <PaperButton @mini={{true}} @onClick={{action (mut showDialog) true}}>
                     {{paper-icon "accessibility"}}
-                  {{/paper-button}}
-                {{/actions.action}}
+                  </PaperButton>
+                </actions.action>
 
-                {{#actions.action}}
-                  {{#paper-button mini=true onClick=(action (mut showDialog) true)}}
+                <actions.action>
+                  <PaperButton @mini={{true}} @onClick={{action (mut showDialog) true}}>
                     {{paper-icon "check-circle"}}
-                  {{/paper-button}}
-                {{/actions.action}}
-              {{/dial.actions}}
-            {{/paper-speed-dial}}
+                  </PaperButton>
+                </actions.action>
+              </dial.actions>
+            </PaperSpeedDial>
             {{! END-SNIPPET }}
           </div>
-        {{/paper-content}}
-        {{#paper-card-content}}
+        </PaperContent>
+        <PaperCardContent>
 
           <div class="layout-align-space-around-stretch layout-row">
 
             <div class="layout-column layout-align-start-center">
               <h4>Direction</h4>
-              {{#paper-radio-group groupValue=direction onChange=(action (mut direction)) as |group|}}
-                {{#group.radio value="up"}}Up{{/group.radio}}
-                {{#group.radio value="down"}}Down{{/group.radio}}
-                {{#group.radio value="left"}}Left{{/group.radio}}
-                {{#group.radio value="right"}}Right{{/group.radio}}
-              {{/paper-radio-group}}
+              <PaperRadioGroup @groupValue={{direction}} @onChange={{action (mut direction)}} as |group|>
+                <group.radio @value="up">Up</group.radio>
+                <group.radio @value="down">Down</group.radio>
+                <group.radio @value="left">Left</group.radio>
+                <group.radio @value="right">Right</group.radio>
+              </PaperRadioGroup>
             </div>
 
             <div class="layout-column layout-align-start-center">
               <h4>Open/Closed</h4>
-              {{#paper-checkbox value=open onChange=(action (mut open))}}
+              <PaperCheckbox @value={{open}} @onChange={{action (mut open)}}>
                 open
-              {{/paper-checkbox}}
+              </PaperCheckbox>
             </div>
 
             <div class="layout-column layout-align-start-center">
               <h4>Animation</h4>
-              {{#paper-radio-group groupValue=animation onChange=(action (mut animation)) as |group|}}
-                {{#group.radio value="fling"}}Fling{{/group.radio}}
-                {{#group.radio value="scale"}}Scale{{/group.radio}}
-              {{/paper-radio-group}}
+              <PaperRadioGroup @groupValue={{animation}} @onChange={{action (mut animation)}} as |group|>
+                <group.radio @value="fling">Fling</group.radio>
+                <group.radio @value="scale">Scale</group.radio>
+              </PaperRadioGroup>
             </div>
 
           </div>
 
-        {{/paper-card-content}}
+        </PaperCardContent>
       </div>
-      {{paper-divider}}
-      {{#paper-card-content}}
+      <PaperDivider />
+      <PaperCardContent>
         <p>
           You may supply a direction of <code>left</code>, <code>up</code>, <code>down</code>, or
           <code>right</code> through the <code>direction</code> attribute. Default value is <code>down</code>.
@@ -100,65 +98,63 @@
           The component can also take a <code>open</code> attribute and an <code>onToggle</code> pair, much like
           <code>paper-sidenav</code>. Use the pair to control the open status of the speed dial.
         </p>
-      {{/paper-card-content}}
-    {{/paper-card}}
+      </PaperCardContent>
+    </PaperCard>
   </div>
 
   <div class="md-padding">
-    {{#paper-card}}
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+    <PaperCard>
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Advanced Usage</h2>
           <span class="flex"></span>
-          {{#paper-button onClick=(action "toggle" "showAdvancedUsageSourceCode") iconButton=true}}
+          <PaperButton @onClick={{action "toggle" "showAdvancedUsageSourceCode"}} @iconButton={{true}}>
             {{paper-icon "code"}}
-          {{/paper-button}}
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
+          </PaperButton>
+        </PaperToolbarTools>
+      </PaperToolbar>
 
       <div class="doc-code-example {{if showAdvancedUsageSourceCode "is-visible"}}">
-        {{code-snippet name="speed-dial-advanced-usage.hbs"}}
+        <CodeSnippet @name="speed-dial-advanced-usage.hbs" />
       </div>
 
       <div class="doc-content-example">
-        {{#paper-content}}
+        <PaperContent>
           <div class="layout-align-center-center layout-row" style="min-height: 300px; overflow: hidden">
             {{! BEGIN-SNIPPET speed-dial-advanced-usage}}
-            {{#paper-speed-dial
-              onMouseEnter=(action (mut open2) true) onMouseLeave=(action (mut open2) false)
-              open=open2 onToggle=(action (mut open2)) hoverFull=hoverFull as |dial|}}
-              {{#dial.trigger}}
-                {{#paper-button fab=true}}
+            <PaperSpeedDial @onMouseEnter={{action (mut open2) true}} @onMouseLeave={{action (mut open2) false}} @open={{open2}} @onToggle={{action (mut open2)}} @hoverFull={{hoverFull}} as |dial|>
+              <dial.trigger>
+                <PaperButton @fab={{true}}>
                   {{paper-icon "menu"}}
-                {{/paper-button}}
-              {{/dial.trigger}}
+                </PaperButton>
+              </dial.trigger>
 
-              {{#dial.actions as |actions|}}
-                {{#actions.action}}
-                  {{#paper-button mini=true onClick=(action (mut showDialog) true)}}
+              <dial.actions as |actions|>
+                <actions.action>
+                  <PaperButton @mini={{true}} @onClick={{action (mut showDialog) true}}>
                     {{paper-icon "people"}}
-                  {{/paper-button}}
-                {{/actions.action}}
+                  </PaperButton>
+                </actions.action>
 
-                {{#actions.action}}
-                  {{#paper-button mini=true onClick=(action (mut showDialog) true)}}
+                <actions.action>
+                  <PaperButton @mini={{true}} @onClick={{action (mut showDialog) true}}>
                     {{paper-icon "accessibility"}}
-                  {{/paper-button}}
-                {{/actions.action}}
+                  </PaperButton>
+                </actions.action>
 
-                {{#actions.action}}
-                  {{#paper-button mini=true onClick=(action (mut showDialog) true)}}
+                <actions.action>
+                  <PaperButton @mini={{true}} @onClick={{action (mut showDialog) true}}>
                     {{paper-icon "check-circle"}}
-                  {{/paper-button}}
-                {{/actions.action}}
-              {{/dial.actions}}
-            {{/paper-speed-dial}}
+                  </PaperButton>
+                </actions.action>
+              </dial.actions>
+            </PaperSpeedDial>
             {{! END-SNIPPET }}
           </div>
-        {{/paper-content}}
+        </PaperContent>
       </div>
-      {{paper-divider}}
-      {{#paper-card-content}}
+      <PaperDivider />
+      <PaperCardContent>
         <p>
           You can use the <code>onMouseEnter</code> and <code>onMouseLeave</code> actions to control
           the <code>open</code> attribute. This results in a speed dial that opens when you hover it.
@@ -169,27 +165,27 @@
           <code>hoverFull=true</code>. Try it with the following checkbox:
         </p>
         <p>
-          {{#paper-checkbox value=hoverFull onChange=(action (mut hoverFull))}}
+          <PaperCheckbox @value={{hoverFull}} @onChange={{action (mut hoverFull)}}>
             hoverFull
-          {{/paper-checkbox}}
+          </PaperCheckbox>
         </p>
-      {{/paper-card-content}}
-    {{/paper-card}}
+      </PaperCardContent>
+    </PaperCard>
   </div>
-{{/doc-content}}
+</DocContent>
 
 {{#if showDialog}}
-  {{#paper-dialog fullscreen=fullscreen onClose=(action (mut showDialog) false)}}
+  <PaperDialog @fullscreen={{fullscreen}} @onClose={{action (mut showDialog) false}}>
 
-    {{#paper-dialog-content}}
+    <PaperDialogContent>
       <h2 class="md-title">An action was clicked!</h2>
       <p>Close this dialog and try another button.</p>
-    {{/paper-dialog-content}}
+    </PaperDialogContent>
 
-    {{#paper-dialog-actions class="layout-row"}}
+    <PaperDialogActions @class="layout-row">
       <span class="flex"></span>
-      {{#paper-button primary=true onClick=(action (mut showDialog) false)}}Okay!{{/paper-button}}
-    {{/paper-dialog-actions}}
+      <PaperButton @primary={{true}} @onClick={{action (mut showDialog) false}}>Okay!</PaperButton>
+    </PaperDialogActions>
 
-  {{/paper-dialog}}
+  </PaperDialog>
 {{/if}}

--- a/tests/dummy/app/templates/demo/switch.hbs
+++ b/tests/dummy/app/templates/demo/switch.hbs
@@ -1,27 +1,27 @@
-{{page-toolbar pageTitle="Switch" isDemo=true}}
+<PageToolbar @pageTitle="Switch" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   <p>
     {{! BEGIN-SNIPPET switch }}
-    {{#paper-switch value=booleanProp1 onChange=(action (mut booleanProp1))}}
+    <PaperSwitch @value={{booleanProp1}} @onChange={{action (mut booleanProp1)}}>
       {{booleanProp1}}
-    {{/paper-switch}}
+    </PaperSwitch>
 
-    {{#paper-switch value=booleanProp2 onChange=(action (mut booleanProp2))}}
+    <PaperSwitch @value={{booleanProp2}} @onChange={{action (mut booleanProp2)}}>
       {{booleanProp2}}
-    {{/paper-switch}}
+    </PaperSwitch>
 
-    {{#paper-switch value=booleanProp3 onChange=(action "changeBooleanProp" "3") disabled=true}}
+    <PaperSwitch @value={{booleanProp3}} @onChange={{action "changeBooleanProp" "3"}} @disabled={{true}}>
       Disabled switch
-    {{/paper-switch}}
+    </PaperSwitch>
 
-    {{#paper-switch value=booleanProp4 onChange=(action "changeBooleanProp" "4") noink=true}}
+    <PaperSwitch @value={{booleanProp4}} @onChange={{action "changeBooleanProp" "4"}} @noink={{true}}>
       Noink switch
-    {{/paper-switch}}
+    </PaperSwitch>
 
-    {{paper-switch label="Blockless version" value=booleanProp5 onChange=(action "changeBooleanProp" "5")}}
+    <PaperSwitch @label="Blockless version" @value={{booleanProp5}} @onChange={{action "changeBooleanProp" "5"}} />
     {{! END-SNIPPET }}
   </p>
   <h3>Template</h3>
-  {{code-snippet name="switch.hbs"}}
-{{/doc-content}}
+  <CodeSnippet @name="switch.hbs" />
+</DocContent>

--- a/tests/dummy/app/templates/demo/tabs.hbs
+++ b/tests/dummy/app/templates/demo/tabs.hbs
@@ -1,48 +1,43 @@
-{{page-toolbar pageTitle="Tabs" isDemo=true}}
+<PageToolbar @pageTitle="Tabs" @isDemo={{true}} />
 
-{{#doc-content class="tabs-demo"}}
+<DocContent @class="tabs-demo">
 
   <div class="md-padding">
-    {{#paper-card}}
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+    <PaperCard>
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Basic Usage</h2>
           <span class="flex"></span>
-          {{#paper-button onClick=(action "toggle" "showBasicUsageSourceCode") iconButton=true}}
-            {{paper-icon icon="code"}}
-          {{/paper-button}}
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
+          <PaperButton @onClick={{action "toggle" "showBasicUsageSourceCode"}} @iconButton={{true}}>
+            <PaperIcon @icon="code" />
+          </PaperButton>
+        </PaperToolbarTools>
+      </PaperToolbar>
 
       <div class="doc-code-example {{if showBasicUsageSourceCode "is-visible"}}">
-        {{code-snippet name="basic-usage.hbs"}}
+        <CodeSnippet @name="basic-usage.hbs" />
       </div>
 
       <div class="doc-content-example">
-        {{#paper-content}}
+        <PaperContent>
           {{! BEGIN-SNIPPET basic-usage}}
-          {{#paper-tabs
-            center=center
-            stretch=stretch
-            borderBottom=borderBottom
-            selected=selectedBasicTab
-            onChange=(action (mut selectedBasicTab)) as |tabs|}}
-            {{#tabs.tab}}
+          <PaperTabs @center={{center}} @stretch={{stretch}} @borderBottom={{borderBottom}} @selected={{selectedBasicTab}} @onChange={{action (mut selectedBasicTab)}} as |tabs|>
+            <tabs.tab>
               Page One
-            {{/tabs.tab}}
-            {{#tabs.tab disabled=true}}
+            </tabs.tab>
+            <tabs.tab @disabled={{true}}>
               Page Two (disabled)
-            {{/tabs.tab}}
-            {{#tabs.tab}}
+            </tabs.tab>
+            <tabs.tab>
               Page Three
-            {{/tabs.tab}}
-            {{#tabs.tab}}
+            </tabs.tab>
+            <tabs.tab>
               Page Four
-            {{/tabs.tab}}
-            {{#tabs.tab}}
+            </tabs.tab>
+            <tabs.tab>
               Page Five
-            {{/tabs.tab}}
-          {{/paper-tabs}}
+            </tabs.tab>
+          </PaperTabs>
 
           {{#liquid-bind (hash tab=selectedBasicTab) class="md-padding" as |current|}}
             <h1 class="md-display-2">Tab {{current.tab}}</h1>
@@ -54,25 +49,25 @@
             </p>
           {{/liquid-bind}}
           {{! END-SNIPPET }}
-        {{/paper-content}}
-        {{#paper-card-content}}
+        </PaperContent>
+        <PaperCardContent>
 
-          {{#paper-checkbox value=center onChange=(action (mut center))}}
+          <PaperCheckbox @value={{center}} @onChange={{action (mut center)}}>
             Center tabs
-          {{/paper-checkbox}}
+          </PaperCheckbox>
 
-          {{#paper-checkbox value=stretch onChange=(action (mut stretch))}}
+          <PaperCheckbox @value={{stretch}} @onChange={{action (mut stretch)}}>
             Stretch tabs
-          {{/paper-checkbox}}
+          </PaperCheckbox>
 
-          {{#paper-checkbox value=borderBottom onChange=(action (mut borderBottom))}}
+          <PaperCheckbox @value={{borderBottom}} @onChange={{action (mut borderBottom)}}>
             Border bottom
-          {{/paper-checkbox}}
+          </PaperCheckbox>
 
-        {{/paper-card-content}}
+        </PaperCardContent>
       </div>
-      {{paper-divider}}
-      {{#paper-card-content}}
+      <PaperDivider />
+      <PaperCardContent>
         <p>
           <em><b>Note:</b> transitions were implemented using liquid-fire.</em>
         </p>
@@ -99,65 +94,58 @@
         <p>
           To test tab pagination resize the browser.
         </p>
-      {{/paper-card-content}}
-    {{/paper-card}}
+      </PaperCardContent>
+    </PaperCard>
   </div>
 
   <div class="md-padding">
-    {{#paper-card}}
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+    <PaperCard>
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Dynamic Usage</h2>
           <span class="flex"></span>
-          {{#paper-button onClick=(action "toggle" "showDynamicUsageSourceCode") iconButton=true}}
+          <PaperButton @onClick={{action "toggle" "showDynamicUsageSourceCode"}} @iconButton={{true}}>
             {{paper-icon "code"}}
-          {{/paper-button}}
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
+          </PaperButton>
+        </PaperToolbarTools>
+      </PaperToolbar>
 
       <div class="doc-code-example {{if showDynamicUsageSourceCode "is-visible"}}">
-        {{code-snippet name="dynamic-usage.hbs"}}
+        <CodeSnippet @name="dynamic-usage.hbs" />
       </div>
 
       <div class="doc-content-example">
-        {{#paper-content}}
+        <PaperContent>
           {{! BEGIN-SNIPPET dynamic-usage}}
-          {{#paper-tabs primary=true
-            borderBottom=true
-            selected=selectedChapter
-            onChange=(action (mut selectedChapter)) as |tabs|}}
+          <PaperTabs @primary={{true}} @borderBottom={{true}} @selected={{selectedChapter}} @onChange={{action (mut selectedChapter)}} as |tabs|>
             {{#each chapters as |chapter|}}
-              {{#tabs.tab value=chapter}}
+              <tabs.tab @value={{chapter}}>
                 {{chapter.title}}
-              {{/tabs.tab}}
+              </tabs.tab>
             {{/each}}
-          {{/paper-tabs}}
+          </PaperTabs>
 
           {{#liquid-bind (hash tab=selectedChapter.index m=selectedChapter) class="md-padding dynamic-animation" as |current|}}
             <h1 class="md-display-2">{{current.m.title}}</h1>
             <p>{{current.m.body}}</p>
-            {{#paper-button
-              primary=true raised=true disabled=(eq chapters.length 1)
-              onClick=(action "removeChapter" current.m)}}
+            <PaperButton @primary={{true}} @raised={{true}} @disabled={{eq chapters.length 1}} @onClick={{action "removeChapter" current.m}}>
               Remove chapter
-            {{/paper-button}}
+            </PaperButton>
           {{/liquid-bind}}
 
           {{! END-SNIPPET }}
-        {{/paper-content}}
+        </PaperContent>
       </div>
-      {{paper-divider}}
+      <PaperDivider />
 
-      {{#paper-card-content}}
+      <PaperCardContent>
         <div class="md-padding layout-row layout-align-space-around-start">
-          {{paper-input class="flex-20" label="Title" value=newTitle required=true onChange=(action (mut newTitle))}}
-          {{paper-input class="flex-60" label="Content" textarea=true value=newContent required=true onChange=(action (mut newContent))}}
+          <PaperInput @class="flex-20" @label="Title" @value={{newTitle}} @required={{true}} @onChange={{action (mut newTitle)}} />
+          <PaperInput @class="flex-60" @label="Content" @textarea={{true}} @value={{newContent}} @required={{true}} @onChange={{action (mut newContent)}} />
           <div class="flex-20 layout-row layout-align-center-start">
-            {{#paper-button
-              primary=true raised=true disabled=(not (and newTitle newContent))
-              onClick=(action "addChapter")}}
+            <PaperButton @primary={{true}} @raised={{true}} @disabled={{not (and newTitle newContent)}} @onClick={{action "addChapter"}}>
               Add chapter
-            {{/paper-button}}
+            </PaperButton>
           </div>
         </div>
 
@@ -174,45 +162,45 @@
           new selected tab. No problem, just set the <code>selected</code> property
           to the newly selected chapter.
         </p>
-      {{/paper-card-content}}
-    {{/paper-card}}
+      </PaperCardContent>
+    </PaperCard>
   </div>
 
   <div class="md-padding">
-    {{#paper-card}}
-      {{#paper-toolbar}}
-        {{#paper-toolbar-tools}}
+    <PaperCard>
+      <PaperToolbar>
+        <PaperToolbarTools>
           <h2>Routable Usage</h2>
           <span class="flex"></span>
-          {{#paper-button onClick=(action "toggle" "showRoutableUsageSourceCode") iconButton=true}}
-            {{paper-icon icon="code"}}
-          {{/paper-button}}
-        {{/paper-toolbar-tools}}
-      {{/paper-toolbar}}
+          <PaperButton @onClick={{action "toggle" "showRoutableUsageSourceCode"}} @iconButton={{true}}>
+            <PaperIcon @icon="code" />
+          </PaperButton>
+        </PaperToolbarTools>
+      </PaperToolbar>
 
       <div class="doc-code-example {{if showRoutableUsageSourceCode "is-visible"}}">
-        {{code-snippet name="routable-usage.hbs"}}
+        <CodeSnippet @name="routable-usage.hbs" />
       </div>
 
       <div class="doc-content-example">
-        {{#paper-content}}
+        <PaperContent>
           {{! BEGIN-SNIPPET routable-usage}}
-          {{#paper-tabs selected=currentRouteName borderBottom=true onChange=(action "noop") as |tabs|}}
-            {{#tabs.tab value="demo.tabs.index" href=(href-to "demo.tabs.index")}}
+          <PaperTabs @selected={{currentRouteName}} @borderBottom={{true}} @onChange={{action "noop"}} as |tabs|>
+            <tabs.tab @value="demo.tabs.index" @href={{href-to "demo.tabs.index"}}>
               Index
-            {{/tabs.tab}}
-            {{#tabs.tab value="demo.tabs.nested-route" href=(href-to "demo.tabs.nested-route")}}
+            </tabs.tab>
+            <tabs.tab @value="demo.tabs.nested-route" @href={{href-to "demo.tabs.nested-route"}}>
               Nested Route
-            {{/tabs.tab}}
-          {{/paper-tabs}}
+            </tabs.tab>
+          </PaperTabs>
 
           {{liquid-outlet class="md-padding"}}
           {{! END-SNIPPET }}
-        {{/paper-content}}
+        </PaperContent>
       </div>
-      {{paper-divider}}
+      <PaperDivider />
 
-      {{#paper-card-content}}
+      <PaperCardContent>
         <p>
           <em><b>Note:</b> transitions were implemented using liquid-fire.</em>
         </p>
@@ -231,8 +219,8 @@
           <b>Hint:</b> for Ember versions less than 2.15, use the <code>ember-router-service-polyfill</code> addon to easily retrieve
           the current route name and use it as the selected value to <code>paper-tabs</code>.
         </p>
-      {{/paper-card-content}}
-    {{/paper-card}}
+      </PaperCardContent>
+    </PaperCard>
   </div>
 
   <div class="md-padding">
@@ -256,4 +244,4 @@
     }}
   </div>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/toast.hbs
+++ b/tests/dummy/app/templates/demo/toast.hbs
@@ -1,69 +1,69 @@
-{{page-toolbar pageTitle="Toast" isDemo=true}}
+<PageToolbar @pageTitle="Toast" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Component Usage</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggleSourceCode") iconButton=true}}
-          {{paper-icon icon="code"}}
-        {{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+        <PaperButton @onClick={{action "toggleSourceCode"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+        </PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
 
     <div class="doc-code-example {{if showSourceCode "is-visible"}}">
-      {{code-snippet name="toast.hbs"}}
+      <CodeSnippet @name="toast.hbs" />
     </div>
 
     <div class="doc-content-example">
       <div id="paper-dialog-demo"></div>
-      {{#paper-card-content}}
+      <PaperCardContent>
         <p>Open a toast over the app's content. Press escape, swipe or timeout to close the toast.</p>
 
         <div class="layout-row layout-wrap">
-          {{#paper-button raised=true primary=true onClick=(action "openToast")}}
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openToast"}}>
             Open toast with accent button
-          {{/paper-button}}
+          </PaperButton>
 
-          {{#paper-button raised=true primary=true onClick=(action "openToastWithout")}}
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openToastWithout"}}>
             Open toast
-          {{/paper-button}}
+          </PaperButton>
         </div>
 
         <h3>Options</h3>
         <div class="layout-row layout-wrap layout-xs-column layout-sm-column">
 
           <div class="flex">
-            {{#paper-radio-group groupValue=positionX onChange=(action (mut positionX)) as |group|}}
-              {{#group.radio value="left"}}Left{{/group.radio}}
-              {{#group.radio value="right"}}Right{{/group.radio}}
-            {{/paper-radio-group}}
+            <PaperRadioGroup @groupValue={{positionX}} @onChange={{action (mut positionX)}} as |group|>
+              <group.radio @value="left">Left</group.radio>
+              <group.radio @value="right">Right</group.radio>
+            </PaperRadioGroup>
           </div>
           <div class="flex">
-            {{#paper-radio-group groupValue=positionY onChange=(action (mut positionY)) as |group|}}
-              {{#group.radio value="top"}}Top{{/group.radio}}
-              {{#group.radio value="bottom"}}Bottom{{/group.radio}}
-            {{/paper-radio-group}}
+            <PaperRadioGroup @groupValue={{positionY}} @onChange={{action (mut positionY)}} as |group|>
+              <group.radio @value="top">Top</group.radio>
+              <group.radio @value="bottom">Bottom</group.radio>
+            </PaperRadioGroup>
           </div>
           <div class="flex">
-            {{#paper-checkbox value=capsule onChange=(action (mut capsule))}}
+            <PaperCheckbox @value={{capsule}} @onChange={{action (mut capsule)}}>
               capsule
-            {{/paper-checkbox}}
+            </PaperCheckbox>
           </div>
           <div class="flex">
-            {{#paper-checkbox value=swipeToClose  flex=true onChange=(action (mut swipeToClose))}}
+            <PaperCheckbox @value={{swipeToClose}} @flex={{true}} @onChange={{action (mut swipeToClose)}}>
               swipeToClose
-            {{/paper-checkbox}}
+            </PaperCheckbox>
           </div>
         </div>
 
         <h3>duration</h3>
         <div class="layout layout-align-center-center slider-container">
           {{paper-icon "watch later"}}
-          {{paper-slider class="flex" value=duration max=6000 onChange=(action (mut duration))}}
-          {{paper-input type="number" value=duration onChange=(action (mut duration))}}
+          <PaperSlider @class="flex" @value={{duration}} @max={{6000}} @onChange={{action (mut duration)}} />
+          <PaperInput @type="number" @value={{duration}} @onChange={{action (mut duration)}} />
         </div>
 
         {{paper-api
@@ -81,53 +81,53 @@
           )
         }}
 
-      {{/paper-card-content}}
+      </PaperCardContent>
     </div>
 
-  {{/paper-card}}
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Paper Toaster Service</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggleSourceCode") iconButton=true}}
-          {{paper-icon icon="code"}}
-        {{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+        <PaperButton @onClick={{action "toggleSourceCode"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+        </PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
 
     <div class="doc-code-example {{if showSourceCode "is-visible"}}">
-      {{code-snippet name="toaster.js"}}
+      <CodeSnippet @name="toaster.js" />
     </div>
 
     <div class="doc-content-example">
-      {{#paper-card-content}}
+      <PaperCardContent>
 
         <p>Open a toast via <code>paperToaster</code> service and <code>\{{paper-toaster}}</code> component.</p>
 
         <h3>Options</h3>
 
         <div class="layout-column">
-          {{paper-input label="Toast text" value=toastText onChange=(action (mut toastText))}}
+          <PaperInput @label="Toast text" @value={{toastText}} @onChange={{action (mut toastText)}} />
 
           <strong>Toast class</strong>
           <div>
-            {{#paper-radio-group class="layout-row" groupValue=toastClass onChange=(action (mut toastClass)) as |group|}}
-              {{#group.radio value=""}}[none]{{/group.radio}}
-              {{#group.radio value="md-accent"}}md-accent{{/group.radio}}
-              {{#group.radio value="md-warn"}}md-warn{{/group.radio}}
-            {{/paper-radio-group}}
+            <PaperRadioGroup @class="layout-row" @groupValue={{toastClass}} @onChange={{action (mut toastClass)}} as |group|>
+              <group.radio @value="">[none]</group.radio>
+              <group.radio @value="md-accent">md-accent</group.radio>
+              <group.radio @value="md-warn">md-warn</group.radio>
+            </PaperRadioGroup>
           </div>
         </div>
 
         <div class="layout-row">
-          {{#paper-button raised=true primary=true onClick=(action "openServiceToast")}}
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openServiceToast"}}>
             Open toast
-          {{/paper-button}}
-          {{#paper-button raised=true primary=true onClick=(action "openServiceActionToast")}}
+          </PaperButton>
+          <PaperButton @raised={{true}} @primary={{true}} @onClick={{action "openServiceActionToast"}}>
             Open toast with action
-          {{/paper-button}}
+          </PaperButton>
         </div>
         <ul>
           {{#each paperToaster.queue as |toast index|}}
@@ -142,9 +142,9 @@
               {{else}}
                 (Waiting)
               {{/if}}
-              {{#paper-button onClick=(action "cancelToast" toast)}}
+              <PaperButton @onClick={{action "cancelToast" toast}}>
                 Cancel
-              {{/paper-button}}
+              </PaperButton>
             </li>
           {{/each}}
         </ul>
@@ -178,28 +178,28 @@
           <code>config/environment.js</code> file:
         </p>
 
-        {{code-snippet name="paper-toaster-defaults.js"}}
+        <CodeSnippet @name="paper-toaster-defaults.js" />
 
-      {{/paper-card-content}}
+      </PaperCardContent>
     </div>
 
-  {{/paper-card}}
+  </PaperCard>
 
   <span id="bottom-of-card"></span>
 
-{{/doc-content}}
+</DocContent>
 
 {{! BEGIN-SNIPPET toast }}
 {{#if showToast}}
-  {{#paper-toast duration=duration position=(concat positionY " " positionX) capsule=capsule swipeToClose=swipeToClose onClose=(action "closeToast") as |toast|}}
-    {{#toast.text}}Hello{{/toast.text}}
-    {{#paper-button accent=true onClick=(action "buttonAction")}}Undo{{/paper-button}}
-  {{/paper-toast}}
+  <PaperToast @duration={{duration}} @position={{concat positionY " " positionX}} @capsule={{capsule}} @swipeToClose={{swipeToClose}} @onClose={{action "closeToast"}} as |toast|>
+    <toast.text>Hello</toast.text>
+    <PaperButton @accent={{true}} @onClick={{action "buttonAction"}}>Undo</PaperButton>
+  </PaperToast>
 {{/if}}
 
 {{#if showToastWithout}}
-  {{#paper-toast duration=duration position=(concat positionY " " positionX) capsule=capsule swipeToClose=swipeToClose onClose=(action "closeToastWithout") as |toast|}}
-    {{#toast.text}}Hello{{/toast.text}}
-  {{/paper-toast}}
+  <PaperToast @duration={{duration}} @position={{concat positionY " " positionX}} @capsule={{capsule}} @swipeToClose={{swipeToClose}} @onClose={{action "closeToastWithout"}} as |toast|>
+    <toast.text>Hello</toast.text>
+  </PaperToast>
 {{/if}}
 {{! END-SNIPPET }}

--- a/tests/dummy/app/templates/demo/toolbar.hbs
+++ b/tests/dummy/app/templates/demo/toolbar.hbs
@@ -1,63 +1,63 @@
-{{page-toolbar pageTitle="Toolbar" isDemo=true}}
+<PageToolbar @pageTitle="Toolbar" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
   {{! BEGIN-SNIPPET toolbar }}
   {{! without contextual components }}
-  {{#paper-toolbar}}
-    {{#paper-toolbar-tools}}
-      {{#paper-button iconButton=true}}
+  <PaperToolbar>
+    <PaperToolbarTools>
+      <PaperButton @iconButton={{true}}>
         {{paper-icon "menu"}}
-      {{/paper-button}}
+      </PaperButton>
       <h2>
         Toolbar with Icon Buttons
       </h2>
       <span class="flex"></span>
-      {{#paper-button iconButton=true}}
+      <PaperButton @iconButton={{true}}>
         {{paper-icon "favorite"}}
-      {{/paper-button}}
-      {{#paper-button iconButton=true}}
+      </PaperButton>
+      <PaperButton @iconButton={{true}}>
         {{paper-icon "more_vert"}}
-      {{/paper-button}}
-    {{/paper-toolbar-tools}}
-  {{/paper-toolbar}}
+      </PaperButton>
+    </PaperToolbarTools>
+  </PaperToolbar>
 
   <br>
   {{! with contextual components }}
-  {{#paper-toolbar as |toolbar|}}
-    {{#toolbar.tools}}
-      {{#paper-button}}
+  <PaperToolbar as |toolbar|>
+    <toolbar.tools>
+      <PaperButton>
         Go Back
-      {{/paper-button}}
+      </PaperButton>
       <h2>Toolbar with Standard Buttons</h2>
       <span class="flex"></span>
-      {{#paper-button raised=true}}
+      <PaperButton @raised={{true}}>
         Learn More
-      {{/paper-button}}
-      {{#paper-button mini=true aria-label="Favorite"}}
+      </PaperButton>
+      <PaperButton @mini={{true}} @aria-label="Favorite">
         {{paper-icon "favorite"}}
-      {{/paper-button}}
-    {{/toolbar.tools}}
-  {{/paper-toolbar}}
+      </PaperButton>
+    </toolbar.tools>
+  </PaperToolbar>
 
   <br>
 
-  {{#paper-toolbar tall=true accent=true}}
-    {{#paper-toolbar-tools}}
+  <PaperToolbar @tall={{true}} @accent={{true}}>
+    <PaperToolbarTools>
       <h2>Toolbar: tall=true, accent=true</h2>
-    {{/paper-toolbar-tools}}
-  {{/paper-toolbar}}
+    </PaperToolbarTools>
+  </PaperToolbar>
 
   <br>
 
-  {{#paper-toolbar tall=true warn=true}}
+  <PaperToolbar @tall={{true}} @warn={{true}}>
     <span class="flex"></span>
-    {{#paper-toolbar-tools}}
+    <PaperToolbarTools>
       <h2>Toolbar: tall with actions pin to the bottom (tall=true warn=true)</h2>
-    {{/paper-toolbar-tools}}
-  {{/paper-toolbar}}
+    </PaperToolbarTools>
+  </PaperToolbar>
   {{! END-SNIPPET }}
 
   <h3>Template</h3>
-  {{code-snippet name="toolbar.hbs"}}
+  <CodeSnippet @name="toolbar.hbs" />
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/demo/tooltip.hbs
+++ b/tests/dummy/app/templates/demo/tooltip.hbs
@@ -1,28 +1,28 @@
-{{page-toolbar pageTitle="Tooltip" isDemo=true}}
+<PageToolbar @pageTitle="Tooltip" @isDemo={{true}} />
 
-{{#doc-content}}
+<DocContent>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic Usage</h2>
         <span class="flex"></span>
-        {{#paper-button onClick=(action "toggle" "showSourceCode") iconButton=true}}
-          {{paper-icon icon="code"}}
-          {{#paper-tooltip}}
+        <PaperButton @onClick={{action "toggle" "showSourceCode"}} @iconButton={{true}}>
+          <PaperIcon @icon="code" />
+          <PaperTooltip>
             {{if showSourceCode "Hide" "Show"}} code
-          {{/paper-tooltip}}
-        {{/paper-button}}
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+          </PaperTooltip>
+        </PaperButton>
+      </PaperToolbarTools>
+    </PaperToolbar>
 
     <div class="doc-code-example {{if showSourceCode "is-visible"}}">
-      {{code-snippet name="tooltip.hbs"}}
+      <CodeSnippet @name="tooltip.hbs" />
     </div>
 
     <div class="doc-content-example">
 
-      {{#paper-card-content}}
+      <PaperCardContent>
         <p>
           You can render tooltips using the paper-tooltip component. This component
           will attach to the immediate parent element and use it for positioning.
@@ -36,51 +36,51 @@
 
         <div class="layout-row layout-align-space-around-center md-padding">
           {{! BEGIN-SNIPPET tooltip }}
-          {{#paper-button raised=true}}
+          <PaperButton @raised={{true}}>
             A button
-            {{#paper-tooltip position=position}}
+            <PaperTooltip @position={{position}}>
               Hey! I'm a tooltip. Çup?
-            {{/paper-tooltip}}
-          {{/paper-button}}
+            </PaperTooltip>
+          </PaperButton>
 
-          {{#paper-button iconButton=true raised=true}}
+          <PaperButton @iconButton={{true}} @raised={{true}}>
             {{paper-icon "create"}}
-            {{#paper-tooltip position=position}}
+            <PaperTooltip @position={{position}}>
               Create
-            {{/paper-tooltip}}
-          {{/paper-button}}
+            </PaperTooltip>
+          </PaperButton>
 
-          {{#paper-button fab=true raised=true accent=true}}
+          <PaperButton @fab={{true}} @raised={{true}} @accent={{true}}>
             {{paper-icon "delete"}}
-            {{#paper-tooltip position=position}}
+            <PaperTooltip @position={{position}}>
               Delete
-            {{/paper-tooltip}}
-          {{/paper-button}}
+            </PaperTooltip>
+          </PaperButton>
 
           <div>
             {{#paper-icon "info"}}
-              {{#paper-tooltip position=position}}
+              <PaperTooltip @position={{position}}>
                 Icon tooltip
-              {{/paper-tooltip}}
+              </PaperTooltip>
             {{/paper-icon}}
           </div>
           {{! END-SNIPPET tooltip }}
         </div>
 
-        {{#paper-radio-group groupValue=position onChange=(action (mut position)) as |group|}}
-          {{#group.radio value="bottom"}}
+        <PaperRadioGroup @groupValue={{position}} @onChange={{action (mut position)}} as |group|>
+          <group.radio @value="bottom">
             Bottom
-          {{/group.radio}}
-          {{#group.radio value="top"}}
+          </group.radio>
+          <group.radio @value="top">
             Top
-          {{/group.radio}}
-          {{#group.radio value="left"}}
+          </group.radio>
+          <group.radio @value="left">
             Left
-          {{/group.radio}}
-          {{#group.radio value="right"}}
+          </group.radio>
+          <group.radio @value="right">
             Right
-          {{/group.radio}}
-        {{/paper-radio-group}}
+          </group.radio>
+        </PaperRadioGroup>
 
         {{paper-api
           (p-section
@@ -91,7 +91,7 @@
           )
         }}
 
-      {{/paper-card-content}}
+      </PaperCardContent>
     </div>
-  {{/paper-card}}
-{{/doc-content}}
+  </PaperCard>
+</DocContent>

--- a/tests/dummy/app/templates/forms.hbs
+++ b/tests/dummy/app/templates/forms.hbs
@@ -1,72 +1,61 @@
-{{page-toolbar pageTitle="Forms" isDemo=false}}
+<PageToolbar @pageTitle="Forms" @isDemo={{false}} />
 
-{{#doc-content class="card-demo"}}
+<DocContent @class="card-demo">
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Basic usage</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+      </PaperToolbarTools>
+    </PaperToolbar>
 
-    {{#paper-card-content}}
+    <PaperCardContent>
       <p>
         ember-paper provides a <code>paper-form</code> to help you build forms
         and keep track of the form's global validity state. This component uses
         the html form tag by default, so expected form behavior will occur.
         (For example, pressing the enter key from within one of the form's
         inputs will submit the form.)
-        <code>paper-form</code> yields <code>{{#link-to "demo.input"}}paper-input{{/link-to}}</code>,
-        <code>{{#link-to "demo.select"}}paper-select{{/link-to}}</code>
-        and <code>{{#link-to "demo.autocomplete"}}paper-autocomplete{{/link-to}}</code> controls.
+        <code>paper-form</code> yields <code><LinkTo @route="demo.input">paper-input</LinkTo></code>,
+        <code><LinkTo @route="demo.select">paper-select</LinkTo></code>
+        and <code><LinkTo @route="demo.autocomplete">paper-autocomplete</LinkTo></code> controls.
         In the following example you can see how we use the yielded form controls:
       </p>
 
       {{! BEGIN-SNIPPET form.basic-usage }}
-      {{#paper-form onSubmit=(action "basicSubmitAction") as |form|}}
+      <PaperForm @onSubmit={{action "basicSubmitAction"}} as |form|>
         <div class="layout-row">
           <div class="layout-column flex-50">
-            {{form.input label="First Name" value=firstName onChange=(action (mut firstName)) required=true}}
-            {{form.input label="Last Name" value=lastName onChange=(action (mut lastName))}}
+            <form.input @label="First Name" @value={{firstName}} @onChange={{action (mut firstName)}} @required={{true}} />
+            <form.input @label="Last Name" @value={{lastName}} @onChange={{action (mut lastName)}} />
           </div>
           <div class="layout-column flex-50">
-            {{#form.autocomplete
-              required=true
-              options=items
-              selected=selectedCountry
-              searchField="name"
-              labelPath="name"
-              label="Country"
-              noMatchesMessage="Oops this country doesn't exist."
-              onSelectionChange=(action (mut selectedCountry)) as |country select|}}
-              {{paper-autocomplete-highlight
-                label=country.name
-                searchText=select.searchText
-                flags="i"}}
-            {{/form.autocomplete}}
-            {{form.input type="number" label="Age" value=age onChange=(action (mut age)) min=13 max=65 required=true}}
+            <form.autocomplete @required={{true}} @options={{items}} @selected={{selectedCountry}} @searchField="name" @labelPath="name" @label="Country" @noMatchesMessage="Oops this country doesn't exist." @onSelectionChange={{action (mut selectedCountry)}} as |country select|>
+              <PaperAutocompleteHighlight @label={{country.name}} @searchText={{select.searchText}} @flags="i" />
+            </form.autocomplete>
+            <form.input @type="number" @label="Age" @value={{age}} @onChange={{action (mut age)}} @min={{13}} @max={{65}} @required={{true}} />
           </div>
         </div>
         <div class="layout-row">
-          {{#form.submit-button raised=true primary=true}}Submit{{/form.submit-button}}
+          <form.submit-button @raised={{true}} @primary={{true}}>Submit</form.submit-button>
         </div>
-      {{/paper-form}}
+      </PaperForm>
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="form.basic-usage.hbs"}}
-    {{/paper-card-content}}
+      <CodeSnippet @name="form.basic-usage.hbs" />
+    </PaperCardContent>
 
-  {{/paper-card}}
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Using the form validity state</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+      </PaperToolbarTools>
+    </PaperToolbar>
 
-    {{#paper-card-content}}
+    <PaperCardContent>
 
       <p>
         A typical use case for the global validity state is to toggle the submit button
@@ -75,32 +64,32 @@
       </p>
 
       {{! BEGIN-SNIPPET form.disabled-submit }}
-      {{#paper-form onSubmit=(action "disabledSubmitAction") as |form|}}
+      <PaperForm @onSubmit={{action "disabledSubmitAction"}} as |form|>
         <div class="layout-row">
-          {{form.input label="Favorite Letter" value=favoriteLetter onChange=(action (mut favoriteLetter)) required=true maxlength=1}}
+          <form.input @label="Favorite Letter" @value={{favoriteLetter}} @onChange={{action (mut favoriteLetter)}} @required={{true}} @maxlength={{1}} />
         </div>
         <div class="layout-row">
-          {{#form.submit-button raised=true primary=true disabled=form.isInvalid}}
+          <form.submit-button @raised={{true}} @primary={{true}} @disabled={{form.isInvalid}}>
             Submit
-          {{/form.submit-button}}
+          </form.submit-button>
         </div>
-      {{/paper-form}}
+      </PaperForm>
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="form.disabled-submit.hbs"}}
-    {{/paper-card-content}}
+      <CodeSnippet @name="form.disabled-submit.hbs" />
+    </PaperCardContent>
 
-  {{/paper-card}}
+  </PaperCard>
 
-  {{#paper-card}}
-    {{#paper-toolbar}}
-      {{#paper-toolbar-tools}}
+  <PaperCard>
+    <PaperToolbar>
+      <PaperToolbarTools>
         <h2>Advanced usage</h2>
-      {{/paper-toolbar-tools}}
-    {{/paper-toolbar}}
+      </PaperToolbarTools>
+    </PaperToolbar>
 
-    {{#paper-card-content}}
+    <PaperCardContent>
 
       <p>
         If you prefer, you can trigger the submit action without using a submit button.
@@ -121,21 +110,21 @@
       </p>
 
       {{! BEGIN-SNIPPET form.custom-components }}
-      {{#paper-form onSubmit=(action "customSubmitAction") as |form|}}
+      <PaperForm @onSubmit={{action "customSubmitAction"}} as |form|>
         <div class="layout-row">
-          {{paper-input label="Favorite Number" value=favoriteNumber onChange=(action (mut favoriteNumber)) required=true min=1 max=10}}
+          <PaperInput @label="Favorite Number" @value={{favoriteNumber}} @onChange={{action (mut favoriteNumber)}} @required={{true}} @min={{1}} @max={{10}} />
         </div>
         <div class="layout-row">
-          {{#form.submit-button raised=true primary=true}}Submit{{/form.submit-button}}
+          <form.submit-button @raised={{true}} @primary={{true}}>Submit</form.submit-button>
         </div>
-      {{/paper-form}}
+      </PaperForm>
       {{! END-SNIPPET }}
 
       <h3>Template</h3>
-      {{code-snippet name="form.custom-components.hbs"}}
+      <CodeSnippet @name="form.custom-components.hbs" />
 
-    {{/paper-card-content}}
+    </PaperCardContent>
 
-  {{/paper-card}}
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Introduction" isDemo=false}}
+<PageToolbar @pageTitle="Introduction" @isDemo={{false}} />
 
-{{#paper-content scroll-y=true class="layout-padding flex"}}
+<PaperContent @scroll-y={{true}} @class="layout-padding flex">
   <div class="doc-content">
 
     <h2 class="md-headline" style="margin-top: 24px;">Welcome to Ember Paper.</h2>
@@ -11,7 +11,7 @@
     <p>
       To install run:
     </p>
-    {{code-snippet name="install.sh"}}
+    <CodeSnippet @name="install.sh" />
 
     <p>This should also automatically create an scss file under <code>app/styles/app.scss</code> with <code>@import 'ember-paper';</code> and install <code>ember-cli-sass</code>.</p>
     <p>Sass is an important part of Ember-paper. Using sass you can override default variables and easily change the default behavior of Ember-paper.</p>
@@ -27,7 +27,7 @@
       You can set this by adding to the Content Security Policy defined in <code>config/environment.js</code> like so:
     </p>
 
-    {{code-snippet name="content-security-policy.js"}}
+    <CodeSnippet @name="content-security-policy.js" />
 
     <p>
       You can find out more information on the CSP addon page <a href="https://github.com/rwjblue/ember-cli-content-security-policy#ember-cli-content-security-policy">here</a>.
@@ -53,14 +53,14 @@
       <dd>
         Consuming apps can optionally specify this array to only include these components into the build.
         You should use either whitelist or blacklist, not both.
-        {{code-snippet name="whitelist.js"}}
+        <CodeSnippet @name="whitelist.js" />
         The dependencies of the specified components will be included as well.
         This is the recommended approach, blacklist is harder to get right.
       </dd>
       <dt><code>ENV['ember-paper'].blacklist</code> (defaults to <code>[]</code>)</dt>
       <dd>
         Consuming apps can optionally specify this array to exclude these components from the build.
-        {{code-snippet name="blacklist.js"}}
+        <CodeSnippet @name="blacklist.js" />
         This only bans from the build the specified components, not its dependencies.
         whitelist is easier to maintain.
       </dd>
@@ -83,4 +83,4 @@
       <a class="github-button" href="https://github.com/miguelcobain/ember-paper" data-style="mega" data-count-href="/miguelcobain/ember-paper/network" data-count-api="/repos/miguelcobain/ember-paper#forks_count">Fork</a>
     </p>
   </div>
-{{/paper-content}}
+</PaperContent>

--- a/tests/dummy/app/templates/layout/child-alignment.hbs
+++ b/tests/dummy/app/templates/layout/child-alignment.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Child Alignment" isLayout=true}}
+<PageToolbar @pageTitle="Child Alignment" @isLayout={{true}} />
 
-{{#doc-content class="layout-docs alignment"}}
+<DocContent @class="layout-docs alignment">
 
   <p>
     The <code>layout-align</code> class takes two words. The first word says how the children
@@ -23,15 +23,15 @@
     settings:
   </p>
 
-  {{#paper-card as |card|}}
-    {{#paper-toolbar as |toolbar|}}
-      {{#toolbar.tools}}
+  <PaperCard as |card|>
+    <PaperToolbar as |toolbar|>
+      <toolbar.tools>
         <h2>
           <span class="layout-class">{{layoutClass}}</span>
           <span class="layout-align-class">{{layoutAlignClass}}</span>
         </h2>
-      {{/toolbar.tools}}
-    {{/paper-toolbar}}
+      </toolbar.tools>
+    </PaperToolbar>
     <div class="example interactive-demo">
       {{! BEGIN-SNIPPET child-alignment }}
       <div class="{{layoutClass}} {{layoutAlignClass}}">
@@ -41,69 +41,69 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
+    <card.content>
       <div class="layout-row layout-align-space-between-start">
         <div class="demo-group">
           <h4>Layout Direction</h4>
-          {{#paper-radio-group groupValue=layoutDirection onChange=(action (mut layoutDirection)) as |group|}}
-            {{#group.radio value="row"}}
+          <PaperRadioGroup @groupValue={{layoutDirection}} @onChange={{action (mut layoutDirection)}} as |group|>
+            <group.radio @value="row">
               row
-            {{/group.radio}}
-            {{#group.radio value="column"}}
+            </group.radio>
+            <group.radio @value="column">
               column
-            {{/group.radio}}
-          {{/paper-radio-group}}
+            </group.radio>
+          </PaperRadioGroup>
         </div>
 
         <div class="demo-group">
           <h4>Alignment in Layout Direction</h4>
-          {{#paper-radio-group groupValue=mainDirection onChange=(action (mut mainDirection)) as |group|}}
-            {{#group.radio value=""}}
+          <PaperRadioGroup @groupValue={{mainDirection}} @onChange={{action (mut mainDirection)}} as |group|>
+            <group.radio @value="">
               none
-            {{/group.radio}}
-            {{#group.radio value="start"}}
+            </group.radio>
+            <group.radio @value="start">
               start (default)
-            {{/group.radio}}
-            {{#group.radio value="center"}}
+            </group.radio>
+            <group.radio @value="center">
               center
-            {{/group.radio}}
-            {{#group.radio value="end"}}
+            </group.radio>
+            <group.radio @value="end">
               end
-            {{/group.radio}}
-            {{#group.radio value="space-around"}}
+            </group.radio>
+            <group.radio @value="space-around">
               space-around
-            {{/group.radio}}
-            {{#group.radio value="space-between"}}
+            </group.radio>
+            <group.radio @value="space-between">
               space-between
-            {{/group.radio}}
-          {{/paper-radio-group}}
+            </group.radio>
+          </PaperRadioGroup>
         </div>
 
         <div class="demo-group">
           <h4>Alignment in Perpendicular Direction</h4>
-          {{#paper-radio-group groupValue=perpDirection onChange=(action (mut perpDirection)) as |group|}}
-            {{#group.radio value=""}}
+          <PaperRadioGroup @groupValue={{perpDirection}} @onChange={{action (mut perpDirection)}} as |group|>
+            <group.radio @value="">
               <em>none</em>
-            {{/group.radio}}
-            {{#group.radio value="start"}}
+            </group.radio>
+            <group.radio @value="start">
               start
-            {{/group.radio}}
-            {{#group.radio value="center"}}
+            </group.radio>
+            <group.radio @value="center">
               center
-            {{/group.radio}}
-            {{#group.radio value="end"}}
+            </group.radio>
+            <group.radio @value="end">
               end
-            {{/group.radio}}
-            {{#group.radio value="stretch"}}
+            </group.radio>
+            <group.radio @value="stretch">
               stretch (default)
-            {{/group.radio}}
-          {{/paper-radio-group}}
+            </group.radio>
+          </PaperRadioGroup>
         </div>
       </div>
 
-      {{code-snippet name="child-alignment.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+      <CodeSnippet @name="child-alignment.hbs" />
+    </card.content>
+  </PaperCard>
 
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/layout/introduction.hbs
+++ b/tests/dummy/app/templates/layout/introduction.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Introduction" isLayout=true}}
+<PageToolbar @pageTitle="Introduction" @isLayout={{true}} />
 
-{{#doc-content class="layout-docs"}}
+<DocContent @class="layout-docs">
 
   <h2>Overview</h2>
 
@@ -90,7 +90,7 @@
 
   <p>Below is an example of the usage of the responsive layout classes:</p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     {{! BEGIN-SNIPPET layout-introduction }}
     <div class="layout-column example introduction-example">
       <div class="flex-33 flex-md-{{box1Height}} box-one"></div>
@@ -102,34 +102,28 @@
       <div class="flex box-three"></div>
     </div>
     {{! END-SNIPPET }}
-    {{#card.content}}
+    <card.content>
 
       <div class="layout-row layout-align-space-between-start">
-        {{paper-input
-        value=box1Height
-        label="box1Height"
-        type="number"
-        passThru=(hash min="0" max="100" step="5")
-        onChange=(action (mut box1Height))
-        }}
+        <PaperInput @value={{box1Height}} @label="box1Height" @type="number" @passThru={{hash min="0" max="100" step="5"}} @onChange={{action (mut box1Height)}} />
 
         <div class="demo-group">
           <h4>direction</h4>
-          {{#paper-radio-group groupValue=direction onChange=(action (mut direction)) as |group|}}
-            {{#group.radio value="row"}}
+          <PaperRadioGroup @groupValue={{direction}} @onChange={{action (mut direction)}} as |group|>
+            <group.radio @value="row">
               row
-            {{/group.radio}}
-            {{#group.radio value="column"}}
+            </group.radio>
+            <group.radio @value="column">
               column
-            {{/group.radio}}
-          {{/paper-radio-group}}
+            </group.radio>
+          </PaperRadioGroup>
         </div>
 
-        {{#paper-switch value=hideBox onChange=(action (mut hideBox))}}hideBox{{/paper-switch}}
+        <PaperSwitch @value={{hideBox}} @onChange={{action (mut hideBox)}}>hideBox</PaperSwitch>
       </div>
 
-      {{code-snippet name="layout-introduction.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+      <CodeSnippet @name="layout-introduction.hbs" />
+    </card.content>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/layout/layout-children.hbs
+++ b/tests/dummy/app/templates/layout/layout-children.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Layout Children" isLayout=true}}
+<PageToolbar @pageTitle="Layout Children" @isLayout={{true}} />
 
-{{#doc-content class="layout-docs children"}}
+<DocContent @class="layout-docs children">
 
   <h2>Children within a Layout Container</h2>
 
@@ -10,7 +10,7 @@
     on the container's child elements:
   </p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-1">
       {{! BEGIN-SNIPPET layout-children.example1 }}
       <div class="layout-row">
@@ -20,10 +20,10 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-children.example1.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+    <card.content>
+      <CodeSnippet @name="layout-children.example1.hbs" />
+    </card.content>
+  </PaperCard>
 
   <p>
     Add the <code>flex</code> class to a layout's child element and the element will flex (grow or shrink)
@@ -31,7 +31,7 @@
     with respect to its parent container and the other elements within the container.
   </p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-2">
       {{! BEGIN-SNIPPET layout-children.example2 }}
       <div class="layout-row layout-wrap">
@@ -45,10 +45,10 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-children.example2.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+    <card.content>
+      <CodeSnippet @name="layout-children.example2.hbs" />
+    </card.content>
+  </PaperCard>
 
   <p>
     A layout child's <code>flex</code> class can be given an integer parameter from 0-100.
@@ -60,7 +60,7 @@
     <code>flex-50</code>, <code>flex-66</code>, <code>flex-75</code>, ... <code>flex-100</code>.
   </p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-3">
       {{! BEGIN-SNIPPET layout-children.example3 }}
       <div class="layout-row">
@@ -73,10 +73,10 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-children.example3.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+    <card.content>
+      <CodeSnippet @name="layout-children.example3.hbs" />
+    </card.content>
+  </PaperCard>
 
   <h2>Additional Flex Parameters</h2>
 
@@ -85,7 +85,7 @@
     API easier to understand.
   </p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-4">
       {{! BEGIN-SNIPPET layout-children.example4 }}
       <div class="layout-row layout-wrap">
@@ -99,8 +99,8 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-children.example4.hbs"}}
+    <card.content>
+      <CodeSnippet @name="layout-children.example4.hbs" />
 
       {{paper-api
         (p-section
@@ -114,8 +114,8 @@
         )
         header=(p-row "Class" "Effect")
       }}
-    {{/card.content}}
-  {{/paper-card}}
+    </card.content>
+  </PaperCard>
 
   <h2>Ordering HTML Elements</h2>
 
@@ -124,7 +124,7 @@
     Any integer parameter value from -20 to 20 is accepted.
   </p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-5">
       {{! BEGIN-SNIPPET layout-children.example5 }}
       <div class="layout-row">
@@ -135,9 +135,9 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-children.example5.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+    <card.content>
+      <CodeSnippet @name="layout-children.example5.hbs" />
+    </card.content>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/layout/layout-containers.hbs
+++ b/tests/dummy/app/templates/layout/layout-containers.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Layout Containers" isLayout=true}}
+<PageToolbar @pageTitle="Layout Containers" @isLayout={{true}} />
 
-{{#doc-content class="layout-docs containers"}}
+<DocContent @class="layout-docs containers">
   <h2>Layout and Containers</h2>
   <p>
     Use the <code>layout</code> class on a container element to specify the layout direction for its
@@ -17,7 +17,7 @@
     header=(p-row "Class" "Effect")
   }}
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-1 layout-row">
       {{! BEGIN-SNIPPET layout-containers.example1 }}
       <div class="layout-row flex">
@@ -30,10 +30,10 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-containers.example1.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+    <card.content>
+      <CodeSnippet @name="layout-containers.example1.hbs" />
+    </card.content>
+  </PaperCard>
 
   <p>
     Note that <code>layout</code> only affects the flow direction for that container's immediate children.
@@ -42,7 +42,7 @@
   <h2>Layouts and Responsive Breakpoints</h2>
 
   <p>
-    As discussed in the {{#link-to "layout.introduction"}}Layout Introduction{{/link-to}} page you can make
+    As discussed in the <LinkTo @route="layout.introduction">Layout Introduction</LinkTo> page you can make
     your layout change depending upon the device view size by using breakpoint alias suffixes.
   </p>
   <p>
@@ -73,7 +73,7 @@
     it will reset to <code>row</code> for <code>gt-sm</code> view sizes.
   </p>
 
-  {{#paper-card as |card|}}
+  <PaperCard as |card|>
     <div class="example example-2">
       {{! BEGIN-SNIPPET layout-containers.example2 }}
       <div class="layout-row layout-xs-column">
@@ -82,9 +82,9 @@
       </div>
       {{! END-SNIPPET }}
     </div>
-    {{#card.content}}
-      {{code-snippet name="layout-containers.example2.hbs"}}
-    {{/card.content}}
-  {{/paper-card}}
+    <card.content>
+      <CodeSnippet @name="layout-containers.example2.hbs" />
+    </card.content>
+  </PaperCard>
 
-{{/doc-content}}
+</DocContent>

--- a/tests/dummy/app/templates/theme.hbs
+++ b/tests/dummy/app/templates/theme.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Themes & Colors" isDemo=false}}
+<PageToolbar @pageTitle="Themes & Colors" @isDemo={{false}} />
 
-{{#paper-content class="md-padding"}}
+<PaperContent @class="md-padding">
   <div class="doc-content">
 
     <p>
@@ -20,7 +20,7 @@
       To customize the default theme, you can override the sass variables for each intention:
     </p>
 
-    {{code-snippet name="theme.import.scss"}}
+    <CodeSnippet @name="theme.import.scss" />
 
     <p>
       As you can see, you can just specify a name string for the palette you want, if that palette
@@ -83,7 +83,7 @@
       Here is the definition of the "teal" palette, applied to the primary intention:
     </p>
 
-    {{code-snippet name="theme.custom-palette.scss"}}
+    <CodeSnippet @name="theme.custom-palette.scss" />
 
     <blockquote>
       You can find some material palette generators online. Example: <a href="http://mcg.mbitson.com/">http://mcg.mbitson.com/</a>.
@@ -111,7 +111,7 @@
       Here is an example of using these functions:
     </p>
 
-    {{code-snippet name="theme.color-function.scss"}}
+    <CodeSnippet @name="theme.color-function.scss" />
 
 
     <h3>Changing themes at runtime</h3>
@@ -127,57 +127,36 @@
       routes of the demo after installing a custom theme.
     </p>
 
-    {{#paper-card as |card|}}
-      {{#card.content class="layout-row"}}
-        {{#paper-select
-          label="Primary palette"
-          class="flex"
-          required=true
-          options=palettes
-          selected=primary
-          onChange=(action (mut primary))
-          as |p|}}
+    <PaperCard as |card|>
+      <card.content @class="layout-row">
+        <PaperSelect @label="Primary palette" @class="flex" @required={{true}} @options={{palettes}} @selected={{primary}} @onChange={{action (mut primary)}} as |p|>
           {{p.name}}
-        {{/paper-select}}
+        </PaperSelect>
 
-        {{#paper-select
-          label="Accent palette"
-          class="flex"
-          required=true
-          options=palettes
-          selected=accent
-          onChange=(action (mut accent))
-          as |p|}}
+        <PaperSelect @label="Accent palette" @class="flex" @required={{true}} @options={{palettes}} @selected={{accent}} @onChange={{action (mut accent)}} as |p|>
           {{p.name}}
-        {{/paper-select}}
+        </PaperSelect>
 
-        {{#paper-select
-          label="Warn palette"
-          class="flex"
-          required=true
-          options=palettes
-          selected=warn
-          onChange=(action (mut warn))
-          as |p|}}
+        <PaperSelect @label="Warn palette" @class="flex" @required={{true}} @options={{palettes}} @selected={{warn}} @onChange={{action (mut warn)}} as |p|>
           {{p.name}}
-        {{/paper-select}}
+        </PaperSelect>
 
-      {{/card.content}}
+      </card.content>
 
-      {{#card.actions}}
-        {{#paper-button primary=true raised=true disabled=isInvalid onClick=(action "installTheme")}}
+      <card.actions>
+        <PaperButton @primary={{true}} @raised={{true}} @disabled={{isInvalid}} @onClick={{action "installTheme"}}>
           Install Theme
-        {{/paper-button}}
+        </PaperButton>
 
-        {{#paper-button accent=true raised=true onClick=(action "uninstallTheme")}}
+        <PaperButton @accent={{true}} @raised={{true}} @onClick={{action "uninstallTheme"}}>
           Uninstall Theme
-        {{/paper-button}}
-      {{/card.actions}}
-    {{/paper-card}}
+        </PaperButton>
+      </card.actions>
+    </PaperCard>
 
     <p>Here is the code used for these actions:</p>
 
-    {{code-snippet name="theme.service.js"}}
+    <CodeSnippet @name="theme.service.js" />
 
     <h3>Browser support</h3>
 
@@ -194,7 +173,7 @@
       such fallback values:
     </p>
 
-    {{code-snippet name="theme.paper-var.scss"}}
+    <CodeSnippet @name="theme.paper-var.scss" />
 
     <h3>Generating palettes based on a color</h3>
 
@@ -221,4 +200,4 @@
       So you can install any generated palette right away!
     </p>
   </div>
-{{/paper-content}}
+</PaperContent>

--- a/tests/dummy/app/templates/typography.hbs
+++ b/tests/dummy/app/templates/typography.hbs
@@ -1,6 +1,6 @@
-{{page-toolbar pageTitle="Typography" isDemo=false}}
+<PageToolbar @pageTitle="Typography" @isDemo={{false}} />
 
-{{#paper-content class="md-padding"}}
+<PaperContent @class="md-padding">
   <div class="doc-content">
     <h3>Headings</h3>
     <div class="preview-block">
@@ -73,7 +73,7 @@
     <h3>Multi-line code blocks</h3>
     <p>
       Use &lt;pre&gt; for multi-line code blocks.
-      {{code-snippet name="typography.code-block.hbs"}}
+      <CodeSnippet @name="typography.code-block.hbs" />
     </p>
 
     <h3>Inline code blocks</h3>
@@ -114,4 +114,4 @@
       </tbody>
     </table>
   </div>
-{{/paper-content}}
+</PaperContent>


### PR DESCRIPTION
# Motivation

I have been using this library to refactor a project I am working on (https://github.com/gabrielcsapo/broccoli-inspector/pull/22) and it has been an awesome help! I am currently trying to use all the octane features and ensure that we are using angle brackets. Having the docs updated to use angle brackets helps for quickly prototyping stuff out! 

## Example

> Here is just an excerpt of how the button pages looks with the codemod run.

![localhost_4500_ (4)](https://user-images.githubusercontent.com/1854811/82274535-3f261c00-9935-11ea-857f-72df13c1428c.png)

checks off angle brackets from https://github.com/miguelcobain/ember-paper/issues/1117