### PR TITLE
add continue-on-error-comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,35 @@ jobs:
         try-scenario:
           - ember-lts-3.20
           - ember-lts-3.24
+          - ember-classic
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+
+  failing-try-scenarios:
+    name: ${{ matrix.try-scenario }} Allowed to fail
+    runs-on: ubuntu-latest
+    needs: "test"
+
+    permissions:
+      pull-requests: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        try-scenario:
           - ember-release
           - ember-beta
           - ember-canary
-          - ember-classic
           - embroider-safe
           - embroider-optimized
 
@@ -73,4 +98,11 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Run Tests
+        id: tests
         run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        continue-on-error: true
+      - uses: mainmatter/continue-on-error-comment@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          outcome: ${{ steps.tests.outcome }}
+          test-id: ${{ matrix.try-scenario }}


### PR DESCRIPTION
This is adding https://github.com/mainmatter/continue-on-error-comment so we can get a green CI for things that we expect to pass 👍 