### PR TITLE
build(deps): upgrades to `ember-css-transitions@^4.4.1`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ember-cli-polyfill-importer": "^0.0.4",
         "ember-cli-sass": "^10.0.1",
         "ember-composability-tools": "^0.0.12",
-        "ember-css-transitions": "^3.1.0",
+        "ember-css-transitions": "^4.4.1",
         "ember-decorators": "^6.1.1",
         "ember-get-config": "^1.0.2",
         "ember-maybe-in-element": "^2.0.3",
@@ -410,10 +410,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
-      "license": "MIT",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
+      "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -948,11 +947,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.17.0.tgz",
-      "integrity": "sha512-qWe85yCXsvDEluNP0OyeQjH63DlhAR3W7K9BxxU1MvbDb48tgBG+Ao6IJJ6smPDrrVzSQZrbF6donpkFBMcs3A==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.25.7.tgz",
+      "integrity": "sha512-oXduHo642ZhstLVYTe2z2GSJIruU0c/W3/Ghr6A5yGMsVrvdnxO1z+3pbTcT7f3/Clnt+1z8D/w1r1f1SHaCHw==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3547,10 +3546,9 @@
       }
     },
     "node_modules/@ember/test-waiters": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.0.1.tgz",
-      "integrity": "sha512-LqV55mMiSuhAAWfbJdJf0bxHc22A/CiG8TKyZwpcSv4A1GJIpdlTvqHCrlcdV6T30+L0/uyj14upC3ayWmV0CQ==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.1.0.tgz",
+      "integrity": "sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==",
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -3565,7 +3563,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
       "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-      "dev": true,
       "dependencies": {
         "resolve-package-path": "^3.1.0",
         "semver": "^7.3.4",
@@ -3573,6 +3570,94 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@embroider/addon-shim": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.9.tgz",
+      "integrity": "sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==",
+      "dependencies": {
+        "@embroider/shared-internals": "^2.6.0",
+        "broccoli-funnel": "^3.0.8",
+        "common-ancestor-path": "^1.0.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/@embroider/shared-internals": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.8.1.tgz",
+      "integrity": "sha512-zi0CENFD1e0DH7c9M/rNKJnFnt2c3+736J3lguBddZdmaIV6Cb8l3HQSkskSW5O4ady+SavemLKO3hCjQQJBIw==",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "is-subdir": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "pkg-entry-points": "^1.1.0",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/babel-import-util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@embroider/macros": {
@@ -9833,6 +9918,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="
+    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -10802,6 +10892,23 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/decorator-transforms": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/decorator-transforms/-/decorator-transforms-2.2.2.tgz",
+      "integrity": "sha512-NHCSJXOUQ29YFli1QzstXWo72EyASpoVx+s0YdkMwswpovf/iAJP580nD1tB0Ph9exvtbfWdVrSAloXrWVo1Xg==",
+      "dependencies": {
+        "@babel/plugin-syntax-decorators": "^7.23.3",
+        "babel-import-util": "^3.0.0"
+      }
+    },
+    "node_modules/decorator-transforms/node_modules/babel-import-util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.0.tgz",
+      "integrity": "sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/deep-eql": {
@@ -14689,15 +14796,14 @@
       }
     },
     "node_modules/ember-css-transitions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-css-transitions/-/ember-css-transitions-3.1.0.tgz",
-      "integrity": "sha512-4mbcjOZ5gWLpd60ccWWYe3zgx7IMHb+EH+asbI7MhRMrExeZdt16va4GlhB9o4zXBMO86JW5PX+zAi/at3eW/Q==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/ember-css-transitions/-/ember-css-transitions-4.4.1.tgz",
+      "integrity": "sha512-QSUc+bDNMU/3vbJZuSWz14a4V/wQbHDq/zY37pzqzZRMXBANGwpjy+KXTyWqDqi1XeXvnMf2BX/nbjYSC3ycbg==",
       "dependencies": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-modifier": "^2.1.2 || ^3.1.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "@ember/test-waiters": "^3.1.0",
+        "@embroider/addon-shim": "^1.8.9",
+        "decorator-transforms": "^2.2.2",
+        "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0"
       }
     },
     "node_modules/ember-data": {
@@ -27167,12 +27273,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -30837,9 +30940,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg=="
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
+      "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.16.8",
@@ -31190,11 +31293,11 @@
       }
     },
     "@babel/plugin-syntax-decorators": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.17.0.tgz",
