### PR TITLE
Draft: Fix paper-menu flying into the screen and leaving ghost content.

### DIFF
--- a/addon/components/paper-menu/content/template.hbs
+++ b/addon/components/paper-menu/content/template.hbs
@@ -23,7 +23,6 @@
   {{!-- @width={{@width}} don't proxy with because we're using our own width value --}}
   @height={{@height}}
   @otherStyles={{this.customStyles}}
-  @animationEnabled={{false}}
   ...attributes>
   {{! template-lint-disable no-invalid-interactive }}
   <md-menu-content width={{@width}} class={{if @dense "md-dense"}} {{did-insert this.focusItem}} {{on "keydown" this.handleKeyDown}}>


### PR DESCRIPTION
Related to #1191.

Only reverts change to `paper-menu`, other occurrences does not seem to do any harm.