### PR TITLE
Fix/ember paper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-paper",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-paper",
   "description": "The Ember approach to Material Design.",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.33",
   "scripts": {
     "build": "ember build --environment=production",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
Reverting to ember-paper 1.0.0-beta.33 in package.json does NOT fix PaperMenuContent.animateOut errors.