### PR TITLE
Setting up the lint-to-the-future dashboard

### DIFF
--- a/.github/workflows/lint-to-the-future.yml
+++ b/.github/workflows/lint-to-the-future.yml
@@ -1,0 +1,11 @@
+name: Lint to the Future Dashboard
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  deploy:
+    uses: mansona/lint-to-the-future-dashboard-action/.github/workflows/dashboard.yml@main


### PR DESCRIPTION
Hey folks 👋 now that we've started using lint-to-the-future from [#1212](https://github.com/miguelcobain/ember-paper/pull/1212) it's worth setting up the dashboard that comes with it.

I know @Subtletree mentioned opening a quest issue for Octane etc, but this dashboard is a bit of a simpler way of keeping track of lints that we want to fix 👍 If you want to see a demo of it you can look at https://mansona.github.io/ember-paper/lint-to-the-future/ which I just setup to make sure that it was working before creating this PR 