### PR TITLE
Add action to return focus to menu button for improved accessibility

### DIFF
--- a/addon/components/paper-menu/content/component.js
+++ b/addon/components/paper-menu/content/component.js
@@ -78,6 +78,7 @@ class PaperMenuContent extends Component {
     } else {
       parentElement.removeChild(clone);
     }
+    this.returnFocus(element);
   }
 
   @action
@@ -92,6 +93,14 @@ class PaperMenuContent extends Component {
 
     if (focusTarget) {
       focusTarget.focus();
+    }
+  }
+
+  @action
+  async returnFocus(element) {
+    const ariaOwningElement = document.querySelector(`[aria-owns=${element.id}]`);
+    if (ariaOwningElement) {
+     ariaOwningElement.firstElementChild.focus();
     }
   }
 


### PR DESCRIPTION
Hi Ember Paper community 👋  &nbsp; first time contributor here.
I've outlined a bug and one possible solution for it. Happy to help with another approach or add tests for this one if you find it useful, would love to see this fixed. Thanks for publishing this add-on : )

**Overview**
Preserving focus is important for users who rely on the keyboard to navigate. This PR would return focus to the menu button on close.

Steps: 
1) Open a menu with a mouse click or the `space` key.
2) Close menu (press `esc` or select one of the items using enter or a click).

**Expected behavior**
When the menu is dialog closed, focus should return to the element that invoked it.
![Restore Focus](https://user-images.githubusercontent.com/14287947/113043163-e62c3480-9150-11eb-886c-37e21f2bcc0f.gif)
(Above gif shows a user navigating via the keyboard and closing the menu using `esc`, focus is returned to the menu button.)

**Current behavior**
Focus is "lost" and users have to re-navigate from the beginning of the page.
![Lost Focus](https://user-images.githubusercontent.com/14287947/113042563-335bd680-9150-11eb-9462-1a21142d3ea1.gif)
(Above gif shows a user navigating via the keyboard and closing the menu using `esc`, focus is sent to the top app level and the user has to start over.)


**Documentation**
Additional details are available in the: [WAI-ARIA Authoring Practices (Menu)](https://www.w3.org/TR/wai-aria-practices/#menu)
Implementations of material design in other frameworks have stumbled across the same issue: https://github.com/angular/material/issues/11678

