### PR TITLE
update paper-radio to use native class syntax

### DIFF
--- a/addon/components/paper-radio.js
+++ b/addon/components/paper-radio.js
@@ -9,6 +9,6 @@ import { ChildMixin } from 'ember-composability-tools';
  * @extends PaperRadioBaseComponent
  * @uses ChildMixin
  */
-export default PaperRadioBaseComponent.extend(ChildMixin, {
-  shouldRegister: false
-});
+export default class PaperRadio extends PaperRadioBaseComponent.extend(ChildMixin) {
+ shouldRegister = false;
+}


### PR DESCRIPTION
This is part of the same work that I'm doing in https://github.com/miguelcobain/ember-paper/pull/1220 

I am trying to update classes that use ParentMixin and Child Mixin to modern syntax so that I can update the `ember-composability-tools` addon and remove a bunch of deprecations. This is all to bring Ember 4.0 support 👍 