### PR TITLE
Better handling basic-dropdown parent for testing env (#1166)

### DIFF
--- a/addon/components/paper-menu/content/component.js
+++ b/addon/components/paper-menu/content/component.js
@@ -8,6 +8,9 @@ import { tagName, layout } from '@ember-decorators/component';
 
 import { ESCAPE, LEFT_ARROW, UP_ARROW, RIGHT_ARROW, DOWN_ARROW } from 'ember-paper/utils/key-constants';
 
+import { getOwner } from '@ember/application';
+import ebdGetParent from 'ember-paper/utils/ebd-get-parent';
+
 function waitForAnimations(element, callback) {
   let computedStyle = window.getComputedStyle(element);
   if (computedStyle.transitionDuration && computedStyle.transitionDuration !== '0s') {
@@ -58,8 +61,9 @@ class PaperMenuContent extends Component {
     let parentElement = this.renderInPlace ? element.parentElement.parentElement : element.parentElement;
 
     // workaround for https://github.com/miguelcobain/ember-paper/issues/1151. See also https://github.com/emberjs/ember.js/issues/18795.
+    // & https://github.com/miguelcobain/ember-paper/issues/1166
     if (!parentElement) {
-      parentElement = document.getElementById('ember-basic-dropdown-wormhole');
+      parentElement = ebdGetParent(getOwner(this))
     }
 
     let clone = element.cloneNode(true);

--- a/addon/components/paper-select/ebd-content/component.js
+++ b/addon/components/paper-select/ebd-content/component.js
@@ -11,6 +11,9 @@ import { ESCAPE, LEFT_ARROW, UP_ARROW, RIGHT_ARROW, DOWN_ARROW, ENTER } from 'em
 
 import { advanceSelectableOption } from 'ember-power-select/utils/group-utils';
 
+import { getOwner } from '@ember/application';
+import ebdGetParent from 'ember-paper/utils/ebd-get-parent';
+
 function waitForAnimations(element, callback) {
   let computedStyle = window.getComputedStyle(element);
   if (computedStyle.transitionDuration && computedStyle.transitionDuration !== '0s') {
@@ -64,6 +67,12 @@ class PaperSelectEbdContent extends Component {
   @action
   async animateOut(dropdownElement) {
     let parentElement = this.renderInPlace ? dropdownElement.parentElement.parentElement : dropdownElement.parentElement;
+
+    // workaround for https://github.com/miguelcobain/ember-paper/issues/1166
+    if (!parentElement) {
+      parentElement = ebdGetParent(getOwner(this))
+    }
+
     let clone = dropdownElement.cloneNode(true);
     clone.id = `${clone.id}--clone`;
     parentElement.appendChild(clone);

--- a/addon/utils/ebd-get-parent.js
+++ b/addon/utils/ebd-get-parent.js
@@ -1,0 +1,28 @@
+import { DEBUG } from '@glimmer/env';
+import requirejs from 'require';
+
+export default function ebdGetParent(owner) {
+  // Try to fix :
+  // - https://github.com/miguelcobain/ember-paper/issues/1151
+  // - https://github.com/miguelcobain/ember-paper/issues/1166
+  // By doing like https://github.com/cibernox/ember-basic-dropdown/blob/850c227c0a58148056d55d41aa0e5d88656b8165/addon/components/basic-dropdown.js#L273-L290
+  let config = owner.resolveRegistration('config:environment');
+  let id;
+  if (config.environment === 'test') {
+    if (DEBUG) {
+      if (requirejs.has('@ember/test-helpers/dom/get-root-element')) {
+        try {
+          id = requirejs('@ember/test-helpers/dom/get-root-element').default().id;
+        } catch(ex) {
+          id = document.querySelector('#ember-testing > .ember-view').id;
+        }
+      } else {
+        id = document.querySelector('#ember-testing > .ember-view').id;
+      }
+    }
+  } else {
+    id =  config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole';
+  }
+
+  return document.getElementById(id);
+}


### PR DESCRIPTION
This try to fix `Cannot read property 'appendChild' of null` issue on `paper-menu` & `paper-select` for ember > 3.17 when testing.

I think related issues are : 
- https://github.com/miguelcobain/ember-paper/issues/1139
- https://github.com/miguelcobain/ember-paper/issues/1151
- https://github.com/miguelcobain/ember-paper/issues/1166

The code of https://github.com/miguelcobain/ember-paper/blob/b7f13ad6137e456c53afa1bfda8ede0855e1a2d1/addon/utils/ebd-get-parent.js is inspired by what `ember-basic-drop-down` do : https://github.com/cibernox/ember-basic-dropdown/blob/850c227c0a58148056d55d41aa0e5d88656b8165/addon/components/basic-dropdown.js#L273-L290


In addition to this PR, maybe I miss something, but : 

From what I understand here, the reason `animateOut` exits on `paper-select` & `paper-menu` is for animation & to handle `isActive` :thinking: .

Plus, on paper-select, to keep the scroll position into the drop-down on animate out... (https://github.com/miguelcobain/ember-paper/blob/master/addon/components/paper-select/ebd-content/component.js#L71)

So we duplicate what `ember-basic-dropdown` already does (https://github.com/cibernox/ember-basic-dropdown/blob/v2.0.15/addon/components/basic-dropdown-content.js#L172-L184) "just" to handle `isActive` & keep scroll... So we have to fix on `ember-paper` side an issue already fixed / wich does not exist in `ember-basic-dropdown`, right ?

Wouldn't it be easier to only handle `isActive` by our own in `paper-select` & `paper-menu` with `did-insert` & `will-destroy`, as it is already done, make the scroll behavior "native" in `ember-basic-dropdown` (seems legit) & rely on `ember-basic-dropdown` for animation part :thinking: 