### PR TITLE
Remove unused eslint-disable directives

### DIFF
--- a/addon/components/paper-progress-circular.js
+++ b/addon/components/paper-progress-circular.js
@@ -237,11 +237,9 @@ export default Component.extend(ColorMixin, {
     let end = `${offset},${radius}`;   // ie: (2.5, 25) or  9 o'clock
     let arcRadius = radius - offset;
 
-    /* eslint-disable */
     return 'M' + start
          + 'A' + arcRadius + ',' + arcRadius + ' 0 1 1 ' + end // 75% circle
          + (indeterminate ? '' : 'A' + arcRadius + ',' + arcRadius + ' 0 0 1 ' + start); // loop to start
-    /* eslint-enable */
   },
 
   /**

--- a/addon/utils/contrasts.js
+++ b/addon/utils/contrasts.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Auto Generated file from exportSass.
 export default  {
   "light-contrast-color": "rgba(255, 255, 255, 0.87)",

--- a/addon/utils/palettes.js
+++ b/addon/utils/palettes.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Auto Generated file from exportSass.
 export default  {
   "red": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
-    "lint:js": "eslint . --cache",
+    "lint:js": "eslint . --cache --report-unused-disable-directives",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",

--- a/tests/integration/components/paper-dialog-test.js
+++ b/tests/integration/components/paper-dialog-test.js
@@ -1,4 +1,4 @@
-/* eslint-disable qunit/require-expect, qunit/no-negated-ok, ember/no-settled-after-test-helper */
+/* eslint-disable ember/no-settled-after-test-helper */
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, find, findAll, click, focus, triggerKeyEvent } from '@ember/test-helpers';


### PR DESCRIPTION
This also adds the `--report-unused-disable-directives` cli option to the `lint:js` package script 👍 This is very useful in conjunction with lint-to-the-future so that we notice whenever things have been fixed and we need to remove any disable directives