### PR TITLE
apply fix to allow continue-on-error-comment to work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - master
-  pull_request: {}
+  pull_request_target: {}
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
I discovered why continue-on-error-comment wasn't working for people creating PRs from forks. You can read more here: https://github.com/mainmatter/continue-on-error-comment#permissions