### PR TITLE
update paper-tabs to class syntax

### DIFF
--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -205,7 +205,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
       }
     },
 
-    onChange(selected) {
+    localOnChange(selected) {
       // support non DDAU scenario
       if (this.onChange) {
         invokeAction(this, 'onChange', selected.get('value'));

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -1,7 +1,8 @@
-/* eslint-disable ember/no-classic-components, ember/no-mixins, ember/require-tagless-components, ember/no-component-lifecycle-hooks, ember/no-get, ember/no-actions-hash */
+/* eslint-disable ember/no-computed-properties-in-native-classes, ember/no-classic-components, ember/no-mixins, ember/no-component-lifecycle-hooks, ember/classic-decorator-no-classic-methods, ember/no-get */
+import { classNames, attributeBindings, tagName, layout as templateLayout } from '@ember-decorators/component';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { gt } from '@ember/object/computed';
-import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { htmlSafe } from '@ember/string';
 import { scheduleOnce, join } from '@ember/runloop';
@@ -10,24 +11,23 @@ import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import { invokeAction } from 'ember-paper/utils/invoke-action';
 
-export default Component.extend(ParentMixin, ColorMixin, {
-  layout,
-  tagName: 'md-tabs',
+@templateLayout(layout)
+@tagName('md-tabs')
+@classNames('md-no-tab-content', 'md-default-theme')
+@attributeBindings('borderBottom:md-border-bottom')
+export default class PaperTabs extends Component.extend(ParentMixin, ColorMixin) {
+  @service
+  constants;
 
-  classNames: ['md-no-tab-content', 'md-default-theme'],
-  attributeBindings: ['borderBottom:md-border-bottom'],
+  selected = 0; // select first tab by default
+  noInkBar = false;
+  noInk = false;
+  ariaLabel = null;
+  stretch = 'sm';
+  movingRight = true;
 
-  constants: service(),
-
-  selected: 0, // select first tab by default
-
-  noInkBar: false,
-  noInk: false,
-  ariaLabel: null,
-  stretch: 'sm',
-  movingRight: true,
-
-  inkBar: computed('noInkBar', '_selectedTab.{width,left}', 'wrapperWidth', function() {
+  @computed('noInkBar', '_selectedTab.{width,left}', 'wrapperWidth')
+  get inkBar() {
     if (this.noInkBar) {
       return null;
     }
@@ -41,24 +41,27 @@ export default Component.extend(ParentMixin, ColorMixin, {
       left: selectedTab.get('left'),
       right: this.wrapperWidth - selectedTab.get('left') - selectedTab.get('width')
     };
-  }),
+  }
 
-  paginationStyle: computed('currentOffset', function() {
+  @computed('currentOffset')
+  get paginationStyle() {
     return htmlSafe(`transform: translate3d(-${this.currentOffset}px, 0px, 0px);`);
-  }),
+  }
 
-  shouldPaginate: true,
+  shouldPaginate = true;
 
-  shouldCenter: computed('shouldPaginate', 'center', function() {
+  @computed('shouldPaginate', 'center')
+  get shouldCenter() {
     return !this.shouldPaginate && this.center;
-  }),
+  }
 
-  shouldStretch: computed('shouldPaginate', 'currentStretch', function() {
+  @computed('shouldPaginate', 'currentStretch')
+  get shouldStretch() {
     return !this.shouldPaginate && this.currentStretch;
-  }),
+  }
 
   didInsertElement() {
-    this._super(...arguments);
+    super.didInsertElement(...arguments);
 
     this.updateCanvasWidth = () => {
       join(() => {
@@ -71,15 +74,15 @@ export default Component.extend(ParentMixin, ColorMixin, {
     window.addEventListener('orientationchange', this.updateCanvasWidth);
 
     scheduleOnce('afterRender', this, this.fixOffsetIfNeeded);
-  },
+  }
 
   didRender() {
-    this._super(...arguments);
+    super.didRender(...arguments);
     // this makes sure that the tabs react to stretch and center changes
     // this method is also called whenever one of the tab is re-rendered (content changes)
     this.updateSelectedTab();
     this.updateCanvasWidth();
-  },
+  }
 
   /**
    * Updates the currently selected tab only once all the <paper-tab> has rendered.
@@ -100,22 +103,22 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this.set('_selectedTab', selectedTab);
 
     scheduleOnce('afterRender', this, this.fixOffsetIfNeeded);
-  },
+  }
 
   willDestroyElement() {
-    this._super(...arguments);
+    super.willDestroyElement(...arguments);
     window.removeEventListener('resize', this.updateCanvasWidth);
     window.removeEventListener('orientationchange', this.updateCanvasWidth);
-  },
+  }
 
   registerChild(childComponent) {
-    this._super(...arguments);
+    super.registerChild(...arguments);
     // automatically set value if not manually set
     if (childComponent.get('value') === undefined) {
       let length = this.childComponents.get('length');
       childComponent.set('value', length - 1);
     }
-  },
+  }
 
   fixOffsetIfNeeded() {
     if (this.isDestroying || this.isDestroyed) {
@@ -147,7 +150,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     }
 
     this.set('currentOffset', newOffset);
-  },
+  }
 
   updateDimensions() {
     let canvasWidth = this.element.querySelector('md-tabs-canvas').offsetWidth;
@@ -156,7 +159,7 @@ export default Component.extend(ParentMixin, ColorMixin, {
     this.set('canvasWidth', canvasWidth);
     this.set('wrapperWidth', wrapperWidth);
     this.set('shouldPaginate', wrapperWidth > canvasWidth);
-  },
+  }
 
   updateStretchTabs() {
     let stretch = this.stretch;
@@ -172,46 +175,51 @@ export default Component.extend(ParentMixin, ColorMixin, {
     }
 
     this.set('currentStretch', currentStretch);
-  },
+  }
 
-  currentOffset: 0,
-  canPageBack: gt('currentOffset', 0),
-  canPageForward: computed('wrapperWidth', 'currentOffset', 'canvasWidth', function() {
+  currentOffset = 0;
+
+  @gt('currentOffset', 0)
+  canPageBack;
+
+  @computed('wrapperWidth', 'currentOffset', 'canvasWidth')
+  get canPageForward() {
     return this.wrapperWidth - this.currentOffset > this.canvasWidth;
-  }),
+  }
 
-  actions: {
-    previousPage() {
-      let tab = this.childComponents.find((t) => {
-        // ensure we are no stuck because of a tab with a width > canvasWidth
-        return (t.get('left') + t.get('width')) >= this.currentOffset;
-      });
-      if (tab) {
-        let left = Math.max(0, tab.get('left') - this.canvasWidth);
-        this.set('currentOffset', left);
-      }
-    },
-
-    nextPage() {
-      let tab = this.childComponents.find((t) => {
-        // ensure tab's offset is greater than current
-        // otherwise if the tab's width is greater than canvas we cannot paginate through it
-        return t.get('left') > this.currentOffset
-          // paginate until the first partially hidden tab
-          && t.get('left') + t.get('width') - this.currentOffset > this.canvasWidth;
-      });
-      if (tab) {
-        this.set('currentOffset', tab.get('left'));
-      }
-    },
-
-    localOnChange(selected) {
-      // support non DDAU scenario
-      if (this.onChange) {
-        invokeAction(this, 'onChange', selected.get('value'));
-      } else {
-        this.set('selected', selected.get('value'));
-      }
+  @action
+  previousPage() {
+    let tab = this.childComponents.find((t) => {
+      // ensure we are no stuck because of a tab with a width > canvasWidth
+      return (t.get('left') + t.get('width')) >= this.currentOffset;
+    });
+    if (tab) {
+      let left = Math.max(0, tab.get('left') - this.canvasWidth);
+      this.set('currentOffset', left);
     }
   }
-});
+
+  @action
+  nextPage() {
+    let tab = this.childComponents.find((t) => {
+      // ensure tab's offset is greater than current
+      // otherwise if the tab's width is greater than canvas we cannot paginate through it
+      return t.get('left') > this.currentOffset
+        // paginate until the first partially hidden tab
+        && t.get('left') + t.get('width') - this.currentOffset > this.canvasWidth;
+    });
+    if (tab) {
+      this.set('currentOffset', tab.get('left'));
+    }
+  }
+
+  @action
+  localOnChange(selected) {
+    // support non DDAU scenario
+    if (this.onChange) {
+      invokeAction(this, 'onChange', selected.get('value'));
+    } else {
+      this.set('selected', selected.get('value'));
+    }
+  }
+}

--- a/addon/templates/components/paper-tabs.hbs
+++ b/addon/templates/components/paper-tabs.hbs
@@ -17,7 +17,7 @@
         tab=(component "paper-tab"
           noInk=noInk
           selected=selected
-          onSelect=(action "onChange")
+          onSelect=(action "localOnChange")
         )
       )}}
 


### PR DESCRIPTION
This is part of the same work that I'm doing in https://github.com/miguelcobain/ember-paper/pull/1220 

I am trying to update classes that use ParentMixin and Child Mixin to modern syntax so that I can update the `ember-composability-tools` addon and remove a bunch of deprecations. This is all to bring Ember 4.0 support 👍 