-      "integrity": "sha512-qWe85yCXsvDEluNP0OyeQjH63DlhAR3W7K9BxxU1MvbDb48tgBG+Ao6IJJ6smPDrrVzSQZrbF6donpkFBMcs3A==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.25.7.tgz",
+      "integrity": "sha512-oXduHo642ZhstLVYTe2z2GSJIruU0c/W3/Ghr6A5yGMsVrvdnxO1z+3pbTcT7f3/Clnt+1z8D/w1r1f1SHaCHw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.25.7"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -33132,10 +33235,9 @@
       }
     },
     "@ember/test-waiters": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.0.1.tgz",
-      "integrity": "sha512-LqV55mMiSuhAAWfbJdJf0bxHc22A/CiG8TKyZwpcSv4A1GJIpdlTvqHCrlcdV6T30+L0/uyj14upC3ayWmV0CQ==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-3.1.0.tgz",
+      "integrity": "sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==",
       "requires": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -33147,12 +33249,81 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
           "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-          "dev": true,
           "requires": {
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
             "silent-error": "^1.1.1"
           }
+        }
+      }
+    },
+    "@embroider/addon-shim": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.9.tgz",
+      "integrity": "sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==",
+      "requires": {
+        "@embroider/shared-internals": "^2.6.0",
+        "broccoli-funnel": "^3.0.8",
+        "common-ancestor-path": "^1.0.1",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.8.1.tgz",
+          "integrity": "sha512-zi0CENFD1e0DH7c9M/rNKJnFnt2c3+736J3lguBddZdmaIV6Cb8l3HQSkskSW5O4ady+SavemLKO3hCjQQJBIw==",
+          "requires": {
+            "babel-import-util": "^2.0.0",
+            "debug": "^4.3.2",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "is-subdir": "^1.2.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "minimatch": "^3.0.4",
+            "pkg-entry-points": "^1.1.0",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        },
+        "babel-import-util": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+          "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "resolve-package-path": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+          "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+          "requires": {
+            "path-root": "^0.1.1"
+          }
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         }
       }
     },
@@ -38534,6 +38705,11 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
+    "common-ancestor-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="
+    },
     "common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -39307,6 +39483,22 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "decorator-transforms": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/decorator-transforms/-/decorator-transforms-2.2.2.tgz",
+      "integrity": "sha512-NHCSJXOUQ29YFli1QzstXWo72EyASpoVx+s0YdkMwswpovf/iAJP580nD1tB0Ph9exvtbfWdVrSAloXrWVo1Xg==",
+      "requires": {
+        "@babel/plugin-syntax-decorators": "^7.23.3",
+        "babel-import-util": "^3.0.0"
+      },
+      "dependencies": {
+        "babel-import-util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.0.tgz",
+          "integrity": "sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ=="
+        }
       }
     },
     "deep-eql": {
@@ -42521,12 +42713,14 @@
       }
     },
     "ember-css-transitions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-css-transitions/-/ember-css-transitions-3.1.0.tgz",
-      "integrity": "sha512-4mbcjOZ5gWLpd60ccWWYe3zgx7IMHb+EH+asbI7MhRMrExeZdt16va4GlhB9o4zXBMO86JW5PX+zAi/at3eW/Q==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/ember-css-transitions/-/ember-css-transitions-4.4.1.tgz",
+      "integrity": "sha512-QSUc+bDNMU/3vbJZuSWz14a4V/wQbHDq/zY37pzqzZRMXBANGwpjy+KXTyWqDqi1XeXvnMf2BX/nbjYSC3ycbg==",
       "requires": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-modifier": "^2.1.2 || ^3.1.0"
+        "@ember/test-waiters": "^3.1.0",
+        "@embroider/addon-shim": "^1.8.9",
+        "decorator-transforms": "^2.2.2",
+        "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0"
       }
     },
     "ember-data": {
@@ -52499,12 +52693,9 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "send": {
       "version": "0.17.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-polyfill-importer": "^0.0.4",
     "ember-cli-sass": "^10.0.1",
     "ember-composability-tools": "^0.0.12",
-    "ember-css-transitions": "^3.1.0",
+    "ember-css-transitions": "^4.4.1",
     "ember-decorators": "^6.1.1",
     "ember-get-config": "^1.0.2",
     "ember-maybe-in-element": "^2.0.3",


### PR DESCRIPTION
Now that fixes have been released via https://github.com/miguelcobain/ember-css-transitions/issues/120#issuecomment-2408339530 we can upgrade!
