### PR TITLE
Patching ebd-content to workaround issue 1166 

### DIFF
--- a/addon/components/paper-select/ebd-content/component.js
+++ b/addon/components/paper-select/ebd-content/component.js
@@ -64,6 +64,12 @@ class PaperSelectEbdContent extends Component {
   @action
   async animateOut(dropdownElement) {
     let parentElement = this.renderInPlace ? dropdownElement.parentElement.parentElement : dropdownElement.parentElement;
+
+    // workaround for https://github.com/miguelcobain/ember-paper/issues/1151. See also https://github.com/emberjs/ember.js/issues/18795.
+    if (!parentElement) {
+      parentElement = document.getElementById('ember-basic-dropdown-wormhole');
+    }
+
     let clone = dropdownElement.cloneNode(true);
     clone.id = `${clone.id}--clone`;
     parentElement.appendChild(clone);


### PR DESCRIPTION
This same patch was applied in paper-menu. I am on Ember 3.22 and this was the only way to get the paper-select component to work.