### PR TITLE
remove Ember 3.28 from ember-try scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
         try-scenario:
           - ember-lts-3.20
           - ember-lts-3.24
-          - ember-lts-3.28
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -23,14 +23,6 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.8',
-          },
-        },
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Hey I just noticed that Ember 3.28 is showing up on the ember-try scenarios (but I didn't see a PR that added that 🤔)

Just a minor thing: we probably don't need that since the current version of Ember in the repo is 3.28 so the normal `Tests` will be using that version.

Happy to leave it there too but it's just a tiny bit of an efficiency to remove it 👍 